### PR TITLE
Implement phase 2 context-shaping extensions

### DIFF
--- a/src/agentm/core/kernel/loop.py
+++ b/src/agentm/core/kernel/loop.py
@@ -138,6 +138,16 @@ def _collect_context_messages(
     return chosen
 
 
+def _collect_error(returns: list[Any]) -> BaseException | None:
+    """Return the last explicit exception object from handler returns."""
+
+    chosen: BaseException | None = None
+    for value in returns:
+        if isinstance(value, BaseException):
+            chosen = value
+    return chosen
+
+
 def _assemble_assistant_message(
     events: list[AssistantStreamEvent], *, fallback_timestamp: float
 ) -> AssistantMessage:
@@ -218,7 +228,12 @@ class AgentLoop:
             )
 
         messages = list(messages)  # local copy; we won't mutate caller's list
-        await self._bus.emit("agent_start", AgentStartEvent(messages=messages))
+        start_returns = await self._bus.emit(
+            "agent_start", AgentStartEvent(messages=messages)
+        )
+        start_error = _collect_error(start_returns)
+        if start_error is not None:
+            raise start_error
 
         tool_index = {t.name: t for t in tools}
         max_turns = self._config.max_turns

--- a/src/agentm/extensions/builtin/file_mutation_queue.py
+++ b/src/agentm/extensions/builtin/file_mutation_queue.py
@@ -1,0 +1,93 @@
+"""Builtin ``file_mutation_queue`` atom per extension-as-scenario §7."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from agentm.core.kernel import AgentStartEvent, Tool, ToolResult
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI, ExtensionLoadError
+
+
+MANIFEST = ExtensionManifest(
+    name="file_mutation_queue",
+    description="Serializes file-mutation tools with per-path asyncio locks.",
+    registers=("event:agent_start",),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "tools": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "additionalProperties": False,
+    },
+)
+
+_PATH_KEYS = ("path", "file_path", "filepath", "target")
+
+
+class _QueuedTool:
+    def __init__(self, wrapped: Tool, locks: dict[str, asyncio.Lock]) -> None:
+        self._wrapped = wrapped
+        self._locks = locks
+        self.name = wrapped.name
+        self.description = wrapped.description
+        self.parameters = wrapped.parameters
+
+    async def execute(
+        self,
+        args: dict[str, Any],
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: Any = None,
+    ) -> ToolResult:
+        lock = self._locks.setdefault(_normalize_path(args), asyncio.Lock())
+        async with lock:
+            return await self._wrapped.execute(
+                args,
+                signal=signal,
+                on_update=on_update,
+            )
+
+
+def _normalize_path(args: dict[str, Any]) -> str:
+    raw = None
+    for key in _PATH_KEYS:
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            raw = value
+            break
+    if raw is None:
+        return "<missing-path>"
+    return os.path.abspath(raw)
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    target_names = tuple(str(name) for name in config.get("tools", ["edit", "write"]))
+    locks: dict[str, asyncio.Lock] = {}
+    wrapped_names: set[str] = set()
+
+    def on_agent_start(_: AgentStartEvent) -> ExtensionLoadError | None:
+        tools_by_name = {tool.name: (index, tool) for index, tool in enumerate(api.tools)}
+        missing = [name for name in target_names if name not in tools_by_name]
+        if missing:
+            return ExtensionLoadError(
+                __name__,
+                RuntimeError(
+                    "file_mutation_queue must load after mutation tools; missing "
+                    + ", ".join(sorted(missing))
+                ),
+            )
+        for name in target_names:
+            if name in wrapped_names:
+                continue
+            index, tool = tools_by_name[name]
+            api.tools[index] = _QueuedTool(tool, locks)
+            wrapped_names.add(name)
+        return None
+
+    api.on("agent_start", on_agent_start)

--- a/src/agentm/extensions/builtin/micro_compact.py
+++ b/src/agentm/extensions/builtin/micro_compact.py
@@ -1,0 +1,133 @@
+"""Builtin ``micro_compact`` atom per extension-as-scenario §7."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from agentm.core.kernel import AgentMessage, AssistantMessage, TextContent
+from agentm.extensions import ExtensionManifest
+from agentm.harness.events import AfterCompactEvent, BeforeCompactEvent
+from agentm.harness.extension import ExtensionAPI
+
+
+MANIFEST = ExtensionManifest(
+    name="micro_compact",
+    description="Auto-compacts context when token usage approaches the model window.",
+    registers=("event:before_send_to_llm", "event:before_compact", "event:after_compact"),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "threshold_pct": {"type": "number", "minimum": 0.0},
+            "keep_last": {"type": "integer", "minimum": 1},
+        },
+        "additionalProperties": False,
+    },
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    threshold_pct = float(config.get("threshold_pct", 0.85))
+    keep_last = int(config.get("keep_last", 8))
+    last_compaction_id: str | None = None
+
+    async def before_send_to_llm(event: Any) -> None:
+        nonlocal last_compaction_id
+
+        model = api.model
+        if model is None or model.context_window <= 0:
+            return
+        messages = event.messages
+        estimated_tokens = _estimate_messages(messages)
+        if estimated_tokens <= int(model.context_window * threshold_pct):
+            return
+        if len(messages) <= keep_last:
+            return
+
+        before = BeforeCompactEvent(messages=messages, reason="auto_overflow")
+        await api.events.emit("before_compact", before)
+
+        original_messages = list(before.messages)
+        compacted_messages, summary_text = _compact_messages(original_messages, keep_last)
+        details = {
+            "reason": "auto_overflow",
+            "threshold_pct": threshold_pct,
+            "keep_last": keep_last,
+            "estimated_tokens_before": estimated_tokens,
+            "estimated_tokens_after": _estimate_messages(compacted_messages),
+            "discarded_message_count": max(0, len(original_messages) - len(compacted_messages)),
+            "parent_id": last_compaction_id,
+            "summary": summary_text,
+        }
+        entry_id = api.session.append_entry("compaction", details, parent_id=last_compaction_id)
+        details["entry_id"] = entry_id
+        last_compaction_id = entry_id
+
+        messages[:] = compacted_messages
+        await api.events.emit(
+            "after_compact",
+            AfterCompactEvent(
+                summary=summary_text,
+                kept_message_count=len(compacted_messages),
+                discarded_message_count=max(0, len(original_messages) - len(compacted_messages)),
+                details=details,
+            ),
+        )
+
+    api.on("before_send_to_llm", before_send_to_llm)
+
+
+def _compact_messages(
+    messages: list[AgentMessage],
+    keep_last: int,
+) -> tuple[list[AgentMessage], str]:
+    kept_tail = list(messages[-keep_last:])
+    dropped = list(messages[:-keep_last])
+    summary_text = _summarize_messages(dropped)
+    summary_message = AssistantMessage(
+        role="assistant",
+        content=[TextContent(type="text", text=summary_text)],
+        timestamp=0.0,
+        stop_reason="end_turn",
+    )
+    return [summary_message, *kept_tail], summary_text
+
+
+def _summarize_messages(messages: list[AgentMessage]) -> str:
+    if not messages:
+        return "Compaction summary: no earlier messages."
+    fragments: list[str] = []
+    for msg in messages[-4:]:
+        role = getattr(msg, "role", "unknown")
+        fragments.append(f"{role}: {_message_text(msg)}")
+    joined = " | ".join(fragments)
+    return f"Compaction summary of {len(messages)} earlier messages: {joined}"[:1200]
+
+
+def _message_text(message: AgentMessage) -> str:
+    parts: list[str] = []
+    for block in getattr(message, "content", []):
+        text = getattr(block, "text", None)
+        if isinstance(text, str) and text:
+            parts.append(text)
+        elif getattr(block, "type", None) == "tool_call":
+            parts.append(f"tool:{getattr(block, 'name', '?')}")
+        elif getattr(block, "type", None) == "tool_result":
+            parts.append("tool_result")
+    if parts:
+        return " ".join(parts)
+    return _safe_string(message)
+
+
+def _estimate_messages(messages: list[AgentMessage]) -> int:
+    total = 0
+    for message in messages:
+        text = _message_text(message)
+        total += max(1, len(text))
+    return total
+
+
+def _safe_string(value: Any) -> str:
+    if is_dataclass(value) and not isinstance(value, type):
+        return str(asdict(value))
+    return str(value)

--- a/src/agentm/extensions/builtin/system_prompt.py
+++ b/src/agentm/extensions/builtin/system_prompt.py
@@ -1,0 +1,35 @@
+"""Builtin ``system_prompt`` atom per extension-as-scenario §7."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+
+MANIFEST = ExtensionManifest(
+    name="system_prompt",
+    description="Prepends configured prompt text to the system prompt.",
+    registers=("event:before_agent_start",),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string"},
+        },
+        "required": ["prompt"],
+        "additionalProperties": False,
+    },
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    prompt = str(config["prompt"])
+
+    def before_agent_start(event: dict[str, Any]) -> dict[str, str]:
+        current = str(event.get("system") or "")
+        updated = f"{prompt}\n\n{current}" if current else prompt
+        event["system"] = updated
+        return {"system": updated}
+
+    api.on("before_agent_start", before_agent_start)

--- a/src/agentm/extensions/builtin/trajectory.py
+++ b/src/agentm/extensions/builtin/trajectory.py
@@ -1,0 +1,115 @@
+"""Builtin ``trajectory`` atom per extension-as-scenario §7."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+
+MANIFEST = ExtensionManifest(
+    name="trajectory",
+    description="Records major event traffic to memory and persists JSONL on agent end.",
+    registers=(
+        "event:agent_start",
+        "event:agent_end",
+        "event:turn_start",
+        "event:turn_end",
+        "event:context",
+        "event:before_send_to_llm",
+        "event:tool_call",
+        "event:tool_result",
+        "event:before_compact",
+        "event:after_compact",
+        "event:child_session_start",
+        "event:child_session_end",
+        "event:cost_budget_exceeded",
+        "event:plan_submitted",
+    ),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "channels": {
+                "type": ["array", "null"],
+                "items": {"type": "string"},
+            },
+        },
+        "additionalProperties": False,
+    },
+)
+
+_DEFAULT_CHANNELS = (
+    "agent_start",
+    "agent_end",
+    "turn_start",
+    "turn_end",
+    "context",
+    "before_send_to_llm",
+    "tool_call",
+    "tool_result",
+    "before_compact",
+    "after_compact",
+    "child_session_start",
+    "child_session_end",
+    "cost_budget_exceeded",
+    "plan_submitted",
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    configured_path = Path(str(config.get("path", "./trajectory.jsonl")))
+    output_path = (
+        configured_path
+        if configured_path.is_absolute()
+        else Path(api.cwd) / configured_path
+    )
+    configured_channels = config.get("channels")
+    channels = (
+        tuple(str(ch) for ch in configured_channels)
+        if configured_channels is not None
+        else _DEFAULT_CHANNELS
+    )
+    records: list[dict[str, Any]] = []
+
+    def _record(channel: str, event: Any) -> None:
+        records.append(
+            {
+                "timestamp": time.time(),
+                "channel": channel,
+                "event": _serialize(event),
+            }
+        )
+
+    for channel in channels:
+        if channel == "agent_end":
+
+            def on_agent_end(event: Any, *, _channel: str = channel) -> None:
+                _record(_channel, event)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                with output_path.open("w", encoding="utf-8") as handle:
+                    for record in records:
+                        handle.write(json.dumps(record, default=str))
+                        handle.write("\n")
+
+            api.on(channel, on_agent_end)
+            continue
+
+        api.on(channel, lambda event, _channel=channel: _record(_channel, event))
+
+
+def _serialize(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {key: _serialize(val) for key, val in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _serialize(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_serialize(item) for item in value]
+    if isinstance(value, tuple):
+        return [_serialize(item) for item in value]
+    return value

--- a/src/agentm/extensions/builtin/turn_reminder.py
+++ b/src/agentm/extensions/builtin/turn_reminder.py
@@ -1,0 +1,40 @@
+"""Builtin ``turn_reminder`` atom per extension-as-scenario §7."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+
+MANIFEST = ExtensionManifest(
+    name="turn_reminder",
+    description="Re-injects a reminder into the system prompt every N turns.",
+    registers=("event:before_agent_start",),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "reminder": {"type": "string"},
+            "every_n_turns": {"type": "integer", "minimum": 1},
+        },
+        "required": ["reminder", "every_n_turns"],
+        "additionalProperties": False,
+    },
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    reminder = str(config["reminder"])
+    every_n_turns = int(config["every_n_turns"])
+
+    def before_agent_start(event: dict[str, Any]) -> dict[str, str] | None:
+        turn_count = len(api.session.get_messages())
+        if turn_count % every_n_turns != 0:
+            return None
+        current = str(event.get("system") or "")
+        updated = f"{current}\n\n{reminder}" if current else reminder
+        event["system"] = updated
+        return {"system": updated}
+
+    api.on("before_agent_start", before_agent_start)

--- a/src/agentm/harness/extension.py
+++ b/src/agentm/harness/extension.py
@@ -158,6 +158,8 @@ class ExtensionAPI(Protocol):
     @property
     def cwd(self) -> str: ...
     @property
+    def tools(self) -> list[Tool]: ...
+    @property
     def session(self) -> ReadonlySession: ...
     @property
     def model(self) -> Model | None: ...
@@ -240,6 +242,10 @@ class _ExtensionAPIImpl:
     @property
     def cwd(self) -> str:
         return self._cwd
+
+    @property
+    def tools(self) -> list[Tool]:
+        return self._tools
 
     @property
     def session(self) -> ReadonlySession:

--- a/src/agentm/harness/session.py
+++ b/src/agentm/harness/session.py
@@ -467,7 +467,8 @@ class AgentSession:
         )
 
         # 6. Append every new assistant / tool_result message.
-        cursor: str | None = entry.id
+        active_branch = self._session_manager.get_active_branch()
+        cursor: str | None = active_branch[-1].id if active_branch else entry.id
         for msg in final_messages[pre_run_count:]:
             child = message_entry(msg, parent_id=cursor)
             self._session_manager.append(child)

--- a/tests/unit/extensions/builtin/_helpers.py
+++ b/tests/unit/extensions/builtin/_helpers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from agentm.core.kernel import (
+    AssistantMessage,
+    MessageEnd,
+    Model,
+    TextContent,
+    ToolCallBlock,
+)
+from agentm.harness.extension import ProviderConfig
+
+
+class RecordingStream:
+    def __init__(self, scripted_messages: list[AssistantMessage]) -> None:
+        self._scripted_messages = scripted_messages
+        self.calls = 0
+        self.seen_systems: list[str | None] = []
+        self.seen_messages: list[list[Any]] = []
+        self.seen_tool_names: list[list[str]] = []
+
+    def __call__(
+        self,
+        *,
+        messages: list[Any],
+        model: Model,
+        tools: list[Any],
+        system: str | None = None,
+        signal: Any = None,
+        thinking: str = "off",
+    ) -> AsyncIterator[Any]:
+        self.calls += 1
+        self.seen_systems.append(system)
+        self.seen_messages.append(list(messages))
+        self.seen_tool_names.append([tool.name for tool in tools])
+        index = min(self.calls - 1, len(self._scripted_messages) - 1)
+        return self._iter(self._scripted_messages[index])
+
+    async def _iter(self, message: AssistantMessage) -> AsyncIterator[Any]:
+        yield MessageEnd(message=message)
+
+
+LAST_STREAM: RecordingStream | None = None
+
+
+def install(api: Any, config: dict[str, Any]) -> None:
+    global LAST_STREAM
+
+    response_texts = [str(text) for text in config.get("response_texts", ["ok"])]
+    tool_calls = config.get("tool_calls", [])
+    scripted_messages: list[AssistantMessage] = []
+
+    for index, text in enumerate(response_texts):
+        content: list[Any]
+        stop_reason = "end_turn"
+        if index < len(tool_calls):
+            tc = tool_calls[index]
+            content = [
+                ToolCallBlock(
+                    type="tool_call",
+                    id=str(tc.get("id", f"call-{index + 1}")),
+                    name=str(tc["name"]),
+                    arguments=dict(tc.get("arguments", {})),
+                )
+            ]
+            stop_reason = "tool_use"
+        else:
+            content = [TextContent(type="text", text=text)]
+
+        scripted_messages.append(
+            AssistantMessage(
+                role="assistant",
+                content=content,
+                timestamp=float(index + 1),
+                stop_reason=stop_reason,
+            )
+        )
+
+    LAST_STREAM = RecordingStream(scripted_messages)
+    api.register_provider(
+        "recording",
+        ProviderConfig(
+            stream_fn=LAST_STREAM,
+            model=Model(
+                id=str(config.get("model_id", "recording-model")),
+                provider="recording",
+                context_window=int(config.get("context_window", 4096)),
+                max_output_tokens=int(config.get("max_output_tokens", 1024)),
+            ),
+            name="recording",
+        ),
+    )

--- a/tests/unit/extensions/builtin/file_mutation_queue/test_file_mutation_queue.py
+++ b/tests/unit/extensions/builtin/file_mutation_queue/test_file_mutation_queue.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from agentm.core.kernel import AgentStartEvent, FunctionTool, TextContent, ToolResult
+from agentm.harness.extension import ExtensionLoadError
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+async def test_file_mutation_queue_serializes_same_path_mutations(tmp_path: Path) -> None:
+    module_name = "tests.unit.extensions.builtin.file_mutation_queue._tools_ext"
+    module = types.ModuleType(module_name)
+    events: list[str] = []
+    in_flight = 0
+    overlap_detected = False
+
+    async def make_result(args: dict[str, object], tool_name: str) -> ToolResult:
+        nonlocal in_flight, overlap_detected
+        if in_flight:
+            overlap_detected = True
+        in_flight += 1
+        events.append(f"start:{tool_name}")
+        await asyncio.sleep(0.01)
+        events.append(f"end:{tool_name}")
+        in_flight -= 1
+        return ToolResult(content=[TextContent(type="text", text=str(args["path"]))])
+
+    def install(api: object, config: dict[str, object]) -> None:
+        api.register_tool(  # type: ignore[attr-defined]
+            FunctionTool(
+                name="edit",
+                description="edit",
+                parameters={"type": "object"},
+                fn=lambda args: make_result(args, "edit"),
+            )
+        )
+        api.register_tool(  # type: ignore[attr-defined]
+            FunctionTool(
+                name="write",
+                description="write",
+                parameters={"type": "object"},
+                fn=lambda args: make_result(args, "write"),
+            )
+        )
+
+    module.install = install  # type: ignore[attr-defined]
+    sys.modules[module_name] = module
+
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                (module_name, {}),
+                ("agentm.extensions.builtin.file_mutation_queue", {}),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    returns = await session.bus.emit("agent_start", AgentStartEvent(messages=[]))
+    assert returns == [None]
+
+    tools = {tool.name: tool for tool in session.tools}
+    await asyncio.gather(
+        tools["edit"].execute({"path": "/tmp/x"}),
+        tools["write"].execute({"path": "/tmp/x"}),
+    )
+
+    assert not overlap_detected
+    assert events in (["start:edit", "end:edit", "start:write", "end:write"], ["start:write", "end:write", "start:edit", "end:edit"])
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_file_mutation_queue_fast_fails_when_loaded_before_tools(tmp_path: Path) -> None:
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                ("agentm.extensions.builtin.file_mutation_queue", {}),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    with pytest.raises(ExtensionLoadError):
+        await session.prompt("hello")
+
+    await session.shutdown()

--- a/tests/unit/extensions/builtin/micro_compact/test_micro_compact.py
+++ b/tests/unit/extensions/builtin/micro_compact/test_micro_compact.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentm.core.kernel import text_message
+from tests.unit.extensions.builtin import _helpers
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+async def test_micro_compact_compacts_and_records_entry(tmp_path: Path) -> None:
+    seen_before: list[object] = []
+    seen_after: list[object] = []
+    initial_messages = [text_message("x" * 200, timestamp=float(i)) for i in range(10)]
+
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                (
+                    "agentm.extensions.builtin.micro_compact",
+                    {"threshold_pct": 0.85, "keep_last": 3},
+                ),
+            ],
+            provider=(
+                "tests.unit.extensions.builtin._helpers",
+                {"context_window": 1000},
+            ),
+            initial_messages=initial_messages,
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+    session.bus.on("before_compact", lambda event: seen_before.append(event))
+    session.bus.on("after_compact", lambda event: seen_after.append(event))
+
+    await session.prompt("hello")
+
+    assert len(seen_before) == 1
+    assert len(seen_after) == 1
+    assert _helpers.LAST_STREAM is not None
+    sent_messages = _helpers.LAST_STREAM.seen_messages[-1]
+    assert len(sent_messages) < len(initial_messages) + 1
+
+    branch = session.session_manager.get_active_branch()
+    compaction_entries = [entry for entry in branch if entry.type == "compaction"]
+    assert len(compaction_entries) == 1
+    assert compaction_entries[0].id != ""
+    payload = compaction_entries[0].payload
+    assert payload["entry_id"] != ""
+    await session.shutdown()

--- a/tests/unit/extensions/builtin/system_prompt/test_system_prompt.py
+++ b/tests/unit/extensions/builtin/system_prompt/test_system_prompt.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.extensions.builtin import _helpers
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_prepends_configured_text(tmp_path: Path) -> None:
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                ("agentm.extensions.builtin.system_prompt", {"prompt": "PREFIX"}),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    await session.prompt("hello")
+
+    assert _helpers.LAST_STREAM is not None
+    assert _helpers.LAST_STREAM.seen_systems[-1] == "PREFIX"
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_stacks_in_declaration_order(tmp_path: Path) -> None:
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                ("agentm.extensions.builtin.system_prompt", {"prompt": "FIRST"}),
+                ("agentm.extensions.builtin.system_prompt", {"prompt": "SECOND"}),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    await session.prompt("hello")
+
+    assert _helpers.LAST_STREAM is not None
+    assert _helpers.LAST_STREAM.seen_systems[-1] == "SECOND\n\nFIRST"
+    await session.shutdown()

--- a/tests/unit/extensions/builtin/trajectory/test_trajectory.py
+++ b/tests/unit/extensions/builtin/trajectory/test_trajectory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+async def test_trajectory_persists_one_record_per_fired_event(tmp_path: Path) -> None:
+    output_path = tmp_path / "trajectory.jsonl"
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                (
+                    "agentm.extensions.builtin.trajectory",
+                    {
+                        "path": str(output_path),
+                        "channels": [
+                            "agent_start",
+                            "turn_start",
+                            "context",
+                            "before_send_to_llm",
+                            "turn_end",
+                            "agent_end",
+                        ],
+                    },
+                ),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    await session.prompt("hello")
+
+    records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    channels = [record["channel"] for record in records]
+    assert channels == [
+        "agent_start",
+        "turn_start",
+        "context",
+        "before_send_to_llm",
+        "turn_end",
+        "agent_end",
+    ]
+    assert len(records) == len(channels)
+    await session.shutdown()

--- a/tests/unit/extensions/builtin/turn_reminder/test_turn_reminder.py
+++ b/tests/unit/extensions/builtin/turn_reminder/test_turn_reminder.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentm.core.kernel import text_message
+from tests.unit.extensions.builtin import _helpers
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_count", "should_remind"),
+    [(2, True), (5, True), (8, True), (1, False), (4, False)],
+)
+async def test_turn_reminder_fires_every_n_turns(
+    tmp_path: Path,
+    initial_count: int,
+    should_remind: bool,
+) -> None:
+    initial_messages = [text_message(f"m{i}", timestamp=float(i)) for i in range(initial_count)]
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[
+                (
+                    "agentm.extensions.builtin.turn_reminder",
+                    {"reminder": "REMEMBER", "every_n_turns": 3},
+                ),
+            ],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            initial_messages=initial_messages,
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    await session.prompt("hello")
+
+    assert _helpers.LAST_STREAM is not None
+    seen_system = _helpers.LAST_STREAM.seen_systems[-1]
+    if should_remind:
+        assert seen_system == "REMEMBER"
+    else:
+        assert seen_system == ""
+    await session.shutdown()

--- a/tests/unit/harness_v2/test_readonly_session_append_entry.py
+++ b/tests/unit/harness_v2/test_readonly_session_append_entry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from agentm.core.kernel import text_message
+from agentm.harness.session import _SessionView
+from agentm.harness.session_manager import InMemorySessionManager, message_entry
+
+
+def test_readonly_session_append_entry_returns_id_and_chains_parent_links() -> None:
+    manager = InMemorySessionManager()
+    root = message_entry(text_message("root", timestamp=0.0), parent_id=None)
+    manager.append(root)
+    view = _SessionView(manager)
+
+    first_id = view.append_entry("compaction", {"step": 1})
+    second_id = view.append_entry("compaction", {"step": 2}, parent_id=first_id)
+
+    assert first_id != ""
+    assert second_id != ""
+
+    branch = manager.get_active_branch()
+    assert [entry.type for entry in branch] == ["message", "compaction", "compaction"]
+    assert branch[-2].id == first_id
+    assert branch[-1].id == second_id
+    assert branch[-1].parent_id == first_id


### PR DESCRIPTION
Fixes #4

- add the five builtin context-shaping extensions
- add the ReadonlySession.append_entry coverage and extension tests
- keep the v2 extension/kernel/harness gates green