### PR TITLE
Add scenario loader and built-in recipe YAMLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ requires = ["uv_build>=0.10.9,<0.11.0"]
 build-backend = "uv_build"
 
 [tool.setuptools.package-data]
-agentm = ["py.typed"]
+agentm = ["py.typed", "extensions/scenarios/*.yaml"]

--- a/src/agentm/extensions/loader.py
+++ b/src/agentm/extensions/loader.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agentm.harness.extension import ExtensionLoadError
+
+
+class ScenarioLoadError(ExtensionLoadError):
+    """Raised when a scenario YAML cannot be resolved or validated."""
+
+
+_PACKAGE = "agentm.extensions"
+
+
+def load_scenario(name_or_path: str) -> list[tuple[str, dict[str, Any]]]:
+    candidate = Path(name_or_path)
+    if candidate.is_absolute():
+        return _load_from_path(candidate)
+
+    resource = files(_PACKAGE).joinpath("scenarios", f"{name_or_path}.yaml")
+    with as_file(resource) as resolved:
+        return _load_from_path(resolved)
+
+
+def _load_from_path(path: Path) -> list[tuple[str, dict[str, Any]]]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise ScenarioLoadError(str(path), exc) from exc
+    return _parse_extensions(payload, source=str(path))
+
+
+def _parse_extensions(
+    payload: Any,
+    *,
+    source: str,
+) -> list[tuple[str, dict[str, Any]]]:
+    if not isinstance(payload, dict):
+        raise ScenarioLoadError(source, ValueError("scenario must be a mapping"))
+
+    raw_extensions = payload.get("extensions")
+    if not isinstance(raw_extensions, list):
+        raise ScenarioLoadError(source, ValueError("'extensions' must be a list"))
+
+    extensions: list[tuple[str, dict[str, Any]]] = []
+    for index, item in enumerate(raw_extensions):
+        if not isinstance(item, dict):
+            raise ScenarioLoadError(
+                source,
+                ValueError(_entry_error(index, "must be a mapping")),
+            )
+
+        module = item.get("module")
+        config = item.get("config", {})
+        if not isinstance(module, str) or not module:
+            raise ScenarioLoadError(
+                source,
+                ValueError(_entry_error(index, "missing string 'module'")),
+            )
+        if not isinstance(config, dict):
+            raise ScenarioLoadError(
+                source,
+                ValueError(_entry_error(index, "'config' must be a mapping")),
+            )
+        extensions.append((module, dict(config)))
+
+    return extensions
+
+
+def _entry_error(index: int, detail: str) -> str:
+    return f"extensions[{index}] {detail}"
+
+
+__all__ = ["ScenarioLoadError", "load_scenario"]

--- a/src/agentm/extensions/scenarios/general_purpose.yaml
+++ b/src/agentm/extensions/scenarios/general_purpose.yaml
@@ -1,0 +1,12 @@
+name: general_purpose
+description: General-purpose coding agent with read/bash/edit/write tools.
+extensions:
+  - module: agentm.extensions.builtin.tool_read
+  - module: agentm.extensions.builtin.tool_bash
+  - module: agentm.extensions.builtin.tool_edit
+  - module: agentm.extensions.builtin.tool_write
+  - module: agentm.extensions.builtin.system_prompt
+    config:
+      prompt: |
+        You are a helpful coding assistant. Use the available tools to read,
+        modify, and execute code. Be careful with destructive operations.

--- a/src/agentm/extensions/scenarios/plan_mode.yaml
+++ b/src/agentm/extensions/scenarios/plan_mode.yaml
@@ -1,0 +1,12 @@
+name: plan_mode
+description: Plan-mode framing - investigate but do not mutate.
+extensions:
+  - module: agentm.extensions.builtin.tool_submit_plan
+  - module: agentm.extensions.builtin.system_prompt
+    config:
+      prompt: |
+        You are in plan mode. Investigate; do not mutate state. Call submit_plan
+        when ready to share your plan with the user.
+  - module: agentm.extensions.builtin.permission
+    config:
+      deny: ["bash", "edit", "write"]

--- a/src/agentm/extensions/scenarios/rca.yaml
+++ b/src/agentm/extensions/scenarios/rca.yaml
@@ -1,0 +1,13 @@
+name: rca
+description: Root cause analysis - data-only, hypothesis-driven.
+extensions:
+  - module: agentm.extensions.builtin.tool_read
+  - module: agentm.extensions.builtin.tool_hypothesis_store
+  - module: agentm.extensions.builtin.system_prompt
+    config:
+      prompt: |
+        You are an RCA analyst. Collect evidence; never draw conclusions
+        without supporting data. Use the hypothesis store to track theories.
+  - module: agentm.extensions.builtin.permission
+    config:
+      deny: ["bash", "edit", "write"]

--- a/src/agentm/extensions/scenarios/trajectory_analysis.yaml
+++ b/src/agentm/extensions/scenarios/trajectory_analysis.yaml
@@ -1,0 +1,10 @@
+name: trajectory_analysis
+description: Analyze recorded agent trajectories.
+extensions:
+  - module: agentm.extensions.builtin.tool_read
+  - module: agentm.extensions.builtin.tool_trajectory_loader
+  - module: agentm.extensions.builtin.system_prompt
+    config:
+      prompt: |
+        You are a trajectory analyst. Load JSONL trajectories, summarize agent
+        behavior, and surface notable events.

--- a/tests/integration/scenarios/__init__.py
+++ b/tests/integration/scenarios/__init__.py
@@ -1,0 +1,1 @@
+"""Scenario integration tests."""

--- a/tests/integration/scenarios/_fixtures/__init__.py
+++ b/tests/integration/scenarios/_fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Scenario test fixtures."""

--- a/tests/integration/scenarios/_fixtures/scripted_provider.py
+++ b/tests/integration/scenarios/_fixtures/scripted_provider.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from agentm.core.kernel import (
+    AssistantMessage,
+    AssistantStreamEvent,
+    MessageEnd,
+    Model,
+    TextContent,
+    TextDelta,
+    ToolCallArgsDelta,
+    ToolCallBlock,
+    ToolCallEnd,
+    ToolCallStart,
+)
+from agentm.harness.extension import ProviderConfig
+
+
+class ScriptedStream:
+    def __init__(self, *, tool_name: str, arguments: dict[str, Any], final_text: str) -> None:
+        self._tool_name = tool_name
+        self._arguments = arguments
+        self._final_text = final_text
+        self.calls = 0
+
+    def __call__(
+        self,
+        *,
+        messages: list[Any],
+        model: Model,
+        tools: list[Any],
+        system: str | None = None,
+        signal: Any = None,
+        thinking: str = "off",
+    ) -> AsyncIterator[AssistantStreamEvent]:
+        del messages, model, tools, system, signal, thinking
+        self.calls += 1
+        return self._iter(self.calls)
+
+    async def _iter(self, call_index: int) -> AsyncIterator[AssistantStreamEvent]:
+        if call_index == 1:
+            import json
+
+            yield ToolCallStart(id="call-1", name=self._tool_name)
+            yield ToolCallArgsDelta(
+                id="call-1",
+                args_json_delta=json.dumps(self._arguments, sort_keys=True),
+            )
+            yield ToolCallEnd(id="call-1")
+            yield MessageEnd(
+                message=AssistantMessage(
+                    role="assistant",
+                    content=[
+                        ToolCallBlock(
+                            type="tool_call",
+                            id="call-1",
+                            name=self._tool_name,
+                            arguments=dict(self._arguments),
+                        )
+                    ],
+                    timestamp=1.0,
+                    stop_reason="tool_use",
+                )
+            )
+            return
+
+        yield TextDelta(text=self._final_text)
+        yield MessageEnd(
+            message=AssistantMessage(
+                role="assistant",
+                content=[TextContent(type="text", text=self._final_text)],
+                timestamp=2.0,
+                stop_reason="end_turn",
+            )
+        )
+
+
+def install(api: Any, config: dict[str, Any]) -> None:
+    stream = ScriptedStream(
+        tool_name=str(config["tool_name"]),
+        arguments=dict(config.get("arguments", {})),
+        final_text=str(config.get("final_text", "done")),
+    )
+    model = Model(
+        id="scripted-fake",
+        provider="scripted-fake",
+        context_window=10000,
+        max_output_tokens=1000,
+    )
+    api.register_provider(
+        "scripted-fake",
+        ProviderConfig(stream_fn=stream, model=model, name="scripted-fake"),
+    )

--- a/tests/integration/scenarios/test_plan_mode_blocks_mutations.py
+++ b/tests/integration/scenarios/test_plan_mode_blocks_mutations.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from agentm.core.operations import BashOperations, ExecResult
+from agentm.extensions.loader import load_scenario
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@dataclass
+class RecordingBashOps(BashOperations):
+    calls: list[tuple[str, str]]
+
+    async def exec(
+        self,
+        cmd: str,
+        *,
+        cwd: str,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        on_data=None,
+        signal=None,
+    ) -> ExecResult:
+        del timeout, env, on_data, signal
+        self.calls.append((cmd, cwd))
+        return ExecResult(stdout=b"ran", stderr=b"", exit_code=0, timed_out=False)
+
+
+@pytest.mark.asyncio
+async def test_plan_mode_blocks_mutating_bash_tool(tmp_path: Path) -> None:
+    bash_ops = RecordingBashOps(calls=[])
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=load_scenario("plan_mode")
+            + [
+                (
+                    "agentm.extensions.builtin.tool_bash",
+                    {"bash_ops": bash_ops},
+                )
+            ],
+            provider=(
+                "tests.integration.scenarios._fixtures.scripted_provider",
+                {
+                    "tool_name": "bash",
+                    "arguments": {"cmd": "echo should-not-run"},
+                    "final_text": "blocked",
+                },
+            ),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    try:
+        final = await session.prompt("try to mutate")
+        tool_result_message = final[2]
+        result_block = tool_result_message.content[0]
+
+        assert result_block.is_error is True
+        assert "Tool call blocked" in result_block.content[0].text
+        assert "denied by denylist" in result_block.content[0].text
+        assert bash_ops.calls == []
+    finally:
+        await session.shutdown()

--- a/tests/integration/scenarios/test_scenarios_smoke.py
+++ b/tests/integration/scenarios/test_scenarios_smoke.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentm.extensions.loader import load_scenario
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scenario_name", "tool_name", "arguments", "expected_entry_types"),
+    [
+        ("general_purpose", "read", None, {"message"}),
+        (
+            "rca",
+            "add_hypothesis",
+            {"id": "H1", "description": "Disk is full"},
+            {"message", "hypothesis"},
+        ),
+        ("trajectory_analysis", "load_trajectory", None, {"message"}),
+        (
+            "plan_mode",
+            "submit_plan",
+            {"plan": "1. Inspect\n2. Validate\n3. Report"},
+            {"message", "plan"},
+        ),
+    ],
+)
+async def test_scenarios_smoke(
+    tmp_path: Path,
+    scenario_name: str,
+    tool_name: str,
+    arguments: dict[str, Any] | None,
+    expected_entry_types: set[str],
+) -> None:
+    read_path = tmp_path / "sample.txt"
+    read_path.write_text("alpha\nbeta\n", encoding="utf-8")
+    trajectory_path = tmp_path / "trajectory.jsonl"
+    trajectory_path.write_text(
+        json.dumps({"channel": "tool_call", "name": "read"}) + "\n"
+        + json.dumps({"channel": "tool_result", "name": "read"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    scenario_arguments = arguments or _default_arguments(
+        tool_name,
+        read_path=read_path,
+        trajectory_path=trajectory_path,
+    )
+
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=load_scenario(scenario_name),
+            provider=(
+                "tests.integration.scenarios._fixtures.scripted_provider",
+                {
+                    "tool_name": tool_name,
+                    "arguments": scenario_arguments,
+                    "final_text": f"{scenario_name} complete",
+                },
+            ),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+    try:
+        assert any(tool.name == tool_name for tool in session.tools)
+
+        final = await session.prompt(f"run {scenario_name}")
+        assert final[-1].role == "assistant"
+
+        branch = session.session_manager.get_active_branch()
+        branch_types = {entry.type for entry in branch}
+        assert expected_entry_types <= branch_types
+    finally:
+        await session.shutdown()
+
+
+def _default_arguments(
+    tool_name: str,
+    *,
+    read_path: Path,
+    trajectory_path: Path,
+) -> dict[str, Any]:
+    if tool_name == "read":
+        return {"path": str(read_path)}
+    if tool_name == "load_trajectory":
+        return {"path": str(trajectory_path)}
+    raise AssertionError(f"missing default arguments for {tool_name!r}")

--- a/tests/unit/extensions/builtin/cost_budget/test_cost_budget.py
+++ b/tests/unit/extensions/builtin/cost_budget/test_cost_budget.py
@@ -45,6 +45,7 @@ async def test_handler_emits_cost_budget_exceeded_payload() -> None:
         renderers=renderers,
         pending_user_messages=pending,
         model_getter=lambda: model,
+        provider_getter=lambda: None,
     )
 
     seen: list[CostBudgetExceededEvent] = []

--- a/tests/unit/extensions/loader/test_load_scenario.py
+++ b/tests/unit/extensions/loader/test_load_scenario.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+from agentm.extensions.loader import ScenarioLoadError, load_scenario
+
+
+_BUILTIN_SCENARIOS = [
+    "general_purpose",
+    "rca",
+    "trajectory_analysis",
+    "plan_mode",
+]
+
+
+def test_load_scenario_resolves_builtin_name() -> None:
+    loaded = load_scenario("rca")
+
+    assert loaded == [
+        ("agentm.extensions.builtin.tool_read", {}),
+        ("agentm.extensions.builtin.tool_hypothesis_store", {}),
+        (
+            "agentm.extensions.builtin.system_prompt",
+            {
+                "prompt": (
+                    "You are an RCA analyst. Collect evidence; never draw conclusions\n"
+                    "without supporting data. Use the hypothesis store to track theories.\n"
+                )
+            },
+        ),
+        (
+            "agentm.extensions.builtin.permission",
+            {"deny": ["bash", "edit", "write"]},
+        ),
+    ]
+    assert loaded[0][0] == "agentm.extensions.builtin.tool_read"
+
+
+def test_load_scenario_accepts_absolute_path() -> None:
+    scenario_path = (
+        Path(__file__).resolve().parents[4]
+        / "src"
+        / "agentm"
+        / "extensions"
+        / "scenarios"
+        / "rca.yaml"
+    )
+
+    assert load_scenario(str(scenario_path)) == load_scenario("rca")
+
+
+def test_load_scenario_rejects_non_list_extensions(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("extensions: not-a-list\n", encoding="utf-8")
+
+    with pytest.raises(ScenarioLoadError, match="extensions"):
+        load_scenario(str(path))
+
+
+def test_load_scenario_rejects_missing_module_key(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("extensions:\n  - config: {}\n", encoding="utf-8")
+
+    with pytest.raises(ScenarioLoadError, match="module"):
+        load_scenario(str(path))
+
+
+@pytest.mark.parametrize("name", _BUILTIN_SCENARIOS)
+def test_builtin_scenarios_resolve_importable_installers(name: str) -> None:
+    loaded = load_scenario(name)
+
+    assert loaded
+    for module_path, _config in loaded:
+        module = import_module(module_path)
+        install = getattr(module, "install", None)
+        assert callable(install), f"{module_path} must export install()"


### PR DESCRIPTION
Fixes #12

## What changed
- add `load_scenario()` plus `ScenarioLoadError`
- add four built-in scenario YAML recipes under `src/agentm/extensions/scenarios/`
- add unit coverage for loader validation and built-in recipe imports
- add integration smoke coverage for all four scenarios and a plan-mode mutation block test
- include scenario YAMLs in package data

## Validation
- `uv run ruff check src/agentm/extensions/loader.py tests/unit/extensions/loader/ tests/integration/scenarios/ tests/unit/extensions/builtin/cost_budget/test_cost_budget.py`
- `uv run mypy src/agentm/extensions/loader.py`
- `uv run python -c "from agentm.extensions.loader import load_scenario; [load_scenario(n) for n in ['general_purpose','rca','trajectory_analysis','plan_mode']]"`
- `uv run pytest tests/unit/extensions/ tests/integration/scenarios/ tests/unit/kernel/ tests/unit/harness_v2/ tests/unit/llm/ tests/unit/core/operations/ -q`
