### PR TITLE
feat: cherry-pick provider registry + OAuth interfaces (#20)

### DIFF
--- a/src/agentm/ai/__init__.py
+++ b/src/agentm/ai/__init__.py
@@ -1,0 +1,31 @@
+"""Provider interface package — port of pi-mono `packages/ai/`.
+
+This is an *interface-only* port. Concrete provider implementations
+(Anthropic, OpenAI, Bedrock, ...) are deliberately not ported; they
+should be added by consumers when needed. The current direct-LLM
+path through ``agentm.llm`` continues to work alongside this registry.
+"""
+
+from agentm.ai.api_registry import (
+    ApiProvider,
+    clear_api_providers,
+    get_api_provider,
+    get_api_providers,
+    register_api_provider,
+    unregister_api_providers,
+)
+from agentm.ai.env_api_keys import find_env_keys, get_env_api_key
+from agentm.ai.types import Model, StreamFunction
+
+__all__ = [
+    "ApiProvider",
+    "Model",
+    "StreamFunction",
+    "clear_api_providers",
+    "find_env_keys",
+    "get_api_provider",
+    "get_api_providers",
+    "get_env_api_key",
+    "register_api_provider",
+    "unregister_api_providers",
+]

--- a/src/agentm/ai/api_registry.py
+++ b/src/agentm/ai/api_registry.py
@@ -1,0 +1,92 @@
+"""Provider registry — port of pi-mono `api-registry.ts`.
+
+Mutable module-level map keyed by `Api` string. `register_api_provider`
+wraps `stream` / `stream_simple` so each call validates the model's
+`api` matches the provider's `api` (matches pi-mono's mismatched-api
+error). `source_id` lets a caller bulk-unregister everything one
+extension or test fixture installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Iterable
+
+from agentm.ai.types import Api, ApiProvider, Model
+
+
+@dataclass(slots=True)
+class _RegisteredProvider:
+    provider: ApiProvider
+    source_id: str | None = None
+
+
+_registry: dict[Api, _RegisteredProvider] = {}
+
+
+def _wrap(provider: ApiProvider) -> ApiProvider:
+    """Return a thin wrapper that enforces `model.api == provider.api`."""
+
+    expected = provider.api
+
+    class _Wrapped:
+        api = expected
+
+        async def stream(
+            self, model: Model, context: Any, options: Any | None = None
+        ) -> Iterable[Any]:
+            if model.api != expected:
+                raise ValueError(f"Mismatched api: {model.api} expected {expected}")
+            result = provider.stream(model, context, options)
+            return await _await(result)
+
+        async def stream_simple(
+            self, model: Model, context: Any, options: Any | None = None
+        ) -> Iterable[Any]:
+            if model.api != expected:
+                raise ValueError(f"Mismatched api: {model.api} expected {expected}")
+            result = provider.stream_simple(model, context, options)
+            return await _await(result)
+
+    return _Wrapped()  # type: ignore[return-value]
+
+
+async def _await(value: Any) -> Any:
+    """Await ``value`` if it is awaitable; otherwise return as-is."""
+
+    if isinstance(value, Awaitable):
+        return await value
+    return value
+
+
+def register_api_provider(provider: ApiProvider, source_id: str | None = None) -> None:
+    """Register ``provider`` under its ``api`` key. Replaces any prior entry."""
+
+    _registry[provider.api] = _RegisteredProvider(provider=_wrap(provider), source_id=source_id)
+
+
+def get_api_provider(api: Api) -> ApiProvider | None:
+    """Look up a registered provider by api string, or ``None`` if unknown."""
+
+    entry = _registry.get(api)
+    return entry.provider if entry is not None else None
+
+
+def get_api_providers() -> list[ApiProvider]:
+    """Return all currently registered providers (snapshot)."""
+
+    return [entry.provider for entry in _registry.values()]
+
+
+def unregister_api_providers(source_id: str) -> None:
+    """Remove every provider that was registered with ``source_id``."""
+
+    stale = [api for api, entry in _registry.items() if entry.source_id == source_id]
+    for api in stale:
+        del _registry[api]
+
+
+def clear_api_providers() -> None:
+    """Drop the entire registry. Intended for tests and process shutdown."""
+
+    _registry.clear()

--- a/src/agentm/ai/env_api_keys.py
+++ b/src/agentm/ai/env_api_keys.py
@@ -1,0 +1,57 @@
+"""Environment-based API key discovery — port of pi-mono `env-api-keys.ts`.
+
+Cherry-picked: only providers AgentM currently has consumers for, plus
+the order convention pi-mono uses (e.g., ``ANTHROPIC_OAUTH_TOKEN`` takes
+precedence over ``ANTHROPIC_API_KEY``). The Bedrock/Vertex ambient-
+credential probing in pi-mono is out of scope here — those providers
+must add their own discovery when ported.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Order matters: first match wins inside `get_env_api_key`. Lists are
+# tuples to keep them immutable at module level.
+_PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
+    "openai": ("OPENAI_API_KEY",),
+    "azure-openai-responses": ("AZURE_OPENAI_API_KEY",),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "google": ("GEMINI_API_KEY",),
+    "google-vertex": ("GOOGLE_CLOUD_API_KEY",),
+    "groq": ("GROQ_API_KEY",),
+    "cerebras": ("CEREBRAS_API_KEY",),
+    "xai": ("XAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "mistral": ("MISTRAL_API_KEY",),
+    "huggingface": ("HF_TOKEN",),
+    "fireworks": ("FIREWORKS_API_KEY",),
+    "github-copilot": ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+}
+
+
+def find_env_keys(provider: str) -> list[str] | None:
+    """Return env var names that are *currently set* for ``provider``.
+
+    Returns ``None`` when the provider is unknown or none of its env
+    vars are populated. Mirrors pi-mono ``findEnvKeys``.
+    """
+
+    candidates = _PROVIDER_ENV_VARS.get(provider)
+    if not candidates:
+        return None
+    found = [name for name in candidates if os.environ.get(name)]
+    return found or None
+
+
+def get_env_api_key(provider: str) -> str | None:
+    """Return the API key for ``provider`` from the highest-priority env var.
+
+    Returns ``None`` if the provider is unknown or no env var is set.
+    """
+
+    found = find_env_keys(provider)
+    if not found:
+        return None
+    return os.environ.get(found[0])

--- a/src/agentm/ai/oauth/__init__.py
+++ b/src/agentm/ai/oauth/__init__.py
@@ -1,0 +1,25 @@
+"""OAuth interface package — interface-only port of pi-mono OAuth utils.
+
+Concrete provider login flows (Anthropic, GitHub Copilot, Google Gemini
+CLI) are not ported. Adding one means implementing
+:class:`OAuthProviderInterface` for the provider and registering it via
+the consumer's own bootstrap.
+"""
+
+from agentm.ai.oauth.pkce import generate_pkce
+from agentm.ai.oauth.types import (
+    OAuthAuthInfo,
+    OAuthCredentials,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthProviderInterface,
+)
+
+__all__ = [
+    "OAuthAuthInfo",
+    "OAuthCredentials",
+    "OAuthLoginCallbacks",
+    "OAuthPrompt",
+    "OAuthProviderInterface",
+    "generate_pkce",
+]

--- a/src/agentm/ai/oauth/pkce.py
+++ b/src/agentm/ai/oauth/pkce.py
@@ -1,0 +1,31 @@
+"""PKCE utilities — port of pi-mono `utils/oauth/pkce.ts`.
+
+Uses Python stdlib ``secrets`` + ``hashlib`` instead of Web Crypto.
+Output is base64url-encoded (no padding) per RFC 7636.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class PKCEPair:
+    verifier: str
+    challenge: str
+
+
+def _base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce() -> PKCEPair:
+    """Return a fresh PKCE verifier+challenge pair (S256)."""
+
+    verifier_bytes = secrets.token_bytes(32)
+    verifier = _base64url(verifier_bytes)
+    challenge = _base64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return PKCEPair(verifier=verifier, challenge=challenge)

--- a/src/agentm/ai/oauth/types.py
+++ b/src/agentm/ai/oauth/types.py
@@ -1,0 +1,71 @@
+"""OAuth type definitions — port of pi-mono `utils/oauth/types.ts`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Protocol
+
+
+@dataclass(slots=True)
+class OAuthCredentials:
+    """Persisted credentials for an OAuth provider session.
+
+    ``expires`` is an absolute unix timestamp in milliseconds (matches
+    pi-mono). Additional provider-specific fields (e.g. ``account_id``)
+    can be stashed in ``extra``.
+    """
+
+    refresh: str
+    access: str
+    expires: int
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True, frozen=True)
+class OAuthPrompt:
+    """User prompt the OAuth flow may request via ``OAuthLoginCallbacks.on_prompt``."""
+
+    message: str
+    placeholder: str | None = None
+    allow_empty: bool = False
+
+
+@dataclass(slots=True, frozen=True)
+class OAuthAuthInfo:
+    """Auth URL the user must visit to complete the login flow."""
+
+    url: str
+    instructions: str | None = None
+
+
+OnAuth = Callable[[OAuthAuthInfo], None]
+OnPrompt = Callable[[OAuthPrompt], Awaitable[str]]
+OnProgress = Callable[[str], None]
+OnManualCodeInput = Callable[[], Awaitable[str]]
+
+
+@dataclass(slots=True)
+class OAuthLoginCallbacks:
+    """Callbacks the host (CLI / web UI) supplies to drive the login flow."""
+
+    on_auth: OnAuth
+    on_prompt: OnPrompt
+    on_progress: OnProgress | None = None
+    on_manual_code_input: OnManualCodeInput | None = None
+
+
+class OAuthProviderInterface(Protocol):
+    """Contract every OAuth provider implementation must satisfy."""
+
+    id: str
+    name: str
+    uses_callback_server: bool
+
+    async def login(self, callbacks: OAuthLoginCallbacks) -> OAuthCredentials:
+        """Run the login flow, returning credentials to persist."""
+
+    async def refresh_token(self, credentials: OAuthCredentials) -> OAuthCredentials:
+        """Refresh expired credentials, returning the updated set."""
+
+    def get_api_key(self, credentials: OAuthCredentials) -> str:
+        """Convert credentials into the API key string the provider accepts."""

--- a/src/agentm/ai/types.py
+++ b/src/agentm/ai/types.py
@@ -1,0 +1,87 @@
+"""Type definitions for the provider registry. Port of pi-mono `types.ts`.
+
+Only the names referenced by `api_registry.py`, `env_api_keys.py`, and the
+OAuth interfaces are included. The full pi-mono `types.ts` defines stream
+options, message events, and ~25 provider literals; we intentionally
+narrow that surface to what the registry needs today and let consumers
+extend `KNOWN_PROVIDERS` / `KNOWN_APIS` when they add new providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Iterable, Literal, Protocol
+
+KnownApi = Literal[
+    "openai-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "bedrock-converse-stream",
+    "google-generative-ai",
+]
+Api = str  # KnownApi | str — accept any string at runtime, narrow via Literal in callers
+
+KnownProvider = Literal[
+    "anthropic",
+    "openai",
+    "amazon-bedrock",
+    "google",
+    "google-vertex",
+    "azure-openai-responses",
+    "openai-codex",
+    "deepseek",
+    "github-copilot",
+    "xai",
+    "groq",
+    "cerebras",
+    "openrouter",
+    "mistral",
+    "huggingface",
+    "fireworks",
+]
+Provider = str
+
+ThinkingLevel = Literal["minimal", "low", "medium", "high", "xhigh"]
+
+
+@dataclass(slots=True)
+class Model:
+    """Minimal model descriptor. Mirrors pi-mono `Model<Api>` shape.
+
+    ``id`` is the provider-side model identifier (e.g. ``claude-3-7-sonnet``).
+    ``provider`` and ``api`` route the call through the registry.
+    ``options`` carries provider-specific config (base_url, headers, ...) —
+    untyped on purpose so the registry stays decoupled from individual
+    provider option schemas.
+    """
+
+    id: str
+    provider: Provider
+    api: Api
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+# Stream functions are async-iterable producers in pi-mono. We model them
+# as callables returning an async iterator of opaque events; the concrete
+# event shape lives with each provider's port (out of scope here).
+
+StreamFunction = Callable[[Model, Any], Awaitable[Iterable[Any]]]
+
+
+class ApiProvider(Protocol):
+    """Protocol every concrete provider implementation must satisfy.
+
+    Mirrors pi-mono `ApiProvider<TApi, TOptions>` interface. The registry
+    stores providers by their `api` string; `stream` and `stream_simple`
+    receive a `Model` whose `api` field must match `provider.api`.
+    """
+
+    api: Api
+
+    def stream(self, model: Model, context: Any, options: Any | None = None) -> Awaitable[Iterable[Any]]:
+        ...
+
+    def stream_simple(
+        self, model: Model, context: Any, options: Any | None = None
+    ) -> Awaitable[Iterable[Any]]:
+        ...

--- a/tests/unit/ai/test_api_registry.py
+++ b/tests/unit/ai/test_api_registry.py
@@ -1,0 +1,89 @@
+"""Tests for the api-registry — port behavior of pi-mono `api-registry.ts`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentm.ai import (
+    Model,
+    clear_api_providers,
+    get_api_provider,
+    get_api_providers,
+    register_api_provider,
+    unregister_api_providers,
+)
+
+
+class _FakeProvider:
+    def __init__(self, api: str) -> None:
+        self.api = api
+        self.stream_calls: list[Model] = []
+
+    async def stream(self, model: Model, context: Any, options: Any | None = None) -> list[str]:
+        self.stream_calls.append(model)
+        return ["streamed", model.id]
+
+    async def stream_simple(
+        self, model: Model, context: Any, options: Any | None = None
+    ) -> list[str]:
+        return ["simple", model.id]
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> None:
+    clear_api_providers()
+    yield
+    clear_api_providers()
+
+
+def test_register_and_lookup_round_trips() -> None:
+    provider = _FakeProvider("anthropic-messages")
+    register_api_provider(provider)
+
+    found = get_api_provider("anthropic-messages")
+    assert found is not None
+    assert found.api == "anthropic-messages"
+    assert get_api_provider("openai-completions") is None
+
+
+def test_register_replaces_prior_entry_for_same_api() -> None:
+    first = _FakeProvider("anthropic-messages")
+    second = _FakeProvider("anthropic-messages")
+    register_api_provider(first)
+    register_api_provider(second)
+
+    assert len(get_api_providers()) == 1
+
+
+def test_unregister_by_source_id_removes_only_matching_entries() -> None:
+    register_api_provider(_FakeProvider("anthropic-messages"), source_id="ext-a")
+    register_api_provider(_FakeProvider("openai-completions"), source_id="ext-b")
+
+    unregister_api_providers("ext-a")
+
+    assert get_api_provider("anthropic-messages") is None
+    assert get_api_provider("openai-completions") is not None
+
+
+@pytest.mark.asyncio
+async def test_stream_rejects_model_with_mismatched_api() -> None:
+    register_api_provider(_FakeProvider("anthropic-messages"))
+    wrapped = get_api_provider("anthropic-messages")
+    assert wrapped is not None
+
+    bad_model = Model(id="m", provider="openai", api="openai-completions")
+    with pytest.raises(ValueError, match="Mismatched api"):
+        await wrapped.stream(bad_model, context=None)
+
+
+@pytest.mark.asyncio
+async def test_stream_passes_through_when_api_matches() -> None:
+    register_api_provider(_FakeProvider("anthropic-messages"))
+    wrapped = get_api_provider("anthropic-messages")
+    assert wrapped is not None
+
+    model = Model(id="claude-3", provider="anthropic", api="anthropic-messages")
+    out = await wrapped.stream(model, context={"hello": "world"})
+    assert out == ["streamed", "claude-3"]

--- a/tests/unit/ai/test_env_api_keys.py
+++ b/tests/unit/ai/test_env_api_keys.py
@@ -1,0 +1,50 @@
+"""Tests for env-api-keys discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentm.ai import find_env_keys, get_env_api_key
+
+
+def test_anthropic_oauth_token_takes_precedence_over_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", "oauth-value")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "api-value")
+
+    assert get_env_api_key("anthropic") == "oauth-value"
+    assert find_env_keys("anthropic") == ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
+
+
+def test_falls_back_to_api_key_when_oauth_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fallback-key")
+
+    assert get_env_api_key("anthropic") == "fallback-key"
+
+
+def test_unknown_provider_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert get_env_api_key("not-a-provider") is None
+    assert find_env_keys("not-a-provider") is None
+
+
+def test_returns_none_when_no_env_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("OPENAI_API_KEY",):
+        monkeypatch.delenv(var, raising=False)
+
+    assert get_env_api_key("openai") is None
+    assert find_env_keys("openai") is None
+
+
+def test_github_copilot_checks_three_token_vars_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-fallback")
+
+    assert get_env_api_key("github-copilot") == "gh-fallback"
+    assert find_env_keys("github-copilot") == ["GITHUB_TOKEN"]

--- a/tests/unit/ai/test_pkce.py
+++ b/tests/unit/ai/test_pkce.py
@@ -1,0 +1,32 @@
+"""Tests for PKCE generation — verifier+challenge S256 contract."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from agentm.ai.oauth import generate_pkce
+
+
+def test_pkce_pair_matches_s256_relationship() -> None:
+    pair = generate_pkce()
+
+    expected_challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(pair.verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert pair.challenge == expected_challenge
+
+
+def test_pkce_pairs_are_unique_per_call() -> None:
+    pairs = {generate_pkce().verifier for _ in range(8)}
+    assert len(pairs) == 8
+
+
+def test_verifier_is_base64url_no_padding() -> None:
+    verifier = generate_pkce().verifier
+    assert "=" not in verifier
+    assert "+" not in verifier and "/" not in verifier
+    # 32 random bytes → 43 base64url chars
+    assert len(verifier) == 43


### PR DESCRIPTION
## Summary

- Interface-only port of pi-mono `packages/ai/src/` registry surface
- Cherry-picked: `api_registry`, `types`, `env_api_keys`, OAuth `types` + `pkce`
- **Skipped** (deferred): all 25 concrete provider implementations, model-registry/resolver, auth-storage, full OAuth flows. The dev-agent attempt at full port (PR #29, closed) showed those are out of practical scope for an SDK — consumers should add what they need.
- Existing direct-LLM path (`agentm.llm.*`) is untouched. This PR adds capability, removes nothing.

## Files

```
src/agentm/ai/__init__.py
src/agentm/ai/types.py            # Api / Provider literals, Model, ApiProvider Protocol
src/agentm/ai/api_registry.py     # register / get / unregister / clear
src/agentm/ai/env_api_keys.py     # find_env_keys, get_env_api_key (anthropic, openai, ...)
src/agentm/ai/oauth/__init__.py
src/agentm/ai/oauth/types.py      # OAuthCredentials, OAuthProviderInterface, callbacks
src/agentm/ai/oauth/pkce.py       # PKCE S256 (stdlib)
tests/unit/ai/                    # 13 tests, all passing
```

## Test plan

- [x] `uv run pytest` — 226 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentm/ai/` — clean

## Acceptance Criteria status

- [x] Provider registry interface present
- [x] OAuth interface (Protocol) present, PKCE helper works
- [x] env-api-keys fallback works for anthropic/openai/etc.
- [x] All existing tests pass; existing direct-LLM API kept (deliberate scope reduction vs. original AC)
- [x] mypy + ruff clean

Closes #20.