### PR TITLE
feat: add tool catalog atom

### DIFF
--- a/src/agentm/core/catalog/__init__.py
+++ b/src/agentm/core/catalog/__init__.py
@@ -9,6 +9,12 @@ from typing import Any
 import yaml
 
 from agentm.core.catalog import _layout
+from agentm.core.catalog.browse import (
+    CatalogAtom,
+    get_manifest_at,
+    list_versions,
+    runs_for,
+)
 from agentm.core.catalog.freeze import freeze_current
 from agentm.core.catalog.hashing import (
     compute_active_set_fingerprint,
@@ -65,9 +71,13 @@ def _load_manifest(path: Path) -> dict[str, Any]:
 
 
 __all__ = [
-    "compute_atom_hash",
+    "CatalogAtom",
     "compute_active_set_fingerprint",
+    "compute_atom_hash",
     "freeze_current",
+    "get_manifest_at",
     "is_constitution_path",
     "list_atoms",
+    "list_versions",
+    "runs_for",
 ]

--- a/src/agentm/core/catalog/browse.py
+++ b/src/agentm/core/catalog/browse.py
@@ -1,0 +1,102 @@
+"""Read-only helpers for browsing the on-disk catalog."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agentm.core.catalog import _layout
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogAtom:
+    name: str
+    versions: tuple[str, ...]
+
+
+def list_versions(name: str, root: Path | None = None) -> list[str]:
+    atom_root = _layout.atoms_dir(name, root=root)
+    if not atom_root.exists():
+        return []
+    versions = {
+        entry.name
+        for entry in atom_root.iterdir()
+        if entry.name != "current" and entry.is_dir()
+    }
+    current = _read_current_version(name, root=root)
+    if current:
+        versions.add(current)
+    return sorted(versions)
+
+
+def get_manifest_at(
+    name: str, version: str, root: Path | None = None
+) -> dict[str, Any]:
+    manifest_path = _layout.atom_manifest_path(name, version, root=root)
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Manifest at {manifest_path} must decode to a mapping, got {type(payload).__name__}"
+        )
+    return payload
+
+
+def runs_for(fingerprint: dict[str, Any] | str, root: Path | None = None) -> list[str]:
+    refs = _normalize_fingerprint(fingerprint)
+    if not refs:
+        return []
+
+    trace_sets: list[set[str]] = []
+    for name, version in refs.items():
+        runs_dir = _layout.atom_runs_dir(name, version, root=root)
+        if not runs_dir.exists():
+            return []
+        trace_sets.append({entry.name for entry in runs_dir.iterdir()})
+    if not trace_sets:
+        return []
+    trace_ids = set.intersection(*trace_sets)
+    return sorted(trace_ids)
+
+
+def _normalize_fingerprint(
+    fingerprint: dict[str, Any] | str,
+) -> dict[str, str]:
+    if isinstance(fingerprint, str):
+        atom, version = _split_atom_ref(fingerprint, None)
+        return {atom: version}
+    if not isinstance(fingerprint, dict):
+        raise TypeError("fingerprint must be a dict or 'atom@version' string")
+
+    raw_atoms = fingerprint.get("atoms")
+    atom_map = raw_atoms if isinstance(raw_atoms, dict) else fingerprint
+    refs: dict[str, str] = {}
+    for key, value in atom_map.items():
+        atom, version = _split_atom_ref(str(value), str(key))
+        refs[atom] = version
+    return refs
+
+
+def _split_atom_ref(value: str, fallback_atom: str | None) -> tuple[str, str]:
+    atom, separator, version = value.partition("@")
+    if separator:
+        if not atom or not version:
+            raise ValueError(f"Invalid atom reference: {value!r}")
+        return atom, version
+    if fallback_atom is None:
+        raise ValueError(f"Expected 'atom@version', got {value!r}")
+    return fallback_atom, value
+
+
+def _read_current_version(name: str, root: Path | None = None) -> str | None:
+    current_path = _layout.atom_current_symlink(name, root=root)
+    if current_path.is_symlink():
+        return Path(os.readlink(current_path)).name
+    if current_path.exists():
+        text = current_path.read_text(encoding="utf-8").strip()
+        return text or None
+    return None

--- a/src/agentm/extensions/builtin/tool_catalog.py
+++ b/src/agentm/extensions/builtin/tool_catalog.py
@@ -76,9 +76,16 @@ _RUNS_FOR_PARAMS = {
 
 
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
-    root = Path(str(config.get("root", ".agentm/catalog")))
-    if not root.is_absolute():
-        root = Path(api.cwd) / root
+    # ``root`` is the *project* root that contains ``.agentm/catalog/``.
+    # ``agentm.core.catalog._layout.catalog_root`` prepends that segment, so
+    # callers must not include it here. Defaults to the session cwd.
+    raw_root = config.get("root")
+    if raw_root is None:
+        root = Path(api.cwd)
+    else:
+        root = Path(str(raw_root))
+        if not root.is_absolute():
+            root = Path(api.cwd) / root
 
     async def _list_versions_tool(args: dict[str, Any]) -> ToolResult:
         versions = list_versions(str(args["atom"]), root)

--- a/src/agentm/extensions/builtin/tool_catalog.py
+++ b/src/agentm/extensions/builtin/tool_catalog.py
@@ -1,0 +1,143 @@
+"""Read-only browser of `.agentm/catalog` for the agent.
+
+Tier-1 MVP scope: browse versions, manifests, and recorded runs. This atom
+intentionally does not expose `compare()` or `propose_change()`; those land in
+Phase 2.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agentm.core.catalog import get_manifest_at, list_versions, runs_for
+from agentm.core.kernel import FunctionTool, TextContent, ToolResult
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+MANIFEST = ExtensionManifest(
+    name="tool_catalog",
+    description=(
+        "Browse catalog versions, manifests, and recorded runs. MVP is read-only; "
+        "compare()/propose_change() are deferred to Phase 2."
+    ),
+    registers=(
+        "tool:catalog_list_versions",
+        "tool:catalog_get_manifest",
+        "tool:catalog_runs_for",
+    ),
+    config_schema={
+        "type": "object",
+        "properties": {"root": {"type": "string"}},
+        "additionalProperties": False,
+    },
+    api_version=1,
+    affects=(),
+    tier=1,
+)
+
+_LIST_VERSIONS_PARAMS = {
+    "type": "object",
+    "properties": {
+        "atom": {
+            "type": "string",
+            "description": "Atom name, for example 'tool_read'.",
+        }
+    },
+    "required": ["atom"],
+    "additionalProperties": False,
+}
+
+_GET_MANIFEST_PARAMS = {
+    "type": "object",
+    "properties": {
+        "atom": {"type": "string"},
+        "version": {
+            "type": "string",
+            "description": "Catalog version hash.",
+        },
+    },
+    "required": ["atom", "version"],
+    "additionalProperties": False,
+}
+
+_RUNS_FOR_PARAMS = {
+    "type": "object",
+    "properties": {
+        "fingerprint": {
+            "description": "Exact atom-set fingerprint mapping or 'atom@version' string.",
+            "oneOf": [{"type": "object"}, {"type": "string"}],
+        }
+    },
+    "required": ["fingerprint"],
+    "additionalProperties": False,
+}
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    root = Path(str(config.get("root", ".agentm/catalog")))
+    if not root.is_absolute():
+        root = Path(api.cwd) / root
+
+    async def _list_versions_tool(args: dict[str, Any]) -> ToolResult:
+        versions = list_versions(str(args["atom"]), root)
+        return _json_result(versions)
+
+    async def _get_manifest_tool(args: dict[str, Any]) -> ToolResult:
+        atom = str(args["atom"])
+        version = str(args["version"])
+        try:
+            return _json_result(get_manifest_at(atom, version, root))
+        except Exception as exc:
+            return _error(
+                f"Failed to load manifest for {atom}@{version}: {exc}"
+            )
+
+    async def _runs_for_tool(args: dict[str, Any]) -> ToolResult:
+        try:
+            trace_ids = runs_for(args["fingerprint"], root)
+            return _json_result(trace_ids)
+        except Exception as exc:
+            return _error(f"Failed to resolve catalog runs: {exc}")
+
+    api.register_tool(
+        FunctionTool(
+            name="catalog_list_versions",
+            description="List known catalog versions for one atom.",
+            parameters=_LIST_VERSIONS_PARAMS,
+            fn=_list_versions_tool,
+        )
+    )
+    api.register_tool(
+        FunctionTool(
+            name="catalog_get_manifest",
+            description="Load the full manifest for one cataloged atom version.",
+            parameters=_GET_MANIFEST_PARAMS,
+            fn=_get_manifest_tool,
+        )
+    )
+    api.register_tool(
+        FunctionTool(
+            name="catalog_runs_for",
+            description="List trace ids recorded for an exact atom-set fingerprint.",
+            parameters=_RUNS_FOR_PARAMS,
+            fn=_runs_for_tool,
+        )
+    )
+
+
+def _json_result(payload: Any) -> ToolResult:
+    return ToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(payload, default=str, indent=2, sort_keys=True),
+            )
+        ],
+        details=payload,
+    )
+
+
+def _error(text: str) -> ToolResult:
+    return ToolResult(content=[TextContent(type="text", text=text)], is_error=True)

--- a/src/agentm/extensions/scenarios/general_purpose.yaml
+++ b/src/agentm/extensions/scenarios/general_purpose.yaml
@@ -9,6 +9,7 @@ extensions:
   - module: agentm.extensions.builtin.tool_grep
   - module: agentm.extensions.builtin.tool_find
   - module: agentm.extensions.builtin.tool_ls
+  - module: agentm.extensions.builtin.tool_catalog
   - module: agentm.extensions.builtin.micro_compact
     config:
       threshold_pct: 0.85

--- a/tests/unit/core/catalog/test_hashing.py
+++ b/tests/unit/core/catalog/test_hashing.py
@@ -68,12 +68,20 @@ def test_active_set_fingerprint_optional_core_and_scenario() -> None:
 
 
 def test_public_surface_all_matches_contract() -> None:
+    # PR #42 froze the catalog-storage surface; PR #43 (tool-catalog-atom)
+    # additively extended it with the read-API helpers
+    # (CatalogAtom/list_versions/get_manifest_at/runs_for). Both are part of
+    # the agreed Wave-2 contract.
     assert catalog.__all__ == [
-        "compute_atom_hash",
+        "CatalogAtom",
         "compute_active_set_fingerprint",
+        "compute_atom_hash",
         "freeze_current",
+        "get_manifest_at",
         "is_constitution_path",
         "list_atoms",
+        "list_versions",
+        "runs_for",
     ]
 
 

--- a/tests/unit/extensions/builtin/tool_catalog/test_tool_catalog.py
+++ b/tests/unit/extensions/builtin/tool_catalog/test_tool_catalog.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agentm.extensions.validate import validate_builtin
+from agentm.harness.resource_loader import InMemoryResourceLoader
+from agentm.harness.session import AgentSession, AgentSessionConfig
+
+
+async def _session(tmp_path: Path) -> AgentSession:
+    return await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            extensions=[("agentm.extensions.builtin.tool_catalog", {})],
+            provider=("tests.unit.extensions.builtin._helpers", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+
+
+def _seed_current(atom_root: Path, version: str) -> None:
+    current = atom_root / "current"
+    try:
+        current.symlink_to(version)
+    except OSError:
+        current.write_text(version, encoding="utf-8")
+
+
+def _seed_atom(
+    tmp_path: Path,
+    *,
+    atom: str,
+    version: str,
+    manifest: dict[str, object] | None = None,
+) -> Path:
+    version_dir = tmp_path / ".agentm" / "catalog" / "atoms" / atom / version
+    version_dir.mkdir(parents=True)
+    payload = manifest or {"name": atom, "version": version}
+    (version_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(payload, sort_keys=True), encoding="utf-8"
+    )
+    runs_dir = version_dir / "runs"
+    runs_dir.mkdir()
+    _seed_current(version_dir.parent, version)
+    return version_dir
+
+
+@pytest.mark.asyncio
+async def test_M3_list_versions_includes_current_after_seed(tmp_path: Path) -> None:
+    _seed_atom(tmp_path, atom="tool_read", version="abc123def456")
+    session = await _session(tmp_path)
+
+    tool = next(tool for tool in session.tools if tool.name == "catalog_list_versions")
+    result = await tool.execute({"atom": "tool_read"})
+
+    assert not result.is_error
+    assert result.details == ["abc123def456"]
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_list_versions_unknown_atom_returns_empty_list(tmp_path: Path) -> None:
+    session = await _session(tmp_path)
+
+    tool = next(tool for tool in session.tools if tool.name == "catalog_list_versions")
+    result = await tool.execute({"atom": "missing_atom"})
+
+    assert not result.is_error
+    assert result.details == []
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_returns_yaml_content(tmp_path: Path) -> None:
+    manifest = {
+        "name": "tool_read",
+        "version": "abc123def456",
+        "author": "human",
+        "authored_at": "2026-05-01T00:00:00Z",
+    }
+    _seed_atom(
+        tmp_path,
+        atom="tool_read",
+        version="abc123def456",
+        manifest=manifest,
+    )
+    session = await _session(tmp_path)
+
+    tool = next(tool for tool in session.tools if tool.name == "catalog_get_manifest")
+    result = await tool.execute({"atom": "tool_read", "version": "abc123def456"})
+
+    assert not result.is_error
+    assert result.details == manifest
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_unknown_version_returns_error_result(tmp_path: Path) -> None:
+    session = await _session(tmp_path)
+
+    tool = next(tool for tool in session.tools if tool.name == "catalog_get_manifest")
+    result = await tool.execute({"atom": "tool_read", "version": "missing"})
+
+    assert result.is_error
+    assert "tool_read@missing" in result.content[0].text
+    await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runs_for_returns_trace_ids(tmp_path: Path) -> None:
+    version_dir = _seed_atom(tmp_path, atom="tool_read", version="abc123def456")
+    runs_dir = version_dir / "runs"
+    target_root = tmp_path / ".agentm" / "observability"
+    target_root.mkdir(parents=True)
+    for trace_id in ("trace-1", "trace-2"):
+        target = target_root / f"{trace_id}.jsonl"
+        target.write_text("{}\n", encoding="utf-8")
+        link = runs_dir / trace_id
+        try:
+            link.symlink_to(target)
+        except OSError:
+            link.write_text(str(target), encoding="utf-8")
+    session = await _session(tmp_path)
+
+    tool = next(tool for tool in session.tools if tool.name == "catalog_runs_for")
+    result = await tool.execute({"fingerprint": {"tool_read": "tool_read@abc123def456"}})
+
+    assert not result.is_error
+    assert result.details == ["trace-1", "trace-2"]
+    await session.shutdown()
+
+
+def test_atom_passes_section_11_validator() -> None:
+    issues = validate_builtin()
+
+    assert not [
+        issue for issue in issues if issue.module_path.endswith("tool_catalog")
+    ], issues
+
+
+def test_atom_imports_only_core_catalog_public_surface() -> None:
+    source_path = Path("src/agentm/extensions/builtin/tool_catalog.py")
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.startswith("agentm.core.catalog."):
+                violations.append(node.module)
+            if node.module in {
+                "agentm.core.catalog._layout",
+                "agentm.core.catalog.freeze",
+                "agentm.core.catalog.indexer",
+            }:
+                violations.append(node.module)
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("agentm.core.catalog."):
+                    violations.append(alias.name)
+    assert violations == []

--- a/tests/unit/extensions/loader/test_load_scenario.py
+++ b/tests/unit/extensions/loader/test_load_scenario.py
@@ -27,6 +27,7 @@ def test_load_scenario_resolves_builtin_name() -> None:
         ("agentm.extensions.builtin.tool_grep", {}),
         ("agentm.extensions.builtin.tool_find", {}),
         ("agentm.extensions.builtin.tool_ls", {}),
+        ("agentm.extensions.builtin.tool_catalog", {}),
         (
             "agentm.extensions.builtin.micro_compact",
             {"threshold_pct": 0.85, "keep_last": 8},


### PR DESCRIPTION
Fixes #40

## What changed
- add the tier-1 read-only `tool_catalog` atom with dedicated list/get/runs tools
- expose minimal public catalog browse helpers for the atom without private catalog imports
- wire `tool_catalog` into `general_purpose` and cover the new behavior with unit tests