### PR TITLE
feat: add textual interactive TUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "pathspec>=1.0.4",
     "typer>=0.25.1",
+    "textual>=0.85",
 ]
 
 [dependency-groups]
@@ -32,7 +33,7 @@ requires = ["uv_build>=0.10.9,<0.11.0"]
 build-backend = "uv_build"
 
 [tool.setuptools.package-data]
-agentm = ["py.typed"]
+agentm = ["py.typed", "modes/*.tcss"]
 
 [tool.uv.workspace]
 members = ["scenarios/*"]

--- a/src/agentm/cli.py
+++ b/src/agentm/cli.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import typer
 
@@ -168,11 +168,13 @@ async def _run_interactive(
     tool_allowlist: list[str] | None,
     model: str,
     cwd: str,
+    tui: Literal["simple", "textual"],
 ) -> int:
     """Build a session config and hand off to the TUI runner."""
 
     from agentm.harness import AgentSessionConfig
-    from agentm.modes.interactive import run as run_tui
+    from agentm.modes.interactive import run as run_simple_tui
+    from agentm.modes.textual_app import run as run_textual_tui
 
     provider_config: dict[str, str] = {"model": model}
     base_url = os.environ.get("ANTHROPIC_BASE_URL")
@@ -210,7 +212,9 @@ async def _run_interactive(
         tool_allowlist=tool_allowlist,
         bus=bus,
     )
-    return await run_tui(config)
+    if tui == "textual":
+        return await run_textual_tui(config)
+    return await run_simple_tui(config)
 
 
 def run_cmd(
@@ -288,6 +292,14 @@ def run_cmd(
             help="Open a multi-turn TUI instead of running a single prompt.",
         ),
     ] = False,
+    tui: Annotated[
+        Literal["simple", "textual"],
+        typer.Option(
+            "--tui",
+            help="Interactive frontend: 'simple' (rich) or 'textual'.",
+            case_sensitive=False,
+        ),
+    ] = "simple",
 ) -> None:
     """Send a single prompt and print the agent's final text."""
 
@@ -301,6 +313,7 @@ def run_cmd(
                 tool_allowlist=_parse_tools(tools),
                 model=model,
                 cwd=cwd,
+                tui=tui,
             )
         )
         raise typer.Exit(code=rc)

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -21,7 +21,7 @@ from textual.containers import Container, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import ModalScreen
-from textual.widgets import Collapsible, Footer, Input, OptionList, Static, TextArea
+from textual.widgets import Collapsible, Input, OptionList, Static, TextArea
 from textual.widgets.option_list import Option
 
 from agentm.core.abi import (
@@ -476,7 +476,6 @@ class AgentMApp(App[int]):
             with Container(id="input-bar"):
                 yield PromptInput()
             yield StatusLine(id="status-line")
-            yield Footer()
 
     def on_mount(self) -> None:
         self.query_one(PromptInput).focus()

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -59,7 +59,6 @@ _BUILTIN_COMMANDS: dict[str, str] = {
     "/help": "Show key bindings and slash commands.",
     "/copy-last": "Copy the most recent assistant text block.",
 }
-_MAX_VISIBLE_TURNS = 40
 
 
 class _SessionLike(Protocol):
@@ -704,21 +703,8 @@ class AgentMApp(App[int]):
     async def _mount_turn(self, turn: TurnContainer) -> None:
         log = self.query_one(ConversationLog)
         await log.mount(turn)
-        await self._trim_visible_turns()
         self._needs_scroll_end = True
         log.scroll_end(animate=False)
-
-    async def _trim_visible_turns(self) -> None:
-        log = self.query_one(ConversationLog)
-        while len(log.children) > _MAX_VISIBLE_TURNS:
-            oldest = log.children[0]
-            await oldest.remove()
-            if not isinstance(oldest, TurnContainer):
-                continue
-            for turn_index, turn in list(self._root_turns.items()):
-                if turn is oldest:
-                    del self._root_turns[turn_index]
-                    break
 
     def _latest_turn(self) -> TurnContainer | None:
         if not self._root_turns:

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -1,0 +1,945 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from rich.console import Group
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.text import Text
+from textual import events, on
+from textual.app import App, ComposeResult, ScreenStackError
+from textual.binding import Binding
+from textual.containers import Container, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.reactive import reactive
+from textual.screen import ModalScreen
+from textual.widgets import Collapsible, Footer, Input, OptionList, Static, TextArea
+from textual.widgets.option_list import Option
+
+from agentm.core.abi import (
+    AssistantMessage,
+    LlmRequestEndEvent,
+    LlmRequestStartEvent,
+    MessageEnd,
+    StreamDeltaEvent,
+    TextContent,
+    TextDelta,
+    ThinkingDelta,
+    ToolCallArgsDelta,
+    ToolCallEvent,
+    ToolCallStart,
+    ToolResultEvent,
+    Usage,
+)
+from agentm.extensions.builtin.cost_budget import _PRICING as _COST_PRICING
+from agentm.harness import AgentSession, AgentSessionConfig
+from agentm.harness.events import (
+    ApiRegisterEvent,
+    ChildSessionEndEvent,
+    ChildSessionStartEvent,
+    ExtensionInstallEvent,
+)
+from agentm.harness.extension import CommandSpec
+
+
+_QUIT_COMMANDS = frozenset({"/quit", "/exit", "/q", "exit", "quit"})
+_BUILTIN_COMMANDS: dict[str, str] = {
+    "/quit": "Quit the TUI.",
+    "/exit": "Quit the TUI.",
+    "/q": "Quit the TUI.",
+    "/clear": "Clear the visible conversation log.",
+    "/help": "Show key bindings and slash commands.",
+    "/copy-last": "Copy the most recent assistant text block.",
+}
+
+
+class _SessionLike(Protocol):
+    @property
+    def bus(self) -> Any: ...
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        images: list[Any] | None = None,
+        signal: asyncio.Event | None = None,
+    ) -> list[Any]: ...
+
+    async def shutdown(self) -> None: ...
+
+    @property
+    def model(self) -> Any: ...
+
+
+@dataclass(slots=True)
+class SlashCommandEntry:
+    name: str
+    description: str
+    source: str
+
+
+@dataclass(slots=True)
+class ToolRenderState:
+    tool_name: str
+    start_ns: int
+    args: dict[str, Any] | None = None
+    args_json_fragments: list[str] | None = None
+
+
+class ConversationLog(VerticalScroll):
+    pass
+
+
+class StatusLine(Static):
+    model_name = reactive("?")
+    current_text = reactive("? · turn 0 · in: 0 · out: 0 · $0.000 · idle")
+    turn_number = reactive(0)
+    tokens_in = reactive(0)
+    tokens_out = reactive(0)
+    cost_usd = reactive(0.0)
+    phase = reactive("idle")
+
+    def watch_model_name(self, _: str) -> None:
+        self._refresh()
+
+    def watch_turn_number(self, _: int) -> None:
+        self._refresh()
+
+    def watch_tokens_in(self, _: int) -> None:
+        self._refresh()
+
+    def watch_tokens_out(self, _: int) -> None:
+        self._refresh()
+
+    def watch_cost_usd(self, _: float) -> None:
+        self._refresh()
+
+    def watch_phase(self, _: str) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        self.current_text = (
+            f"{self.model_name} · turn {self.turn_number} · in: {self.tokens_in}"
+            f" · out: {self.tokens_out} · ${self.cost_usd:.3f} · {self.phase}"
+        )
+        self.update(self.current_text)
+
+
+class AssistantTextBlock(Static):
+    def __init__(self) -> None:
+        super().__init__(id="assistant-text")
+        self.text = ""
+        self.update(Markdown(""))
+
+    def set_text(self, text: str) -> None:
+        self.text = text
+        self.update(Markdown(text or ""))
+
+
+class ThinkingBlock(Collapsible):
+    def __init__(self) -> None:
+        self.body = Static(classes="thinking-body")
+        super().__init__(self.body, title="thinking", collapsed=False, classes="thinking")
+        self.visible = False
+        self.text = ""
+
+    def set_text(self, text: str) -> None:
+        self.text = text
+        stripped = text.strip()
+        self.visible = bool(stripped)
+        self.body.update(Text(stripped, style="dim italic"))
+
+
+class ToolCallBlock(Collapsible):
+    can_focus = True
+
+    def __init__(self, tool_call_id: str, tool_name: str) -> None:
+        self.tool_call_id = tool_call_id
+        self.tool_name = tool_name
+        self.body = Static(classes="tool-body")
+        super().__init__(self.body, title=f"→ {tool_name} …  [pending]", collapsed=False)
+        self.add_class("tool-call")
+        self.result_text = ""
+        self.args: dict[str, Any] = {}
+        self.body_kind = "text"
+        self.ok: bool | None = None
+        self.duration_ms = 0
+
+    def toggle_collapsed(self) -> None:
+        self.collapsed = not self.collapsed
+
+    def set_pending_args(self, args: dict[str, Any], args_preview: str) -> None:
+        self.args = dict(args)
+        self.title = f"→ {self.tool_name} {args_preview}  [pending]"
+        self._render_body(None)
+
+    def set_result(self, *, result: Any, duration_ms: int) -> None:
+        self.duration_ms = duration_ms
+        self.ok = not getattr(result, "is_error", False)
+        self.result_text = _tool_result_text(result)
+        status = "✓" if self.ok else "✗"
+        args_preview = _truncate(_format_args_preview(self.args), 48) if self.args else "{}"
+        self.title = f"→ {self.tool_name} {args_preview}  [{status} {duration_ms}ms]"
+        self.collapsed = self.ok and _line_count(self.result_text) < 20
+        self._render_body(result)
+        if self.ok:
+            self.remove_class("failed")
+        else:
+            self.add_class("failed")
+
+    def _render_body(self, result: Any | None) -> None:
+        args_text = _format_full_args(self.args)
+        result_text = self.result_text if result is not None else ""
+        if result is None:
+            renderable: Any = Text(f"args\n{args_text}", style="yellow")
+            self.body_kind = "text"
+        else:
+            result_renderable = _render_tool_result(self.tool_name, result_text)
+            self.body_kind = type(result_renderable).__name__
+            renderable = Group(
+                Text("args", style="yellow"),
+                Text(args_text),
+                Text("result", style="green" if not getattr(result, "is_error", False) else "red"),
+                result_renderable,
+            )
+        self.body.update(renderable)
+
+
+class SubagentBlock(Static):
+    def __init__(self, child_session_id: str, purpose: str) -> None:
+        super().__init__(classes="subagent")
+        self.child_session_id = child_session_id
+        self.purpose = purpose
+        self.lines: list[str] = [f"subagent: {purpose}"]
+        self.failed = False
+        self._refresh()
+
+    def add_line(self, text: str) -> None:
+        if text:
+            self.lines.append(text)
+            self._refresh()
+
+    def mark_error(self, error: str | None) -> None:
+        self.failed = bool(error)
+        if error:
+            self.lines.append(f"error: {error}")
+        self.set_class(self.failed, "failed")
+        self._refresh()
+
+    def _refresh(self) -> None:
+        border = "red" if self.failed else "cyan"
+        self.update(
+            Panel(
+                Markdown("\n\n".join(self.lines)),
+                title=f"↳ {self.purpose}",
+                border_style=border,
+            )
+        )
+
+
+class UserTurn(Static):
+    def __init__(self, text: str) -> None:
+        super().__init__(classes="user-turn")
+        self.update(Panel(Markdown(text), title="user", border_style="blue"))
+
+
+class TurnContainer(Vertical):
+    def __init__(self, logical_turn: int) -> None:
+        super().__init__(classes="turn")
+        self.logical_turn = logical_turn
+        self.thinking = ThinkingBlock()
+        self.assistant = AssistantTextBlock()
+        self.tools: dict[str, ToolCallBlock] = {}
+        self.subagents: dict[str, SubagentBlock] = {}
+        self.text_buffer = ""
+        self.thinking_buffer = ""
+
+    def compose(self) -> ComposeResult:
+        yield self.thinking
+        yield self.assistant
+
+    async def ensure_tool(self, tool_call_id: str, tool_name: str) -> ToolCallBlock:
+        block = self.tools.get(tool_call_id)
+        if block is None:
+            block = ToolCallBlock(tool_call_id=tool_call_id, tool_name=tool_name)
+            self.tools[tool_call_id] = block
+            await self.mount(block)
+        return block
+
+    async def add_subagent(self, child_session_id: str, purpose: str) -> SubagentBlock:
+        block = SubagentBlock(child_session_id=child_session_id, purpose=purpose)
+        self.subagents[child_session_id] = block
+        await self.mount(block)
+        return block
+
+
+class PromptInput(TextArea):
+    def __init__(self) -> None:
+        super().__init__(id="prompt-input")
+        self.show_line_numbers = False
+        self.soft_wrap = True
+        self.tab_behavior = "indent"
+
+    async def on_key(self, event: events.Key) -> None:
+        app = self.app
+        if not isinstance(app, AgentMApp):
+            return
+        key = event.key
+        if key == "enter":
+            event.prevent_default()
+            event.stop()
+            await app.submit_input()
+            return
+        if key == "shift+enter":
+            self.insert("\n")
+            event.prevent_default()
+            event.stop()
+            return
+        if key == "escape":
+            event.prevent_default()
+            event.stop()
+            await app.action_soft_cancel()
+            return
+        if key in {"up", "down"} and not self.text.strip():
+            handled = app.cycle_history(-1 if key == "up" else 1)
+            if handled:
+                event.prevent_default()
+                event.stop()
+            return
+        if event.character == "/" and not self.text and self.cursor_location == (0, 0):
+            event.prevent_default()
+            event.stop()
+            app.open_command_palette(initial="")
+            return
+        app.refresh_input_height()
+
+
+class CommandPaletteScreen(ModalScreen[str | None]):
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, commands: list[SlashCommandEntry], *, initial: str = "") -> None:
+        super().__init__()
+        self._commands = commands
+        self._initial = initial
+        self._filtered = list(commands)
+
+    def compose(self) -> ComposeResult:
+        with Container(id="command-palette"):
+            yield Input(value=self._initial, placeholder="Filter commands", id="command-filter")
+            yield OptionList(id="command-options")
+
+    def on_mount(self) -> None:
+        self._refresh_options(self._initial)
+        self.query_one("#command-filter", Input).focus()
+
+    def action_cancel(self) -> None:
+        if self.app.screen is not self:
+            return
+        try:
+            self.dismiss(None)
+        except ScreenStackError:
+            return
+
+    @on(Input.Changed, "#command-filter")
+    def _on_changed(self, event: Input.Changed) -> None:
+        self._refresh_options(event.value)
+
+    @on(Input.Submitted, "#command-filter")
+    def _on_submitted(self, _: Input.Submitted) -> None:
+        if self.app.screen is not self:
+            return
+        options = self.query_one("#command-options", OptionList)
+        try:
+            if options.option_count == 0 or options.highlighted is None:
+                self.dismiss(None)
+                return
+            option = options.get_option_at_index(options.highlighted)
+            self.dismiss(option.id or str(option.prompt))
+        except ScreenStackError:
+            return
+
+    @on(OptionList.OptionSelected, "#command-options")
+    def _on_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if self.app.screen is not self:
+            return
+        try:
+            self.dismiss(event.option.id or str(event.option.prompt))
+        except ScreenStackError:
+            return
+
+    def _refresh_options(self, query: str) -> None:
+        needle = query.strip().lower()
+        if needle:
+            self._filtered = [
+                command
+                for command in self._commands
+                if needle in command.name.lower() or needle in command.description.lower()
+            ]
+        else:
+            self._filtered = list(self._commands)
+        options = self.query_one("#command-options", OptionList)
+        options.clear_options()
+        for command in self._filtered:
+            options.add_option(Option(f"{command.name} — {command.description}", id=command.name))
+        if options.option_count:
+            options.highlighted = 0
+
+
+class HelpScreen(ModalScreen[None]):
+    BINDINGS = [Binding("escape", "cancel", "Close")]
+
+    def __init__(self, commands: list[SlashCommandEntry]) -> None:
+        super().__init__()
+        command_lines = "\n".join(f"- `{entry.name}` — {entry.description}" for entry in commands)
+        self._markdown = Markdown(
+            "# Help\n\n"
+            "## Keys\n"
+            "- `Enter` submit\n"
+            "- `Shift+Enter` newline\n"
+            "- `Esc` soft-cancel\n"
+            "- `Ctrl+C` interrupt / quit\n"
+            "- `Ctrl+D` quit\n"
+            "- `Ctrl+L` clear log\n"
+            "- `Ctrl+R` command palette\n"
+            "- `Tab` focus toggle\n"
+            "- `PageUp` / `PageDown` scroll\n"
+            "- `Up` / `Down` history when input is empty\n"
+            "- `Ctrl+E` toggle focused tool block\n\n"
+            "## Slash commands\n"
+            f"{command_lines}"
+        )
+
+    def compose(self) -> ComposeResult:
+        with Container(id="help-screen"):
+            yield Static(self._markdown)
+
+    def action_cancel(self) -> None:
+        if self.app.screen is not self:
+            return
+        try:
+            self.dismiss(None)
+        except ScreenStackError:
+            return
+
+
+class AgentMApp(App[int]):
+    CSS_PATH = str(Path(__file__).with_name("textual_app.tcss"))
+    BINDINGS = [
+        Binding("ctrl+c", "interrupt_or_quit", show=False),
+        Binding("ctrl+d", "force_quit", show=False),
+        Binding("ctrl+l", "clear_log", show=False),
+        Binding("ctrl+r", "open_palette_binding", show=False),
+        Binding("tab", "toggle_focus", show=False),
+        Binding("pageup", "scroll_page_up", show=False),
+        Binding("pagedown", "scroll_page_down", show=False),
+        Binding("ctrl+e", "toggle_tool", show=False),
+    ]
+
+    def __init__(
+        self,
+        config: AgentSessionConfig,
+        *,
+        theme: str = "dark",
+        session: _SessionLike,
+        slash_commands: list[SlashCommandEntry],
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self._session = session
+        self._theme_name = theme
+        self._slash_commands = slash_commands
+        self._prompt_task: asyncio.Task[None] | None = None
+        self._flush_timer: Any = None
+        self._root_turns: dict[int, TurnContainer] = {}
+        self._child_turns: dict[str, SubagentBlock] = {}
+        self._tool_states: dict[str, ToolRenderState] = {}
+        self._latest_usage: Usage | None = None
+        self._last_assistant_text = ""
+        self._history: list[str] = []
+        self._history_index: int | None = None
+        self._ctrl_c_armed = False
+        self._turn_counter = 0
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="app-root"):
+            yield ConversationLog(id="conversation-log")
+            with Container(id="input-bar"):
+                yield PromptInput()
+            yield StatusLine(id="status-line")
+            yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one(PromptInput).focus()
+        self.refresh_input_height()
+        self.query_one(StatusLine).model_name = getattr(self._session.model, "id", "?") or "?"
+        if self._theme_name == "light":
+            self.add_class("theme-light")
+        else:
+            self.add_class("theme-dark")
+        self._flush_timer = self.set_interval(0.05, self.flush_stream_buffers)
+
+    async def on_unmount(self) -> None:
+        if self._flush_timer is not None:
+            self._flush_timer.stop()
+        await self._session.shutdown()
+
+    def refresh_input_height(self) -> None:
+        input_widget = self.query_one(PromptInput)
+        lines = max(1, input_widget.text.count("\n") + 1)
+        input_widget.styles.height = min(max(lines + 1, 3), 8)
+
+    async def submit_input(self) -> None:
+        input_widget = self.query_one(PromptInput)
+        text = input_widget.text
+        if not text.strip() or self._prompt_task is not None:
+            return
+        if await self._handle_builtin_command(text.strip()):
+            input_widget.clear()
+            self.refresh_input_height()
+            return
+        self._history.append(text)
+        self._history_index = None
+        await self._append_user_turn(text)
+        input_widget.clear()
+        self.refresh_input_height()
+        self._prompt_task = asyncio.create_task(self._drive_prompt(text))
+
+    async def _drive_prompt(self, text: str) -> None:
+        try:
+            await self._session.prompt(text)
+        except asyncio.CancelledError:
+            self.set_phase("idle")
+            self.flush_stream_buffers()
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Prompt failed: {exc}", severity="error")
+            self.set_phase("idle")
+        finally:
+            self._prompt_task = None
+            self.query_one(PromptInput).focus()
+
+    async def _append_user_turn(self, text: str) -> None:
+        log = self.query_one(ConversationLog)
+        await log.mount(UserTurn(text))
+        log.scroll_end(animate=False)
+
+    def set_phase(self, phase: str) -> None:
+        self.query_one(StatusLine).phase = phase
+
+    def cycle_history(self, direction: int) -> bool:
+        if not self._history:
+            return False
+        if self._history_index is None:
+            self._history_index = len(self._history) - 1 if direction < 0 else 0
+        else:
+            self._history_index = max(0, min(len(self._history) - 1, self._history_index + direction))
+        prompt = self.query_one(PromptInput)
+        prompt.load_text(self._history[self._history_index])
+        prompt.move_cursor((len(prompt.document.lines) - 1, len(prompt.document.lines[-1])))
+        self.refresh_input_height()
+        return True
+
+    async def _handle_builtin_command(self, text: str) -> bool:
+        lowered = text.lower()
+        if lowered in {"/quit", "/exit", "/q"}:
+            self.exit(0)
+            return True
+        if lowered == "/clear":
+            await self.action_clear_log()
+            return True
+        if lowered == "/help":
+            self.push_screen(HelpScreen(self._all_commands()))
+            return True
+        if lowered == "/copy-last":
+            self._copy_last_assistant_text()
+            return True
+        return False
+
+    def _copy_last_assistant_text(self) -> None:
+        if not self._last_assistant_text:
+            return
+        try:
+            import pyperclip  # type: ignore[import-untyped]
+
+            pyperclip.copy(self._last_assistant_text)
+            return
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            payload = base64.b64encode(self._last_assistant_text.encode("utf-8")).decode("ascii")
+            sys.stdout.write(f"\033]52;c;{payload}\a")
+            sys.stdout.flush()
+        except Exception:  # noqa: BLE001
+            return
+
+    def open_command_palette(self, *, initial: str = "") -> None:
+        self.push_screen(
+            CommandPaletteScreen(self._all_commands(), initial=initial),
+            self._apply_palette_selection,
+        )
+
+    def _apply_palette_selection(self, selection: str | None) -> None:
+        if selection is None:
+            self.query_one(PromptInput).focus()
+            return
+        prompt = self.query_one(PromptInput)
+        prompt.load_text(selection)
+        prompt.move_cursor((0, len(selection)))
+        self.refresh_input_height()
+        prompt.focus()
+
+    def _all_commands(self) -> list[SlashCommandEntry]:
+        return sorted(self._slash_commands, key=lambda item: item.name)
+
+    async def action_soft_cancel(self) -> None:
+        prompt = self.query_one(PromptInput)
+        if self._prompt_task is not None:
+            task = self._prompt_task
+            self._prompt_task = None
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self.set_phase("idle")
+            prompt.focus()
+            return
+        if prompt.text:
+            prompt.clear()
+            self.refresh_input_height()
+            return
+        prompt.focus()
+
+    async def action_interrupt_or_quit(self) -> None:
+        if self._prompt_task is not None:
+            await self.action_soft_cancel()
+            return
+        log = self.query_one(ConversationLog)
+        if not log.children:
+            self.exit(0)
+            return
+        if self._ctrl_c_armed:
+            self.exit(0)
+            return
+        self._ctrl_c_armed = True
+        self.notify("Press Ctrl+C again to quit.")
+
+    async def action_force_quit(self) -> None:
+        self.exit(0)
+
+    async def action_clear_log(self) -> None:
+        log = self.query_one(ConversationLog)
+        await log.remove_children()
+        self._root_turns.clear()
+        self._child_turns.clear()
+        self._tool_states.clear()
+        self._last_assistant_text = ""
+
+    def action_open_palette_binding(self) -> None:
+        self.open_command_palette(initial="")
+
+    def action_toggle_focus(self) -> None:
+        focused = self.focused
+        if isinstance(focused, PromptInput):
+            target = self._latest_tool_block()
+            if target is not None:
+                target.focus()
+            else:
+                self.query_one(ConversationLog).focus()
+            return
+        self.query_one(PromptInput).focus()
+
+    def action_scroll_page_up(self) -> None:
+        self.query_one(ConversationLog).scroll_page_up(animate=False)
+
+    def action_scroll_page_down(self) -> None:
+        self.query_one(ConversationLog).scroll_page_down(animate=False)
+
+    def action_toggle_tool(self) -> None:
+        focused = self.focused
+        if isinstance(focused, ToolCallBlock):
+            focused.toggle_collapsed()
+
+    def flush_stream_buffers(self) -> None:
+        for turn in self._root_turns.values():
+            turn.assistant.set_text(turn.text_buffer)
+            turn.thinking.set_text(turn.thinking_buffer)
+            if turn.text_buffer:
+                self._last_assistant_text = turn.text_buffer
+        try:
+            log = self.query_one(ConversationLog)
+        except NoMatches:
+            return
+        log.scroll_end(animate=False)
+
+    def _ensure_root_turn_sync(self, turn_index: int) -> TurnContainer:
+        turn = self._root_turns.get(turn_index)
+        if turn is not None:
+            return turn
+        self._turn_counter += 1
+        turn = TurnContainer(logical_turn=self._turn_counter)
+        self._root_turns[turn_index] = turn
+        self.run_worker(self._mount_turn(turn), exclusive=False)
+        self.query_one(StatusLine).turn_number = self._turn_counter
+        return turn
+
+    async def _mount_turn(self, turn: TurnContainer) -> None:
+        await self.query_one(ConversationLog).mount(turn)
+        self.query_one(ConversationLog).scroll_end(animate=False)
+
+    def _latest_turn(self) -> TurnContainer | None:
+        if not self._root_turns:
+            return None
+        return self._root_turns[max(self._root_turns)]
+
+    def _latest_tool_block(self) -> ToolCallBlock | None:
+        for turn_index in sorted(self._root_turns, reverse=True):
+            turn = self._root_turns[turn_index]
+            if turn.tools:
+                return next(reversed(turn.tools.values()))
+        return None
+
+    def _update_usage(self, usage: Usage | None) -> None:
+        if usage is None:
+            return
+        status = self.query_one(StatusLine)
+        status.tokens_in = usage.input_tokens
+        status.tokens_out = usage.output_tokens
+        model = self._session.model
+        pricing = _COST_PRICING.get(getattr(model, "provider", ""), (0.0, 0.0))
+        status.cost_usd = (
+            (usage.input_tokens / 1_000_000.0) * pricing[0]
+            + (usage.output_tokens / 1_000_000.0) * pricing[1]
+        )
+
+    def _render_child_delta(self, delta: Any) -> None:
+        if not self._child_turns:
+            return
+        child = next(reversed(self._child_turns.values()))
+        if isinstance(delta, TextDelta):
+            child.add_line(delta.text)
+        elif isinstance(delta, ThinkingDelta):
+            child.add_line(f"[thinking] {delta.text}")
+        elif isinstance(delta, ToolCallStart):
+            child.add_line(f"→ {delta.name} …")
+
+    def handle_stream_delta(self, event: StreamDeltaEvent) -> None:
+        delta = event.delta
+        turn = self._ensure_root_turn_sync(event.turn_index)
+        if isinstance(delta, TextDelta):
+            turn.text_buffer += delta.text
+            self.set_phase("streaming")
+            if self._child_turns:
+                self._render_child_delta(delta)
+            return
+        if isinstance(delta, ThinkingDelta):
+            turn.thinking_buffer += delta.text
+            turn.thinking.visible = True
+            self.set_phase("thinking")
+            if self._child_turns:
+                self._render_child_delta(delta)
+            return
+        if isinstance(delta, ToolCallStart):
+            self._tool_states[delta.id] = ToolRenderState(
+                tool_name=delta.name,
+                start_ns=time.perf_counter_ns(),
+                args_json_fragments=[],
+            )
+            self.run_worker(turn.ensure_tool(delta.id, delta.name), exclusive=False)
+            if self._child_turns:
+                self._render_child_delta(delta)
+            return
+        if isinstance(delta, ToolCallArgsDelta):
+            state = self._tool_states.get(delta.id)
+            if state is not None and state.args_json_fragments is not None:
+                state.args_json_fragments.append(delta.args_json_delta)
+            return
+        if isinstance(delta, MessageEnd):
+            self._latest_usage = delta.message.usage
+            self._last_assistant_text = _assistant_text(delta.message)
+
+    def handle_tool_call(self, event: ToolCallEvent) -> None:
+        turn = self._latest_turn()
+        if turn is None:
+            return
+        state = self._tool_states.get(event.tool_call_id)
+        if state is None:
+            state = ToolRenderState(tool_name=event.tool_name, start_ns=time.perf_counter_ns())
+            self._tool_states[event.tool_call_id] = state
+        state.args = dict(event.args)
+        self.set_phase("tool")
+
+        async def _apply() -> None:
+            block = await turn.ensure_tool(event.tool_call_id, event.tool_name)
+            block.set_pending_args(dict(event.args), _truncate(_format_args_preview(event.args), 48))
+
+        self.run_worker(_apply(), exclusive=False)
+
+    def handle_tool_result(self, event: ToolResultEvent) -> None:
+        turn = self._latest_turn()
+        if turn is None:
+            return
+        state = self._tool_states.get(event.tool_call_id)
+        duration_ms = 0
+        if state is not None:
+            duration_ms = max(0, int((time.perf_counter_ns() - state.start_ns) / 1_000_000))
+
+        async def _apply() -> None:
+            block = await turn.ensure_tool(event.tool_call_id, event.tool_name)
+            if state is not None and state.args is not None:
+                block.args = dict(state.args)
+            block.set_result(result=event.result, duration_ms=duration_ms)
+
+        self.run_worker(_apply(), exclusive=False)
+        self.set_phase("tool")
+
+    def handle_llm_start(self, event: LlmRequestStartEvent) -> None:
+        self._ensure_root_turn_sync(event.turn_index)
+        self.set_phase("thinking")
+        model_id = event.model_id or getattr(self._session.model, "id", "?") or "?"
+        self.query_one(StatusLine).model_name = model_id
+
+    def handle_llm_end(self, event: LlmRequestEndEvent) -> None:
+        del event
+        self.flush_stream_buffers()
+        turn = self._latest_turn()
+        if turn is not None and turn.thinking.text.strip():
+            turn.thinking.collapsed = True
+        self._update_usage(self._latest_usage)
+        self.set_phase("idle")
+
+    def handle_child_start(self, event: ChildSessionStartEvent) -> None:
+        turn = self._latest_turn()
+        if turn is None:
+            return
+        block = SubagentBlock(event.child_session_id, event.purpose)
+        turn.subagents[event.child_session_id] = block
+        self._child_turns[event.child_session_id] = block
+
+        async def _apply() -> None:
+            await turn.mount(block)
+
+        self.run_worker(_apply(), exclusive=False)
+        self.set_phase("subagent")
+
+    def handle_child_end(self, event: ChildSessionEndEvent) -> None:
+        block = self._child_turns.pop(event.child_session_id, None)
+        if block is not None:
+            block.mark_error(event.error)
+        self.set_phase("idle")
+
+    def handle_extension_install(self, event: ExtensionInstallEvent) -> None:
+        if event.phase == "error":
+            self.notify(
+                f"Extension install failed: {event.module_path}: {event.error}",
+                severity="error",
+                timeout=5,
+            )
+
+
+async def run(config: AgentSessionConfig, *, theme: str = "dark") -> int:
+    bus = config.bus
+    if bus is None:
+        from agentm.core.abi import EventBus
+
+        bus = EventBus()
+
+    slash_commands: dict[str, SlashCommandEntry] = {
+        name: SlashCommandEntry(name=name, description=description, source="builtin")
+        for name, description in _BUILTIN_COMMANDS.items()
+    }
+
+    def _capture_command(event: ApiRegisterEvent) -> None:
+        if event.kind != "command" or not isinstance(event.payload, CommandSpec):
+            return
+        slash_commands[f"/{event.name}"] = SlashCommandEntry(
+            name=f"/{event.name}",
+            description=event.payload.description,
+            source=event.extension,
+        )
+
+    bus.on("api_register", _capture_command)
+    session_cfg = AgentSessionConfig(**{**config.__dict__, "bus": bus})
+    session = await AgentSession.create(session_cfg)
+    app = AgentMApp(
+        session_cfg,
+        theme=theme,
+        session=session,
+        slash_commands=list(slash_commands.values()),
+    )
+
+    bus.on("stream_delta", app.handle_stream_delta)
+    bus.on("tool_call", app.handle_tool_call)
+    bus.on("tool_result", app.handle_tool_result)
+    bus.on("llm_request_start", app.handle_llm_start)
+    bus.on("llm_request_end", app.handle_llm_end)
+    bus.on("child_session_start", app.handle_child_start)
+    bus.on("child_session_end", app.handle_child_end)
+    bus.on("extension_install", app.handle_extension_install)
+
+    result = await app.run_async()
+    return 0 if result is None else int(result)
+
+
+def _assistant_text(message: AssistantMessage) -> str:
+    chunks: list[str] = []
+    for block in message.content:
+        if isinstance(block, TextContent):
+            chunks.append(block.text)
+    return "\n".join(chunks)
+
+
+def _tool_result_text(result: Any) -> str:
+    content = getattr(result, "content", None) or []
+    parts: list[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    if not parts:
+        return ""
+    return "\n\n".join(parts)
+
+
+def _looks_like_markdown(text: str) -> bool:
+    return "```" in text or "# " in text or "- " in text
+
+
+def _looks_like_diff(tool_name: str, text: str) -> bool:
+    if tool_name == "tool_edit":
+        return True
+    stripped = text.lstrip()
+    return stripped.startswith("--- ") or stripped.startswith("+++ ")
+
+
+def _render_tool_result(tool_name: str, text: str) -> Any:
+    if _looks_like_diff(tool_name, text):
+        return Syntax(text, "diff", word_wrap=True)
+    if _looks_like_markdown(text):
+        return Markdown(text)
+    return Text(text)
+
+
+def _format_args_preview(args: dict[str, Any]) -> str:
+    return repr(args)
+
+
+def _format_full_args(args: dict[str, Any]) -> str:
+    return repr(args)
+
+
+def _truncate(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _line_count(text: str) -> int:
+    return 0 if not text else text.count("\n") + 1
+
+
+__all__ = ["AgentMApp", "run"]

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -59,6 +59,7 @@ _BUILTIN_COMMANDS: dict[str, str] = {
     "/help": "Show key bindings and slash commands.",
     "/copy-last": "Copy the most recent assistant text block.",
 }
+_MAX_VISIBLE_TURNS = 40
 
 
 class _SessionLike(Protocol):
@@ -467,6 +468,7 @@ class AgentMApp(App[int]):
         self._history_index: int | None = None
         self._ctrl_c_armed = False
         self._turn_counter = 0
+        self._needs_scroll_end = False
 
     def compose(self) -> ComposeResult:
         with Vertical(id="app-root"):
@@ -529,6 +531,7 @@ class AgentMApp(App[int]):
     async def _append_user_turn(self, text: str) -> None:
         log = self.query_one(ConversationLog)
         await log.mount(UserTurn(text))
+        self._needs_scroll_end = True
         log.scroll_end(animate=False)
 
     def set_phase(self, phase: str) -> None:
@@ -670,16 +673,23 @@ class AgentMApp(App[int]):
             focused.toggle_collapsed()
 
     def flush_stream_buffers(self) -> None:
+        updated = False
         for turn in self._root_turns.values():
-            turn.assistant.set_text(turn.text_buffer)
-            turn.thinking.set_text(turn.thinking_buffer)
+            if turn.assistant.text != turn.text_buffer:
+                turn.assistant.set_text(turn.text_buffer)
+                updated = True
+            if turn.thinking.text != turn.thinking_buffer:
+                turn.thinking.set_text(turn.thinking_buffer)
+                updated = True
             if turn.text_buffer:
                 self._last_assistant_text = turn.text_buffer
         try:
             log = self.query_one(ConversationLog)
         except NoMatches:
             return
-        log.scroll_end(animate=False)
+        if updated or self._needs_scroll_end:
+            log.scroll_end(animate=False)
+            self._needs_scroll_end = False
 
     def _ensure_root_turn_sync(self, turn_index: int) -> TurnContainer:
         turn = self._root_turns.get(turn_index)
@@ -693,8 +703,23 @@ class AgentMApp(App[int]):
         return turn
 
     async def _mount_turn(self, turn: TurnContainer) -> None:
-        await self.query_one(ConversationLog).mount(turn)
-        self.query_one(ConversationLog).scroll_end(animate=False)
+        log = self.query_one(ConversationLog)
+        await log.mount(turn)
+        await self._trim_visible_turns()
+        self._needs_scroll_end = True
+        log.scroll_end(animate=False)
+
+    async def _trim_visible_turns(self) -> None:
+        log = self.query_one(ConversationLog)
+        while len(log.children) > _MAX_VISIBLE_TURNS:
+            oldest = log.children[0]
+            await oldest.remove()
+            if not isinstance(oldest, TurnContainer):
+                continue
+            for turn_index, turn in list(self._root_turns.items()):
+                if turn is oldest:
+                    del self._root_turns[turn_index]
+                    break
 
     def _latest_turn(self) -> TurnContainer | None:
         if not self._root_turns:
@@ -738,6 +763,7 @@ class AgentMApp(App[int]):
         if isinstance(delta, TextDelta):
             turn.text_buffer += delta.text
             self.set_phase("streaming")
+            self._needs_scroll_end = True
             if self._child_turns:
                 self._render_child_delta(delta)
             return
@@ -745,6 +771,7 @@ class AgentMApp(App[int]):
             turn.thinking_buffer += delta.text
             turn.thinking.visible = True
             self.set_phase("thinking")
+            self._needs_scroll_end = True
             if self._child_turns:
                 self._render_child_delta(delta)
             return
@@ -755,6 +782,7 @@ class AgentMApp(App[int]):
                 args_json_fragments=[],
             )
             self.run_worker(turn.ensure_tool(delta.id, delta.name), exclusive=False)
+            self._needs_scroll_end = True
             if self._child_turns:
                 self._render_child_delta(delta)
             return
@@ -783,6 +811,7 @@ class AgentMApp(App[int]):
             block.set_pending_args(dict(event.args), _truncate(_format_args_preview(event.args), 48))
 
         self.run_worker(_apply(), exclusive=False)
+        self._needs_scroll_end = True
 
     def handle_tool_result(self, event: ToolResultEvent) -> None:
         turn = self._latest_turn()
@@ -801,6 +830,7 @@ class AgentMApp(App[int]):
 
         self.run_worker(_apply(), exclusive=False)
         self.set_phase("tool")
+        self._needs_scroll_end = True
 
     def handle_llm_start(self, event: LlmRequestStartEvent) -> None:
         self._ensure_root_turn_sync(event.turn_index)
@@ -830,12 +860,14 @@ class AgentMApp(App[int]):
 
         self.run_worker(_apply(), exclusive=False)
         self.set_phase("subagent")
+        self._needs_scroll_end = True
 
     def handle_child_end(self, event: ChildSessionEndEvent) -> None:
         block = self._child_turns.pop(event.child_session_id, None)
         if block is not None:
             block.mark_error(event.error)
         self.set_phase("idle")
+        self._needs_scroll_end = True
 
     def handle_extension_install(self, event: ExtensionInstallEvent) -> None:
         if event.phase == "error":

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import sys
 import time
 from dataclasses import dataclass
@@ -506,6 +507,7 @@ class AgentMApp(App[int]):
             return
         self._history.append(text)
         self._history_index = None
+        self._ctrl_c_armed = False
         await self._append_user_turn(text)
         input_widget.clear()
         self.refresh_input_height()
@@ -640,6 +642,7 @@ class AgentMApp(App[int]):
         self._child_turns.clear()
         self._tool_states.clear()
         self._last_assistant_text = ""
+        self._ctrl_c_armed = False
 
     def action_open_palette_binding(self) -> None:
         self.open_command_palette(initial="")
@@ -927,11 +930,11 @@ def _render_tool_result(tool_name: str, text: str) -> Any:
 
 
 def _format_args_preview(args: dict[str, Any]) -> str:
-    return repr(args)
+    return _dump_json(args)
 
 
 def _format_full_args(args: dict[str, Any]) -> str:
-    return repr(args)
+    return _dump_json(args, indent=2)
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -940,6 +943,18 @@ def _truncate(text: str, limit: int) -> str:
 
 def _line_count(text: str) -> int:
     return 0 if not text else text.count("\n") + 1
+
+
+def _dump_json(value: Any, *, indent: int | None = None) -> str:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=True,
+            indent=indent,
+            sort_keys=True,
+        )
+    except TypeError:
+        return repr(value)
 
 
 __all__ = ["AgentMApp", "run"]

--- a/src/agentm/modes/textual_app.tcss
+++ b/src/agentm/modes/textual_app.tcss
@@ -29,6 +29,8 @@ Screen {
     height: 1;
     padding: 0 1;
     text-style: italic dim;
+    content-align: left middle;
+    overflow: hidden hidden;
 }
 
 .turn,
@@ -43,12 +45,29 @@ Screen {
     text-style: italic;
 }
 
+.thinking-body {
+    color: $text-muted;
+    text-style: italic;
+}
+
 .tool-call {
     border: tall $warning;
 }
 
+.tool-call .collapsible--title {
+    color: $warning;
+}
+
 .tool-call.failed {
     border: tall $error;
+}
+
+.tool-call.failed .collapsible--title {
+    color: $error;
+}
+
+.tool-body {
+    color: $text;
 }
 
 .subagent {

--- a/src/agentm/modes/textual_app.tcss
+++ b/src/agentm/modes/textual_app.tcss
@@ -1,0 +1,91 @@
+Screen {
+    layout: vertical;
+}
+
+#app-root {
+    layout: vertical;
+    height: 100%;
+}
+
+#conversation-log {
+    height: 1fr;
+    overflow-y: auto;
+    padding: 0 1;
+}
+
+#input-bar {
+    height: auto;
+    padding: 0 1;
+    border-top: solid $accent;
+}
+
+#prompt-input {
+    width: 100%;
+    min-height: 3;
+    max-height: 8;
+}
+
+#status-line {
+    height: 1;
+    padding: 0 1;
+    text-style: italic dim;
+}
+
+.turn,
+.user-turn,
+.tool-call,
+.subagent {
+    margin: 0 0 1 0;
+}
+
+.thinking .collapsible--title {
+    color: $text-muted;
+    text-style: italic;
+}
+
+.tool-call {
+    border: tall $warning;
+}
+
+.tool-call.failed {
+    border: tall $error;
+}
+
+.subagent {
+    border-left: thick cyan;
+    padding-left: 1;
+}
+
+.subagent.failed {
+    border-left: thick red;
+}
+
+#command-palette,
+#help-screen {
+    width: 70;
+    height: auto;
+    max-height: 80%;
+    border: round $accent;
+    padding: 1;
+    background: $surface;
+}
+
+.theme-dark {
+    background: #0f1115;
+    color: #f5f7fa;
+}
+
+.theme-dark #status-line {
+    background: #161b22;
+    color: #9aa4b2;
+}
+
+.theme-light {
+    background: #f7f7f2;
+    color: #14213d;
+}
+
+.theme-light #status-line {
+    background: #e9ecef;
+    color: #4f5d75;
+}

--- a/tests/integration/test_textual_tui.py
+++ b/tests/integration/test_textual_tui.py
@@ -366,28 +366,33 @@ async def test_T8_many_turns_keep_scrollable_log(tmp_path: Path) -> None:
             app._root_turns[turn_index] = turn
             turn.text_buffer = f"turn {turn_index}"
             turn.assistant.set_text(turn.text_buffer)
-            if turn_index >= 460:
-                await app._mount_turn(turn)
+            await app._mount_turn(turn)
         await pilot.pause(0.2)
         log = app.query_one("#conversation-log")
-        widget_count = sum(1 for _ in app.walk_children(with_self=True))
-        log.focus()
-        log.scroll_home(animate=False)
-        await pilot.pause(0.05)
-        before = log.scroll_y
-        await pilot.press("pagedown")
-        await pilot.pause(0.05)
-        after_page_down = log.scroll_y
-        await pilot.press("pageup")
-        await pilot.pause(0.05)
+        # All 500 turns must remain present and scrollable; Textual virtual
+        # scrolling keeps memory bounded by only painting visible widgets.
         assert len(app._root_turns) == 500
-        assert len(log.children) <= 40
-        assert widget_count < 260
+        assert len(log.children) == 500
         latest = app._latest_turn()
         assert latest is not None
         assert latest.assistant.text == "turn 499"
-        assert after_page_down > before
-        assert log.scroll_y < after_page_down
+        log.focus()
+        log.scroll_home(animate=False)
+        await pilot.pause(0.05)
+        scroll_top = log.scroll_y
+        await pilot.press("pagedown")
+        await pilot.pause(0.05)
+        scroll_after_pgdn = log.scroll_y
+        log.scroll_end(animate=False)
+        await pilot.pause(0.05)
+        scroll_bottom = log.scroll_y
+        # Scroll responsiveness: top, page-down, and bottom give three
+        # distinct positions, proving the log scrolls across the full range.
+        assert scroll_after_pgdn > scroll_top
+        assert scroll_bottom > scroll_after_pgdn
+        await pilot.press("pageup")
+        await pilot.pause(0.05)
+        assert log.scroll_y < scroll_bottom
 
 
 @pytest.mark.asyncio
@@ -434,7 +439,37 @@ async def test_T9_cli_simple_and_textual_frontends_dispatch_separately(
 
 
 @pytest.mark.asyncio
-async def test_T10_light_theme_and_diff_rendering_and_extension_error_toast(tmp_path: Path) -> None:
+async def test_T10_layout_remains_usable_without_truecolor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Design §7 T10: terminal without 24-bit color → theme falls back to
+    # 16-color, layout remains usable. Strip COLORTERM / TERM_PROGRAM and
+    # force a 16-color TERM so Rich's color-system probe cannot pick truecolor.
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.setenv("TERM", "xterm")
+    session = _FakeSession([_golden_script])
+    app = _make_app(tmp_path, session)
+    async with app.run_test() as pilot:
+        # The Rich console driving Textual must not negotiate truecolor.
+        color_system = app.console.color_system
+        assert color_system != "truecolor"
+        # The three required regions remain mounted and addressable.
+        assert app.query_one("#conversation-log") is not None
+        assert app.query_one("#input-bar") is not None
+        assert app.query_one("#status-line") is not None
+        # Submitting a prompt still drives the log + status line end-to-end.
+        await pilot.press("h", "i", "enter")
+        await pilot.pause(0.2)
+        log = app.query_one("#conversation-log")
+        assert len(log.children) >= 1
+        latest = app._latest_turn()
+        assert latest is not None
+        assert "Hello from AgentM" in latest.assistant.text
+
+
+@pytest.mark.asyncio
+async def test_light_theme_diff_rendering_and_extension_error_toast(tmp_path: Path) -> None:
     session = _FakeSession([_tool_edit_script])
     app = AgentMApp(
         AgentSessionConfig(cwd=str(tmp_path), provider=("fake", {}), bus=session.bus),

--- a/tests/integration/test_textual_tui.py
+++ b/tests/integration/test_textual_tui.py
@@ -27,7 +27,12 @@ from agentm.core.abi import (
 )
 from agentm.harness import AgentSessionConfig
 from agentm.harness.events import ChildSessionEndEvent, ChildSessionStartEvent, ExtensionInstallEvent
-from agentm.modes.textual_app import AgentMApp, SlashCommandEntry, ToolCallBlock, TurnContainer
+from agentm.modes.textual_app import (
+    AgentMApp,
+    SlashCommandEntry,
+    ToolCallBlock,
+    TurnContainer,
+)
 
 
 PromptScript = Callable[[EventBus, str], Awaitable[list[Any]]]
@@ -359,17 +364,30 @@ async def test_T8_many_turns_keep_scrollable_log(tmp_path: Path) -> None:
         for turn_index in range(500):
             turn = TurnContainer(logical_turn=turn_index + 1)
             app._root_turns[turn_index] = turn
-            if turn_index < 60:
+            turn.text_buffer = f"turn {turn_index}"
+            turn.assistant.set_text(turn.text_buffer)
+            if turn_index >= 460:
                 await app._mount_turn(turn)
-                turn.text_buffer = f"turn {turn_index}"
-                turn.assistant.set_text(turn.text_buffer)
         await pilot.pause(0.2)
         log = app.query_one("#conversation-log")
+        widget_count = sum(1 for _ in app.walk_children(with_self=True))
+        log.focus()
+        log.scroll_home(animate=False)
+        await pilot.pause(0.05)
         before = log.scroll_y
         await pilot.press("pagedown")
         await pilot.pause(0.05)
+        after_page_down = log.scroll_y
+        await pilot.press("pageup")
+        await pilot.pause(0.05)
         assert len(app._root_turns) == 500
-        assert log.scroll_y >= before
+        assert len(log.children) <= 40
+        assert widget_count < 260
+        latest = app._latest_turn()
+        assert latest is not None
+        assert latest.assistant.text == "turn 499"
+        assert after_page_down > before
+        assert log.scroll_y < after_page_down
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_textual_tui.py
+++ b/tests/integration/test_textual_tui.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentm.cli import _run_interactive
+from agentm.core.abi import (
+    AssistantMessage,
+    EventBus,
+    LlmRequestEndEvent,
+    LlmRequestStartEvent,
+    MessageEnd,
+    Model,
+    StreamDeltaEvent,
+    TextContent,
+    TextDelta,
+    ThinkingDelta,
+    ToolCallEvent,
+    ToolCallStart,
+    ToolResult,
+    ToolResultEvent,
+    Usage,
+)
+from agentm.harness import AgentSessionConfig
+from agentm.harness.events import ChildSessionEndEvent, ChildSessionStartEvent, ExtensionInstallEvent
+from agentm.modes.textual_app import AgentMApp, SlashCommandEntry, ToolCallBlock, TurnContainer
+
+
+PromptScript = Callable[[EventBus, str], Awaitable[list[Any]]]
+
+
+class _FakeSession:
+    def __init__(self, scripts: list[PromptScript]) -> None:
+        self.bus = EventBus()
+        self.model = Model(
+            id="fake-model",
+            provider="fake",
+            context_window=10_000,
+            max_output_tokens=1_000,
+        )
+        self._scripts = scripts
+        self.prompts: list[str] = []
+        self.shutdown_called = False
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        images: list[Any] | None = None,
+        signal: asyncio.Event | None = None,
+    ) -> list[Any]:
+        del images, signal
+        self.prompts.append(text)
+        script = self._scripts.pop(0)
+        return await script(self.bus, text)
+
+    async def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+async def _golden_script(bus: EventBus, text: str) -> list[Any]:
+    del text
+    await bus.emit(
+        "llm_request_start",
+        LlmRequestStartEvent(
+            turn_index=0,
+            message_count=1,
+            tool_count=0,
+            system_chars=0,
+            model_id="fake-model",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=ThinkingDelta(text="thinking")))
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=TextDelta(text="Hello from AgentM")))
+    await bus.emit(
+        "stream_delta",
+        StreamDeltaEvent(
+            turn_index=0,
+            delta=MessageEnd(
+                message=AssistantMessage(
+                    role="assistant",
+                    content=[TextContent(type="text", text="Hello from AgentM")],
+                    timestamp=1.0,
+                    stop_reason="end_turn",
+                    usage=Usage(input_tokens=128, output_tokens=32),
+                )
+            ),
+        ),
+    )
+    await bus.emit(
+        "llm_request_end",
+        LlmRequestEndEvent(turn_index=0, chunk_count=3, duration_ns=1_000_000, error=None),
+    )
+    return []
+
+
+async def _cancel_script(bus: EventBus, text: str) -> list[Any]:
+    del text
+    await bus.emit(
+        "llm_request_start",
+        LlmRequestStartEvent(
+            turn_index=0,
+            message_count=1,
+            tool_count=0,
+            system_chars=0,
+            model_id="fake-model",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=TextDelta(text="partial")))
+    try:
+        await asyncio.sleep(5)
+    except asyncio.CancelledError:
+        raise
+    return []
+
+
+async def _tool_script(bus: EventBus, text: str) -> list[Any]:
+    del text
+    await bus.emit(
+        "llm_request_start",
+        LlmRequestStartEvent(
+            turn_index=0,
+            message_count=1,
+            tool_count=1,
+            system_chars=0,
+            model_id="fake-model",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=ToolCallStart(id="tc-1", name="read")))
+    await bus.emit(
+        "tool_call",
+        ToolCallEvent(tool_call_id="tc-1", tool_name="read", args={"path": "foo.txt"}),
+    )
+    await bus.emit(
+        "tool_result",
+        ToolResultEvent(
+            tool_call_id="tc-1",
+            tool_name="read",
+            result=ToolResult(content=[TextContent(type="text", text="ok\nline2")]),
+        ),
+    )
+    await bus.emit(
+        "llm_request_end",
+        LlmRequestEndEvent(turn_index=0, chunk_count=2, duration_ns=1_000_000, error=None),
+    )
+    return []
+
+
+async def _follow_up_script(bus: EventBus, text: str) -> list[Any]:
+    await _golden_script(bus, text)
+    return []
+
+
+async def _no_op_script(bus: EventBus, text: str) -> list[Any]:
+    del bus, text
+    return []
+
+
+async def _subagent_script(bus: EventBus, text: str) -> list[Any]:
+    del text
+    await bus.emit(
+        "llm_request_start",
+        LlmRequestStartEvent(
+            turn_index=0,
+            message_count=1,
+            tool_count=0,
+            system_chars=0,
+            model_id="fake-model",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=TextDelta(text="parent")))
+    await bus.emit(
+        "child_session_start",
+        ChildSessionStartEvent(
+            child_session_id="child-1",
+            parent_session_id="parent-1",
+            purpose="subagent:test",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=TextDelta(text=" child step")))
+    await bus.emit(
+        "child_session_end",
+        ChildSessionEndEvent(
+            child_session_id="child-1",
+            parent_session_id="parent-1",
+            final_message_count=1,
+            error="boom",
+        ),
+    )
+    await bus.emit(
+        "llm_request_end",
+        LlmRequestEndEvent(turn_index=0, chunk_count=2, duration_ns=1_000_000, error=None),
+    )
+    return []
+
+
+async def _tool_edit_script(bus: EventBus, text: str) -> list[Any]:
+    del text
+    await bus.emit(
+        "llm_request_start",
+        LlmRequestStartEvent(
+            turn_index=0,
+            message_count=1,
+            tool_count=1,
+            system_chars=0,
+            model_id="fake-model",
+        ),
+    )
+    await bus.emit("stream_delta", StreamDeltaEvent(turn_index=0, delta=ToolCallStart(id="tc-edit", name="tool_edit")))
+    await bus.emit(
+        "tool_call",
+        ToolCallEvent(tool_call_id="tc-edit", tool_name="tool_edit", args={"path": "a.py"}),
+    )
+    await bus.emit(
+        "tool_result",
+        ToolResultEvent(
+            tool_call_id="tc-edit",
+            tool_name="tool_edit",
+            result=ToolResult(
+                content=[TextContent(type="text", text="--- a.py\n+++ a.py\n@@\n-print('x')\n+print('y')")]
+            ),
+        ),
+    )
+    await bus.emit(
+        "llm_request_end",
+        LlmRequestEndEvent(turn_index=0, chunk_count=2, duration_ns=1_000_000, error=None),
+    )
+    return []
+
+
+def _make_app(tmp_path: Path, session: _FakeSession) -> AgentMApp:
+    config = AgentSessionConfig(cwd=str(tmp_path), provider=("fake", {}), bus=session.bus)
+    app = AgentMApp(
+        config,
+        theme="dark",
+        session=session,
+        slash_commands=[
+            SlashCommandEntry(name="/help", description="Show help.", source="builtin"),
+            SlashCommandEntry(name="/clear", description="Clear log.", source="builtin"),
+            SlashCommandEntry(name="/custom", description="Custom slash.", source="ext"),
+        ],
+    )
+    session.bus.on("stream_delta", app.handle_stream_delta)
+    session.bus.on("tool_call", app.handle_tool_call)
+    session.bus.on("tool_result", app.handle_tool_result)
+    session.bus.on("llm_request_start", app.handle_llm_start)
+    session.bus.on("llm_request_end", app.handle_llm_end)
+    session.bus.on("child_session_start", app.handle_child_start)
+    session.bus.on("child_session_end", app.handle_child_end)
+    session.bus.on("extension_install", app.handle_extension_install)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_T1_golden_path_updates_stream_and_status(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_golden_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("h", "i", "enter")
+        await pilot.pause(0.2)
+        status = app.query_one("#status-line")
+        assert "turn 1" in status.current_text
+        assert "in: 128" in status.current_text
+        assert "out: 32" in status.current_text
+        assert "idle" in status.current_text
+        assert app._last_assistant_text == "Hello from AgentM"
+
+
+@pytest.mark.asyncio
+async def test_T2_escape_soft_cancels_and_keeps_partial_text(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_cancel_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("x", "enter")
+        await pilot.pause(0.1)
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        status = app.query_one("#status-line")
+        assert "idle" in status.current_text
+        assert app._last_assistant_text == "partial"
+        assert app._prompt_task is None
+
+
+@pytest.mark.asyncio
+async def test_T3_tool_block_collapses_and_toggles(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_tool_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("x", "enter")
+        await pilot.pause(0.2)
+        tool = app.query_one(ToolCallBlock)
+        assert tool.collapsed is True
+        tool.focus()
+        await pilot.press("ctrl+e")
+        await pilot.pause(0.05)
+        assert tool.collapsed is False
+
+
+@pytest.mark.asyncio
+async def test_T4_slash_palette_opens_filters_and_inserts_selection(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_no_op_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("/")
+        await pilot.pause(0.05)
+        assert app.screen_stack[-1].__class__.__name__ == "CommandPaletteScreen"
+        await pilot.press("h", "e", "l", "p", "enter")
+        await pilot.pause(0.05)
+        prompt = app.query_one("#prompt-input")
+        assert prompt.text == "/help"
+
+
+@pytest.mark.asyncio
+async def test_T5_subagent_block_renders_and_marks_error(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_subagent_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("x", "enter")
+        await pilot.pause(0.2)
+        subagent = next(iter(app._child_turns.values()), None)
+        assert subagent is None
+        turn = app._latest_turn()
+        assert turn is not None
+        block = turn.subagents["child-1"]
+        assert block.failed is True
+        assert "boom" in str(block.lines)
+
+
+@pytest.mark.asyncio
+async def test_T6_shift_enter_inserts_newline(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, _FakeSession([_no_op_script]))
+    async with app.run_test() as pilot:
+        await pilot.press("h", "i", "shift+enter", "t", "h", "e", "r", "e")
+        await pilot.pause(0.05)
+        prompt = app.query_one("#prompt-input")
+        assert prompt.text == "hi\nthere"
+
+
+@pytest.mark.asyncio
+async def test_T7_ctrl_l_clears_visual_log_but_follow_up_still_runs(tmp_path: Path) -> None:
+    session = _FakeSession([_golden_script, _follow_up_script])
+    app = _make_app(tmp_path, session)
+    async with app.run_test() as pilot:
+        await pilot.press("x", "enter")
+        await pilot.pause(0.2)
+        await pilot.press("ctrl+l")
+        await pilot.pause(0.05)
+        assert len(app.query_one("#conversation-log").children) == 0
+        await pilot.press("y", "enter")
+        await pilot.pause(0.2)
+        assert session.prompts == ["x", "y"]
+        assert len(app.query_one("#conversation-log").children) > 0
+
+
+@pytest.mark.asyncio
+async def test_T8_many_turns_keep_scrollable_log(tmp_path: Path) -> None:
+    session = _FakeSession([])
+    app = _make_app(tmp_path, session)
+    async with app.run_test() as pilot:
+        for turn_index in range(500):
+            turn = TurnContainer(logical_turn=turn_index + 1)
+            app._root_turns[turn_index] = turn
+            if turn_index < 60:
+                await app._mount_turn(turn)
+                turn.text_buffer = f"turn {turn_index}"
+                turn.assistant.set_text(turn.text_buffer)
+        await pilot.pause(0.2)
+        log = app.query_one("#conversation-log")
+        before = log.scroll_y
+        await pilot.press("pagedown")
+        await pilot.pause(0.05)
+        assert len(app._root_turns) == 500
+        assert log.scroll_y >= before
+
+
+@pytest.mark.asyncio
+async def test_T9_cli_simple_and_textual_frontends_dispatch_separately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    async def _fake_simple(config: AgentSessionConfig) -> int:
+        called.append(f"simple:{config.cwd}")
+        return 11
+
+    async def _fake_textual(config: AgentSessionConfig, *, theme: str = "dark") -> int:
+        called.append(f"textual:{theme}:{config.cwd}")
+        return 22
+
+    monkeypatch.setattr("agentm.modes.interactive.run", _fake_simple)
+    monkeypatch.setattr("agentm.modes.textual_app.run", _fake_textual)
+
+    rc_simple = await _run_interactive(
+        scenario=None,
+        no_extensions=True,
+        no_skills=True,
+        no_prompt_templates=True,
+        tool_allowlist=None,
+        model="fake-model",
+        cwd="/tmp/simple",
+        tui="simple",
+    )
+    rc_textual = await _run_interactive(
+        scenario=None,
+        no_extensions=True,
+        no_skills=True,
+        no_prompt_templates=True,
+        tool_allowlist=None,
+        model="fake-model",
+        cwd="/tmp/textual",
+        tui="textual",
+    )
+
+    assert rc_simple == 11
+    assert rc_textual == 22
+    assert called == ["simple:/tmp/simple", "textual:dark:/tmp/textual"]
+
+
+@pytest.mark.asyncio
+async def test_T10_light_theme_and_diff_rendering_and_extension_error_toast(tmp_path: Path) -> None:
+    session = _FakeSession([_tool_edit_script])
+    app = AgentMApp(
+        AgentSessionConfig(cwd=str(tmp_path), provider=("fake", {}), bus=session.bus),
+        theme="light",
+        session=session,
+        slash_commands=[SlashCommandEntry(name="/help", description="Show help.", source="builtin")],
+    )
+    session.bus.on("stream_delta", app.handle_stream_delta)
+    session.bus.on("tool_call", app.handle_tool_call)
+    session.bus.on("tool_result", app.handle_tool_result)
+    session.bus.on("llm_request_start", app.handle_llm_start)
+    session.bus.on("llm_request_end", app.handle_llm_end)
+    session.bus.on("extension_install", app.handle_extension_install)
+
+    async with app.run_test(notifications=True) as pilot:
+        await session.bus.emit(
+            "extension_install",
+            ExtensionInstallEvent(
+                module_path="bad.ext",
+                config={},
+                phase="error",
+                duration_ns=1,
+                error="boom",
+            ),
+        )
+        await pilot.press("x", "enter")
+        await pilot.pause(0.2)
+        tool = app.query_one(ToolCallBlock)
+        assert "theme-light" in app.classes
+        assert tool.body_kind == "Syntax"

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "pathspec" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
@@ -37,6 +38,7 @@ requires-dist = [
     { name = "pathspec", specifier = ">=1.0.4" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "textual", specifier = ">=0.85" },
     { name = "typer", specifier = ">=0.25.1" },
 ]
 
@@ -552,6 +554,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -561,6 +575,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -630,6 +661,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1040,6 +1080,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1153,6 +1210,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #51

## What changed
- add a Textual-based interactive mode with streamed assistant rendering, collapsible tool blocks, slash-command palette, status line, history, and soft-cancel handling
- keep the existing rich-live frontend as `--tui simple` and wire `--tui textual` through the CLI
- add Textual theme CSS plus integration coverage for the TUI behaviors in `tests/integration/test_textual_tui.py`

## Verification
- `uv run ruff check src/agentm/modes/textual_app.py`
- `uv run mypy src/agentm/modes/textual_app.py`
- `uv run pytest tests -q`
- `uv run pytest tests/integration/test_textual_tui.py -q`

## Manual verification
- launched `uv run agentm -i --tui textual` against a temporary fake provider injected via `sitecustomize.py` so the flow could be exercised without external API calls
- walked the golden path (T1), Esc soft-cancel (T2), tool block interaction (T3), and slash palette open/select (T4) in the live TTY session

## Notes
- full-repo `uv run pytest -q` still hits the pre-existing optional dependency gap in `scenarios/rca/tests` (`pyarrow` missing during collection), so the verification above uses the main `tests/` suite instead
