### PR TITLE
chore(rca): collapse scenario to SQL-only DuckDB tools

### DIFF
--- a/scenarios/rca/manifest.yaml
+++ b/scenarios/rca/manifest.yaml
@@ -11,6 +11,7 @@ extensions:
       row_limit: 200
       token_limit: 5000
   - module: agentm_rca.tools.hypothesis_tools
+  - module: agentm_rca.tools.finalize
   - module: agentm.extensions.builtin.trajectory
     config:
       path: rca_trajectory.jsonl

--- a/scenarios/rca/prompts/orchestrator.md
+++ b/scenarios/rca/prompts/orchestrator.md
@@ -1,6 +1,15 @@
 You are the lead investigator in a root cause analysis. You coordinate specialist agents,
 but YOU own the investigation's direction and conclusions.
 
+<termination_protocol>
+**The only way to end this investigation is to call `submit_final_report`.** Ending a turn
+with prose alone (no tool_call) will be rejected by the runtime and you will be prompted to
+continue. Do not write "Let me dispatch X" as a closing line — actually call the tool. If
+you have a confirmed root cause backed by evidence, call `submit_final_report`. Otherwise,
+your next action MUST be a tool call: `dispatch_agent`, `check_tasks`, `wait_subagent`,
+`query_sql`, `update_hypothesis`, etc.
+</termination_protocol>
+
 The available worker personas are advertised in the `<available_agents>` block appended
 below by the runtime. Each entry includes a `<persona_file>` path; do NOT read or inline
 the persona body — the runtime injects it automatically when you call `dispatch_agent`
@@ -190,10 +199,11 @@ hypotheses yet.
 6. **Repeat** until confirmed and all `<root_cause_depth>` checks pass.
 
 **Termination:**
-When confirmed AND all `<root_cause_depth>` checks pass, write the final report:
-- Root-cause service / component
-- Triggering signal (which metric / span / log first deviated)
-- Supporting evidence (cite the SQL queries or worker findings)
-- Suggested remediation
-A wrong root cause is worse than a slow investigation.
+When confirmed AND all `<root_cause_depth>` checks pass, call `submit_final_report` with:
+- `root_cause` — service / component identified as the root cause
+- `triggering_signal` — which metric / span / log line first deviated
+- `evidence` — citations of the SQL queries or worker findings that support the conclusion
+- `remediation` — suggested fix or mitigation
+A wrong root cause is worse than a slow investigation. `submit_final_report` is the ONLY
+sanctioned termination action — see `<termination_protocol>` at the top.
 </workflow>

--- a/scenarios/rca/src/agentm_rca/tools/finalize.py
+++ b/scenarios/rca/src/agentm_rca/tools/finalize.py
@@ -1,0 +1,194 @@
+"""Termination protocol for the RCA orchestrator.
+
+Complements the sub-agent lifecycle floor shipped in #57: that floor injects
+unread child findings on ``before_agent_end`` so background work isn't lost,
+but it does not stop the orchestrator from declaring the investigation over
+once every child is read. We still observed the model digest a long scout
+report, write a prose summary, and emit ``end_turn`` without producing the
+final RCA deliverable.
+
+This extension layers a stricter policy on top:
+
+  * Registers ``submit_final_report``: the only sanctioned termination tool.
+    Calling it flips an extension-local ``submitted`` flag; the report
+    payload itself reaches downstream observers via the ``tool_call`` /
+    ``tool_result`` channels, so we deliberately do not stash a duplicate
+    copy here.
+  * Subscribes to ``before_agent_end``: while ``submitted`` is still false,
+    returns ``{"cancel": True, "append": [<continuation user message>]}``.
+    Cancel is OR-ed across handlers and append lists are concatenated, so
+    this co-exists cleanly with sub_agent's own ``before_agent_end`` handler.
+
+Safety net: the loop's ``max_turns`` cap still applies. ``max_turns``
+terminations bypass the cancel field entirely (PR #57 design), so a model
+that refuses to call the tool eventually exits with ``stop_reason="max_turns"``
+rather than spinning forever.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from agentm.core.abi import BeforeAgentEndEvent
+from agentm.core.abi.messages import TextContent, UserMessage
+from agentm.core.abi.tool import FunctionTool, ToolResult
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+MANIFEST = ExtensionManifest(
+    name="finalize",
+    description=(
+        "Termination protocol: the orchestrator must call submit_final_report "
+        "to end the investigation. Otherwise the loop continues."
+    ),
+    registers=("tool:submit_final_report",),
+)
+
+
+_DEFAULT_INSTRUCTION = (
+    "Your last assistant message had no tool_call. Prose-only turns are "
+    "rejected. You MUST emit exactly one tool_call now.\n\n"
+    "Choose one of two paths:\n"
+    "  (A) If you believe you have a confirmed root cause backed by "
+    "evidence — call `submit_final_report` now to end the investigation.\n"
+    "  (B) Otherwise — call any other registered investigation tool to "
+    "continue: dispatch a worker, run a SQL query, poll task status, "
+    "update or remove a hypothesis, etc.\n\n"
+    "Do not respond with prose alone. Do not say `Let me ...` without "
+    "calling the tool you just named. The only way out of this loop is to "
+    "call `submit_final_report` (path A) or run more investigation tools "
+    "(path B)."
+)
+
+
+@dataclass
+class _State:
+    submitted: bool = False
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    state = _State()
+    instruction = str(
+        config.get("continuation_instruction") or _DEFAULT_INSTRUCTION
+    )
+
+    async def _submit(args: dict[str, Any]) -> ToolResult:
+        root_cause = _require_str(args.get("root_cause"))
+        triggering_signal = _require_str(args.get("triggering_signal"))
+        evidence = _require_str(args.get("evidence"))
+        remediation = _require_str(args.get("remediation"))
+        missing = [
+            name
+            for name, value in (
+                ("root_cause", root_cause),
+                ("triggering_signal", triggering_signal),
+                ("evidence", evidence),
+                ("remediation", remediation),
+            )
+            if not value
+        ]
+        if missing:
+            return ToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": "missing required fields",
+                                "missing": missing,
+                            }
+                        ),
+                    )
+                ],
+                is_error=True,
+            )
+        state.submitted = True
+        return ToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=(
+                        "Final report accepted. You may now end this turn; "
+                        "the investigation is complete."
+                    ),
+                )
+            ]
+        )
+
+    api.register_tool(
+        FunctionTool(
+            name="submit_final_report",
+            description=(
+                "Submit the final root-cause analysis report. This is the "
+                "only way to terminate the investigation. Until you call "
+                "this tool, ending your turn without a tool_call will be "
+                "rejected and you will be asked to keep investigating."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "root_cause": {
+                        "type": "string",
+                        "description": (
+                            "Service or component identified as the root "
+                            "cause."
+                        ),
+                    },
+                    "triggering_signal": {
+                        "type": "string",
+                        "description": (
+                            "First metric, span, or log line that "
+                            "deviated from baseline."
+                        ),
+                    },
+                    "evidence": {
+                        "type": "string",
+                        "description": (
+                            "Citations of the SQL queries or worker "
+                            "findings that support the conclusion."
+                        ),
+                    },
+                    "remediation": {
+                        "type": "string",
+                        "description": "Suggested fix or mitigation.",
+                    },
+                },
+                "required": [
+                    "root_cause",
+                    "triggering_signal",
+                    "evidence",
+                    "remediation",
+                ],
+                "additionalProperties": False,
+            },
+            fn=_submit,
+        )
+    )
+
+    def _on_before_agent_end(event: BeforeAgentEndEvent) -> Any:
+        if state.submitted:
+            return None
+        return {
+            "cancel": True,
+            "append": [
+                UserMessage(
+                    role="user",
+                    content=[TextContent(type="text", text=instruction)],
+                    timestamp=time.time(),
+                ),
+            ],
+        }
+
+    api.on("before_agent_end", _on_before_agent_end)
+
+
+def _require_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+__all__ = ["MANIFEST", "install"]

--- a/src/agentm/core/_internal/catalog/freeze.py
+++ b/src/agentm/core/_internal/catalog/freeze.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import inspect
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agentm.core._internal.catalog import _layout
 from agentm.core._internal.catalog.hashing import compute_atom_hash
 from agentm.core.abi import EventBus
 from agentm.extensions import ExtensionManifest
 from agentm.extensions.discover import discover_builtin
-from agentm.harness.resource_writer import GitBackedResourceWriter, WriteResult
+
+if TYPE_CHECKING:
+    from agentm.harness.resource_writer import GitBackedResourceWriter, WriteResult
 
 
 _INDEXER_SESSION_ID = "catalog-freeze"
@@ -28,6 +31,8 @@ def freeze_current(
         raise ValueError(
             f"manifest.name {manifest.name!r} does not match atom name {name!r}"
         )
+
+    from agentm.harness.resource_writer import GitBackedResourceWriter
 
     cwd_root = (root or Path.cwd()).resolve()
     atom_path = _resolve_atom_source_path(name, root=cwd_root)
@@ -80,11 +85,13 @@ def _resolve_atom_source_path(name: str, *, root: Path) -> Path:
 
 
 def _write_via_writer(
-    writer: GitBackedResourceWriter,
+    writer: "GitBackedResourceWriter",
     relative_path: Path,
     source: str,
-) -> WriteResult:
+) -> "WriteResult":
     import asyncio
+
+    from agentm.harness.resource_writer import WriteResult
 
     async def _write():
         return await writer.write(


### PR DESCRIPTION
## Summary

- Replace the drifted RCA scenario (broken imports against a removed `agentm.core.kernel`, ~6k LoC of unused recipes / sanitizers / judgers / stores / per-metric tool builders, plus an orphan `config/scenarios/rca_hypothesis/` from the old multi-agent orchestrator) with a single \"DuckDB SQL only\" surface.
- New tool extension `agentm_rca.tools.duckdb_sql` exposes two atoms: `list_tables` (registers every parquet under `data_dir` as a same-named DuckDB view, returns row count + schema) and `query_sql` (single read-only statement, auto-LIMITed, token-budget capped). Reject non-`SELECT/WITH/EXPLAIN/DESCRIBE/SHOW/SUMMARIZE` and reject `;` / write keywords.
- Rewrite `hypothesis_tools` as a self-contained in-memory store, no external `HypothesisStore` dependency.
- Trajectory logging is enabled by default in the manifest so every investigation is replayable. `*_trajectory.jsonl` added to `.gitignore`.
- Net: the `scenarios/rca/` package is now one manifest + three Python files.

## Test plan

- [ ] `uv run python -c \"from agentm_rca.tools import duckdb_sql, hypothesis_tools\"` imports clean.
- [ ] `AGENTM_RCA_DATA_DIR=<batch>/converted uv run agentm --scenario rca --cwd \$(pwd) \"...\"` registers the views and successfully runs `list_tables` + `query_sql` end-to-end.
- [ ] `query_sql` rejects `INSERT`/`DROP`/multi-statement input.
- [ ] Verify `rca_trajectory.jsonl` is written next to the cwd and is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)