### PR TITLE
docs: multi-agent team design (lifecycle + artifacts + budget)

### DIFF
--- a/.claude/designs/agent-team.md
+++ b/.claude/designs/agent-team.md
@@ -1,0 +1,453 @@
+# Agent Team
+
+Status: design (not yet implemented)
+Owner: scenario layer + small extensions to `sub_agent`
+
+Reaches into: `extensions/builtin/sub_agent.py` (additions), persona file
+frontmatter convention, scenario manifest convention, references
+`sub_agent_lifecycle` and `artifact_system` as load-bearing dependencies.
+
+## Why team is not a SDK type
+
+The first instinct on reading multi-agent literature is to introduce a
+`Team` first-class type — members, hierarchy, protocols, shared memory,
+budget — all bundled under one declaration. CrewAI does this, AutoGen does
+this. We deliberately do not.
+
+A `Team` type fuses orthogonal concerns into one abstraction:
+
+- **Identity** — who the agent is (persona, system prompt, tools).
+- **Lifecycle** — how a session is spawned and ended.
+- **Memory** — what artifacts persist and who can read them.
+- **Coordination** — who dispatches whom, who arbitrates conflicts.
+- **Budget** — token and tool-call ceilings, scaling rules.
+
+Bundled, every change to one concern ripples through the team type. Worse,
+the bundling hides which concerns are actually load-bearing for a given
+scenario; teams that only need lightweight delegation pay the full type
+weight.
+
+AgentM's `pluggable_architecture` and `extension_as_scenario` already
+mandate that **features compose out of orthogonal primitives, not layered
+abstractions**. A team is what you get when several primitives stand
+together in one scenario. The runtime never knows.
+
+This design therefore documents **the conventions and the small additions**
+that make team formation safe, observable, and budget-aware — without
+introducing a Team type.
+
+## There is no mode switch
+
+A second instinct is to draw a line between "single-agent mode" and
+"team mode" — a boot tool, a runtime flag, a manifest toggle, anything that
+flips the system from one regime to the other. We deliberately do not.
+
+The right shape is identical to the one Claude Code uses: an agent always
+has a set of capabilities; it decides when to use which. There is no
+`enable_team_mode()` call before using `Agent({subagent_type: ...})`. The
+Agent tool is always present; the model dispatches when it judges the task
+warrants it.
+
+Concretely, in a team-capable AgentM scenario:
+
+- `dispatch_agent`, `artifact_write`, `artifact_read`, `wait_subagent`,
+  `check_tasks` are all registered at session start.
+- The orchestrator's system prompt may *encourage* delegation but does not
+  require it.
+- A simple lookup gets answered with a single `query_sql`; a deep
+  investigation gets fanned out into N workers; both happen in the same
+  session, no transition.
+- Workers can recurse: a dispatched specialist may itself dispatch deeper
+  specialists if its scenario inherits `sub_agent`.
+
+The runtime never observes which "mode" the system is in, because there is
+no mode. There are only:
+
+- Capabilities the scenario manifest decided to register.
+- An LLM that calls those capabilities when it judges the task warrants
+  them.
+
+This is the same architectural choice as `sub_agent_lifecycle`'s
+"runtime guards the boundary, agent owns the decision" — generalised one
+level up. The runtime guarantees that team-shaped capabilities (artifacts,
+subagent dispatch) are *available*; the agent's prompt and reasoning
+decide *whether and when* to use them.
+
+### Implication for runtime extension loading
+
+A separate question: should an agent be able to *acquire new capabilities
+at runtime* (load `tool_git` on demand, install a new persona)? That is a
+real and useful capability — `self_modifiable_architecture.md` already
+specifies `api.reload_atom` with transactional install — but it is
+**orthogonal to team formation**. Loading a new tool dynamically is
+"acquiring a capability"; deciding to use `dispatch_agent` is "exercising
+an already-loaded capability." Conflating them produces the false binary
+this section rejects.
+
+If a scenario wants the agent to grow team capabilities mid-flight (e.g.
+start without `artifact_store`, install it once a long task warrants),
+that goes through `reload_atom`. The pillars in this design assume the
+opposite default for *team-capable* scenarios: load all four pillars
+upfront, let the agent ignore them on simple tasks.
+
+**Caveat — this is not a universal recommendation.** Each loaded
+extension contributes tool schemas to every system prompt of every turn;
+on a latency-sensitive single-purpose scenario (e.g. a one-shot
+classifier), paying that overhead per call to support delegation that
+will never happen is wasteful. The "load upfront" default applies to
+scenarios that *expect* multi-step investigation and *might* delegate.
+For scenarios where delegation is rare or never, the scenario author
+should leave the team pillars out of the manifest entirely.
+
+## The four pillars
+
+A scenario is operating in "team mode" when all four hold:
+
+| Pillar | Mechanism | Status |
+|---|---|---|
+| A. Lifecycle floor | `BeforeAgentEndEvent` + sub_agent handler | designed in `sub_agent_lifecycle.md` |
+| B. Shared memory tier | `artifact_store` extension + sub_agent integration | designed in `artifact-system.md` |
+| C. Brief contract | persona `input_schema` advisory + persona-body self-rejection | this doc |
+| D. Budget awareness | persona `budget_defaults` + per-dispatch `budget` override | this doc |
+
+Pillars A and B are full designs in their own right; this doc references
+them. Pillars C and D are smaller additions that live entirely in the
+sub_agent extension and the persona file format.
+
+## Pillar A — Lifecycle floor (reference)
+
+See `sub_agent_lifecycle.md`. Summary of the contract for a team scenario:
+
+- `dispatch_agent` is async; returns task_id immediately.
+- Parent's loop will not declare `agent_end` while completed-but-unread
+  child findings exist; runtime injects a notification user-message and
+  re-enters the loop.
+- `check_tasks` blocks until at least one child changes state.
+- `wait_subagent(task_id)` blocks on a specific child.
+- The parent decides timing; the runtime guarantees no findings are lost.
+
+Without this floor, a team scenario where the orchestrator forgets to poll
+silently drops worker output. With it, the architecture is fault-tolerant
+at the LLM-decision layer.
+
+## Pillar B — Shared memory tier (reference)
+
+See `artifact-system.md`. Summary:
+
+- Workers write findings to a shared, session-tree-scoped artifact store.
+- They return a short `<summary>` plus `<artifacts>` list of references in
+  the notification block, not a 5K-character text dump.
+- Orchestrator reads artifacts on demand via `artifact_read` /
+  `artifact_grep` / `artifact_list`.
+- Append-only with provenance — no atomic-update conflicts.
+
+Without this tier, every worker output is a lossy compression and the
+orchestrator's context grows linearly with worker count. With it, context
+grows logarithmically and intermediate work is recoverable.
+
+## Pillar C — Brief contract (persona-owned, not runtime-enforced)
+
+### Problem
+
+The literature's #1 lesson on multi-agent design (Anthropic): orchestrators
+that give vague briefs cause subagents to duplicate work, leave gaps, or
+misinterpret scope. Today, `dispatch_agent` accepts a freeform `prompt`
+string. Brief quality is implicit, not contractual.
+
+### Why this is *not* runtime-validated
+
+The first design draft had the SDK grep the dispatched prompt for literal
+`<objective>...</objective>` markers and reject the dispatch on miss. We
+rejected this for three reasons:
+
+1. **Trivially gameable.** An LLM facing a structured error will inject
+   `<objective>tbd</objective>` to pass the check; the assertion is zero
+   defense against actual brief vagueness.
+2. **Runtime forces a brief format.** Hard-coding XML-tag detection into
+   `sub_agent` would mean every scenario that wants Markdown sections,
+   YAML, or JSON briefs has to reach into SDK code. That violates the
+   SDK-vs-scenario separation we already maintain.
+3. **Negative reinforcement loop.** Rejection-by-runtime trains the
+   orchestrator to satisfy syntax, not to write better briefs.
+
+### Mechanism (persona-owned)
+
+Persona files declare what a good brief looks like — as **prose
+expectations the persona's own system prompt enforces**, plus an optional
+`input_schema` advisory the orchestrator can read for guidance:
+
+```yaml
+---
+name: scout
+description: First responder; produces multi-dimensional observability map.
+tools: list_tables, query_sql
+input_schema:
+  required: [objective, scope_services, output_format]
+  optional: [prior_findings, hypothesis_under_test]
+artifact_kinds: [topology, finding, query_result]
+---
+
+<expected_brief>
+Your dispatcher should provide:
+- objective: the question you are answering, one sentence
+- scope_services: backtick-quoted service names you should investigate
+- output_format: artifact kinds expected (topology / finding / query_result)
+
+If any field is missing or vacuous (e.g. "investigate everything"), your
+FIRST action MUST be to write an artifact of kind="brief_rejection"
+explaining what's missing and call agent_end. Do not investigate.
+</expected_brief>
+
+You are a Scout Agent — ...
+```
+
+The persona body, not the runtime, decides what to do when a brief is
+inadequate. The orchestrator sees `brief_rejection` artifacts in the
+notification block and adapts the next dispatch.
+
+`input_schema` survives in the frontmatter as **advisory metadata**. The
+orchestrator's prompt may reference it ("the persona declares
+`required: [objective, scope_services, output_format]`; include all three
+in your brief"), and tooling can surface it in `<available_agents>`
+listings, but the runtime never validates it.
+
+### Observability (the only runtime piece)
+
+`dispatch_agent` records the dispatched prompt's length and the
+`subagent_type` to trajectory. Combined with the persona's
+`brief_rejection` artifacts, post-hoc analysis can compute "fraction of
+dispatches that produced rejections" per scenario — the actual signal of
+brief-quality drift, without any false-positive rejection-loop risk.
+
+### What this buys
+
+- No SDK-level brief format lock-in; scenarios can choose XML, Markdown,
+  JSON, or none.
+- Brief-quality enforcement lives where it can actually reason about
+  *content* (the persona's LLM), not where it can only pattern-match.
+- Failure mode "subagent misinterpreted scope" (MAST-categorized) becomes
+  detectable via `brief_rejection` artifacts.
+
+### What it does not enforce
+
+- Output format compliance. The persona body remains responsible.
+- That the persona body actually implements the `<expected_brief>`
+  contract — that's authoring discipline, same as any system prompt.
+
+## Pillar D — Budget awareness
+
+### Problem
+
+Anthropic's analysis: multi-agent systems use 15× the tokens of single-agent
+chats; token usage explains 80% of performance variance. Without an
+explicit budget concept, scenarios over-spend on simple queries and
+under-spend on complex ones. The literature's recommendation (Anthropic):
+"Simple fact-finding requires one agent with 3–10 tool calls; direct
+comparisons need 2–4 subagents with 10–15 calls each; complex research
+might use over 10 subagents."
+
+Today, every dispatched worker inherits the same `LoopConfig.max_turns =
+32` regardless of task complexity.
+
+### Mechanism
+
+Three layers, **all opt-in, no scenario-wide complexity tier**:
+
+A scenario-level `task_complexity` knob was considered and rejected: a
+single rca scenario routinely handles both "list tables" (cheap lookup)
+and "find root cause" (deep fan-out). Pinning a complexity at the
+manifest level mis-locates the decision — complexity is a property of
+the *query*, not the scenario.
+
+**Layer 1 — persona `budget_defaults`**
+
+Persona frontmatter declares per-task budget defaults:
+
+```yaml
+budget_defaults:
+  max_tool_calls: 15
+  max_turns: 10
+```
+
+These apply to every dispatch of that persona unless the orchestrator
+overrides at call time. A `verify` persona might default to 5 tool
+calls; a `deep_analyze` persona to 25. Default-safe per role.
+
+**Layer 2 — per-dispatch budget on the tool call**
+
+`dispatch_agent` accepts an optional `budget` object:
+
+```json
+{
+  "subagent_type": "scout",
+  "purpose": "...",
+  "prompt": "...",
+  "budget": {"max_tool_calls": 15, "max_turns": 10}
+}
+```
+
+When set, overrides persona defaults for that dispatch only. The
+orchestrator scales depth per query: a quick scout pass gets
+`max_tool_calls: 6`; a forensic deep-dive gets `30`.
+
+**Layer 3 — `sub_agent.max_workers` (already exists)**
+
+Caps parallel concurrency at the manifest level. Already in production.
+
+The composition: `max_workers` bounds parallelism, `budget_defaults`
+bounds per-persona depth, per-dispatch `budget` lets the orchestrator
+adjust per query. No fourth scenario-wide knob is needed; adding one
+would mis-locate complexity at the manifest tier.
+
+### What this buys
+
+- Default-safe: a scenario author who declares `task_complexity: simple`
+  cannot accidentally have their orchestrator fan out 10 workers.
+- Observability: trajectory records the budget that was applied,
+  per-dispatch, alongside actual usage. Post-hoc analysis (which scenarios
+  are over- or under-spending) becomes mechanical.
+- Cost control: a single line in a manifest is the difference between a
+  $0.05 query and a $0.75 query.
+
+### What it does not enforce
+
+- Token budgets. Tool-call ceiling is a proxy. Real token enforcement
+  belongs in `cost_budget` (existing Tier-2 atom). The two compose: a
+  worker can be both tool-call-capped and dollar-capped.
+- Adaptive scaling. We do not auto-detect "this query needs deeper
+  research" and bump the budget. The orchestrator may dispatch with a
+  larger explicit `budget`; the cap is still bounded by `team_profile`.
+
+## Failure-mode mapping
+
+Each pillar defends against named failure modes from the literature.
+This is the explicit checklist that justifies the design.
+
+| MAST / literature failure mode | Pillar(s) | Defense |
+|---|---|---|
+| Lost child output (silent drop on agent_end) | A | Lifecycle floor injects all completed children before exit |
+| Polling burns parent budget | A | Blocking `check_tasks` |
+| Context loss at handoff (lossy summarization) | B | Artifact store + reference-based handoff |
+| Supervisor context bloat | B | Notification block is summary + ids only |
+| Inconsistent shared state | B | Append-only model with provenance |
+| Subagent misinterpreted scope | C | Persona body self-rejects vacuous briefs via `brief_rejection` artifact |
+| Duplicate work between subagents | C | Persona's `<expected_brief>` requires `scope_services` and refuses without it |
+| Token over-spend on simple queries | D | Persona `budget_defaults` keep cheap personas cheap; per-dispatch override |
+| Token under-spend on complex queries | D | Per-dispatch `budget` override scales the right query, not the whole scenario |
+| Cascade context poisoning | A + B | Each worker has private tier-1; tier-2 immutable |
+| Open mesh routing (no clear authority) | scenario layout | Orchestrator-only dispatch is the default convention |
+
+## Three usage modes, one mechanism
+
+Same as `sub_agent_lifecycle` (no new modes). The pillars are orthogonal
+to mode; any of fire-and-forget, explicit wait, steered fan-out works
+identically whether artifacts are written or not, whether budgets are
+declared or not.
+
+## Persona file format (consolidated)
+
+After this design, a persona file looks like:
+
+```markdown
+---
+name: scout
+description: First responder; produces multi-dimensional observability map.
+tools: list_tables, query_sql
+input_schema:
+  required: [objective, scope_services, output_format]
+  optional: [prior_findings, hypothesis_under_test, budget_tool_calls]
+artifact_kinds: [topology, finding, query_result]
+budget_defaults:
+  max_tool_calls: 15
+  max_turns: 10
+---
+
+You are a Scout Agent — first responder in a root cause analysis.
+... (rest of persona body) ...
+```
+
+All new fields are optional. Personas without them behave as today.
+
+## Scenario manifest (consolidated)
+
+```yaml
+name: rca
+description: Root-cause analysis over parquet observability data.
+extensions:
+  - module: agentm.extensions.builtin.artifact_store
+  - local: orchestrator_setup
+  - module: agentm.extensions.builtin.sub_agent
+    config:
+      max_workers: 4
+      inherit_extensions: [duckdb_sql, artifact_store, trajectory]
+      available_inherited_extensions:
+        duckdb_sql: { module: agentm_rca.tools.duckdb_sql, config: {...} }
+        artifact_store: { module: agentm.extensions.builtin.artifact_store, config: {} }
+        trajectory: { module: agentm.extensions.builtin.trajectory, config: {path: rca_worker_trajectory.jsonl} }
+  - module: agentm_rca.tools.duckdb_sql
+    config: {...}
+  - module: agentm.extensions.builtin.trajectory
+    config: { path: rca_trajectory.jsonl }
+```
+
+No new top-level manifest keys. The four pillars are pure composition of
+existing primitives plus per-persona / per-dispatch fields.
+
+## What is not in scope
+
+- **First-class Team type** — see opening rationale.
+- **Peer-to-peer dispatch** — workers spawning workers without going
+  through the orchestrator. Technically possible (each session has its
+  own `sub_agent`) but discouraged for default scenarios; the literature
+  is consistent that flat mesh communication fails in production.
+- **Built-in voting / arbitration** — when an orchestrator wants debate,
+  it dispatches N opposing personas and arbitrates in its own prompt.
+  Not a runtime concern.
+- **Cross-scenario persona registry** — personas live in
+  `scenarios/<name>/agents/`. Sharing across scenarios is a filesystem /
+  git concern (symlinks, submodules), not a SDK feature.
+- **Output schema validation** — runtime cannot enforce the worker's
+  final text matches a schema. Persona prompt body is responsible.
+  Future work could add this; tracked in `artifact-system.md` open
+  questions.
+- **Adaptive budget escalation** — orchestrator can request more budget
+  per-dispatch but cannot exceed `team_profile` defaults without
+  changing the manifest. No runtime "promote complexity" path.
+
+## Compatibility and migration
+
+- All four pillars are opt-in. A scenario that uses `dispatch_agent`
+  today (rca) continues to work without `artifact_store`,
+  `team_profile`, or `input_schema`.
+- Adding `input_schema: required: []` (empty) to a persona is a no-op.
+- The `team_profile` key is read by an optional builtin; absent =
+  no defaults applied.
+- New persona frontmatter fields are additive; old personas valid.
+- `dispatch_agent` `budget` argument is optional.
+
+## Effort estimate
+
+This doc on top of `sub_agent_lifecycle.md` and `artifact-system.md`:
+
+- Persona `input_schema` advisory parsing + surface in `<available_agents>`: ~15 lines
+- Persona `budget_defaults` parsing + apply to child LoopConfig: ~20 lines
+- `dispatch_agent` optional `budget` argument override: ~20 lines
+- rca scenario migration (add `<expected_brief>` blocks to personas,
+  switch hypothesis tools to artifact_write): ~40 lines
+
+Combined with the dependent designs:
+
+- `sub_agent_lifecycle`: 100–150 lines
+- `artifact_system`: 250–300 lines
+- This design's additions: ~95 lines
+
+Grand total for full team-mode capability: roughly 460–550 lines of
+code across three coordinated PRs. No data migration. Each PR ships
+independently and provides incremental value:
+
+1. `sub_agent_lifecycle` first (no team needed; benefits any
+   sub-agent dispatch scenario).
+2. `artifact_system` second (depends on lifecycle for clean
+   integration; benefits scenarios with multi-step worker pipelines).
+3. This doc's additions third (refines the API, adds defaults,
+   migrates rca to the new shape).

--- a/.claude/designs/artifact-system.md
+++ b/.claude/designs/artifact-system.md
@@ -1,0 +1,321 @@
+# Artifact System
+
+Status: design (not yet implemented)
+Owner: harness layer + new builtin extension
+
+Reaches into: `extensions/builtin/artifact_store.py` (new), session-tree
+state, optional integration with `sub_agent_lifecycle` notification format,
+optional integration with `evolution_substrate` tier-3 vault.
+
+## Problem
+
+Today every sub-agent invocation in AgentM follows the same shape:
+
+1. Parent dispatches a worker with a freeform prompt.
+2. Worker runs N tool calls of real investigation, accumulating intermediate
+   findings in its private message history.
+3. Worker emits one final assistant message; harness extracts the text.
+4. Worker session is destroyed.
+5. Parent receives the text as a tool result (or, with sub_agent_lifecycle, as
+   a notification block before agent_end).
+
+Every step from (3) onward is **lossy compression**. The worker's
+intermediate reasoning, the tool results it cited, the queries it tried and
+abandoned — all of it is collapsed into one prose blob. The parent has no way
+to ask "show me the SQL that backed this finding" or "what queries did you
+abandon and why?". Once the child shuts down its message history is gone.
+
+The literature names this exactly: "Every hand-off between agents puts your
+workflow's shared memory at risk. When one model's reply exceeds another's
+context window, critical details vanish, and the next agent starts reasoning
+from a partial snapshot." Field studies of multi-agent failure traces
+(MAST taxonomy, 1600+ traces) attribute **36.9% of failures to inter-agent
+misalignment** rooted in inconsistent shared state.
+
+The operational footprint in rca:
+
+- Scout finds 5 services on the abnormal call chain. Returns 5701-character
+  summary. Verify worker, dispatched two turns later, must rederive every
+  topology query because scout's actual SQL is gone.
+- Orchestrator's context grows linearly with worker count.
+- Coordinator and workers cannot peer at each other's intermediate notebook
+  pages — every cross-reference round-trips through the orchestrator's text.
+
+The fix is not "longer summaries" or "smarter compression." It is **artifacts
+as first-class objects, references as the handoff currency.**
+
+## Principle: filesystem is the store
+
+Claude Code's lesson is the relevant one: when a subagent needs to hand off
+non-trivial output, the simplest correct mechanism is **write a file, return
+the path**. No database, no serialization layer, no cross-process schema —
+the OS already provides atomic writes, listing, grep, content-addressing
+via the path namespace, and post-mortem inspection (you can `cat` the
+file).
+
+We adopt the same shape. Artifacts are files under
+`<cwd>/.agentm/artifacts/<root_session_id>/`. Tools read, write, list, and
+grep them. Provenance lives in a small `.meta.json` sidecar per artifact.
+There is no SQLite, no FTS, no ORM.
+
+This is also a hybrid memory architecture in the literature's vocabulary:
+
+- **Tier 1 — private**: each session's own message history (already exists).
+- **Tier 2 — team shared (this design)**: artifact directory, session-tree-scoped.
+- **Tier 3 — long-term**: cross-run vault (deferred to `evolution_substrate`).
+
+## Layout
+
+```
+<cwd>/.agentm/artifacts/<root_session_id>/
+├── art_001__topology__abnormal-call-graph.md
+├── art_001__topology__abnormal-call-graph.meta.json
+├── art_002__query_result__service-span-counts.md
+├── art_002__query_result__service-span-counts.meta.json
+├── art_003__finding__ts-auth-disappearance.md
+├── art_003__finding__ts-auth-disappearance.meta.json
+└── art_004__brief_rejection__missing-scope.md
+    ...
+```
+
+File-name structure: `<artifact_id>__<kind>__<slugified-title>.md`. The
+filename is itself a partial index — `ls .agentm/artifacts/<root>/ | grep
+__topology__` enumerates all topology artifacts without opening the
+sidecar files.
+
+The `.meta.json` carries the provenance:
+
+```json
+{
+  "artifact_id": "art_001",
+  "parent_id": null,
+  "kind": "topology",
+  "title": "Abnormal call graph (DOT format)",
+  "tags": ["scout", "round1"],
+  "parent_artifact_ids": [],
+  "created_by": {
+    "session_id": "sess_abc",
+    "task_id": "task_xyz",
+    "persona": "scout",
+    "timestamp": 1740000000.0
+  }
+}
+```
+
+The artifact body is a plain UTF-8 file. `.md` is the default extension
+because most artifacts are prose findings; binary artifacts are out of
+scope (text only, same as the original constraint).
+
+Append-only: the writer never modifies an existing file. Revisions are new
+artifacts that reference the predecessor via `parent_id`. Deletion is also
+out of scope — operators can `rm` the directory after the root session ends
+if retention pressure demands it.
+
+## Storage backend
+
+Plain filesystem. No database, no library dependency.
+
+- `artifact_id` allocation: monotonically incremented per root session,
+  zero-padded (`art_001`, `art_002`, ...). The store keeps a tiny
+  `.next_id` file in the directory; allocation is a read-modify-write under
+  a `fcntl.flock` (or asyncio lock — workers are in-process today).
+- Atomic writes: write to `<id>__<kind>__<slug>.md.tmp`, then `os.rename`
+  to the final name. POSIX rename is atomic; readers never see partial
+  files.
+- Listing: `os.scandir` of the directory.
+- Filtering by `kind`: filename prefix match (`art_*__topology__*.md`).
+- Searching by content: `re.search` over each candidate file's body. We
+  rely on the OS page cache; for the artifact volumes we expect (tens to
+  hundreds per session), a linear scan is fast enough. If a scenario ever
+  produces thousands, the user can `grep -l` from a shell — same shape.
+
+Cross-root sharing is not supported. Different root sessions get
+different directories.
+
+## Inheritability
+
+`artifact_store` registers as an inheritable extension in the same
+`available_inherited_extensions` map `sub_agent` already uses. When a
+parent dispatches a child, the child's `artifact_store` install reads the
+parent's `root_session_id` from the dispatch metadata and opens the
+**same directory**. All descendants of one root share one folder.
+
+This is the only piece of cross-session coupling. Everything else is
+read/write of files in a known directory.
+
+## Tools registered (one extension)
+
+A single new builtin: `extensions/builtin/artifact_store.py`. Tier 1
+(no permission). Inheritable into worker sessions.
+
+**`artifact_write({kind, title, body, tags?, parent_artifact_ids?}) -> {artifact_id, path}`**
+
+Append-only. Allocates the next id, writes body atomically to
+`<id>__<kind>__<slug>.md`, writes the sidecar. Provenance is captured
+automatically from the session context. Returns id and absolute path.
+
+**`artifact_read({artifact_id, range?}) -> {kind, title, created_by, body}`**
+
+Returns the content. **`range` parameter is mandatory in spirit, optional
+in syntax**:
+
+- omitted → returns body if it's under a per-call cap (default 8 KiB),
+  else returns the first 8 KiB plus a truncation marker with byte offsets
+  and a recommendation to call again with `range`.
+- `{lines: [start, end]}` → 1-indexed, end-inclusive line slice.
+- `{bytes: [start, end]}` → byte slice for non-line-oriented bodies.
+- `{head: N}` / `{tail: N}` → first/last N lines.
+
+Without bounded reads, an artifact system delays context bloat instead
+of preventing it; the cap is load-bearing.
+
+**`artifact_list({kind?, tags?, created_by_task?, since?, limit?}) -> {artifacts: [{id, kind, title, path, created_by, tags, size_bytes}]}`**
+
+Lightweight listing — no `body`. Filters by frontmatter fields. Default:
+latest 50, sorted by timestamp descending. Implementation reads
+`.meta.json` files; for typical session sizes (≤ a few hundred artifacts)
+this is microseconds.
+
+**`artifact_grep({pattern, kind?, tags?, max_hits?, snippet_lines?}) -> {hits: [{id, title, line_no, snippet}]}`**
+
+Linear regex scan over filtered artifacts. Returns matched lines with
+configurable surrounding context (default 2 lines each side). Bounded by
+`max_hits` (default 20) to prevent runaway results blowing context.
+
+The four-tool surface mirrors `tool_read` / `tool_grep` / `tool_ls` from
+the file-system world. Deliberately no `artifact_edit` / `artifact_delete`.
+
+## Worker return convention
+
+Combined with `sub_agent_lifecycle`, the notification block format is
+extended:
+
+```xml
+<subagent_result task_id="abc123" purpose="Map service topology">
+  <summary>Topology mapped. 5 services on abnormal chain. ts-auth absent
+  in abnormal period (was 30K spans normal); ts-verification-code took
+  its place (34K spans abnormal). Resource scan shows ts-route-service
+  CPU 6.5x normal.</summary>
+  <artifacts>
+    <ref id="art_001" kind="topology" title="Abnormal call graph (DOT format)" />
+    <ref id="art_002" kind="query_result" title="Service span counts (abnormal vs normal)" />
+    <ref id="art_003" kind="finding" title="ts-auth-service disappearance evidence" />
+  </artifacts>
+</subagent_result>
+```
+
+The orchestrator gets a tight summary plus a list of artifact references.
+To inspect any one in detail it calls `artifact_read(id, range=...)`.
+To enumerate everything a particular worker produced it calls
+`artifact_list(created_by_task=task_id)`.
+
+The `<summary>` is what the worker chose to highlight; the artifacts are
+what it actually produced. They can disagree, and the orchestrator
+resolves discrepancies by reading the artifact.
+
+## Persona file convention
+
+Worker personas (`agents/<name>.md`) gain an optional frontmatter field:
+
+```yaml
+artifact_kinds: [finding, query_result, trace]
+```
+
+Documented expectation only — no runtime enforcement. The persona body
+should reinforce in prose what kinds it produces.
+
+## Integration with sub_agent_lifecycle
+
+`_ChildTask` gains a fourth state field:
+
+```python
+@dataclass
+class _ChildTask:
+    ...
+    summary: str | None = None
+    artifact_ids: list[str] = field(default_factory=list)
+```
+
+When a worker calls `agent_end`:
+
+1. The harness extracts its final assistant message text → `summary`.
+2. The artifact directory is scanned for sidecars with
+   `created_by.task_id == task_id` → `artifact_ids`.
+3. `before_agent_end` (parent side) builds the notification block from
+   these two fields, not from the full `final_messages` history.
+
+If a worker writes zero artifacts, the block degrades to the
+`sub_agent_lifecycle.md` baseline (just `<summary>` text). If a worker
+writes artifacts but emits no final text, the block carries only
+`<artifacts>`. Both ends are graceful.
+
+## Failure modes addressed
+
+| Failure mode (literature) | Defense (this design) |
+|---|---|
+| Context loss at handoff | Worker's full work survives in artifact files; not compressed into final_text |
+| Cascade failure / context poisoning | Artifacts immutable; later workers cannot retroactively corrupt earlier ones |
+| Communication overhead (re-explain) | Workers read each other's artifacts directly, no orchestrator round-trip |
+| Summarization drift | Original artifacts persist alongside any summary that references them |
+| Supervisor context bloat | Notification block is summary + ids; bounded `artifact_read` prevents blow-up |
+| Inconsistent shared state | Append-only model; provenance lets later readers detect contradictions |
+
+What this design does **not** address:
+
+- Inter-agent disagreement / arbitration: still the orchestrator's job.
+- Long-running cross-session evolution: tier 3 / `evolution_substrate`.
+- Binary artifacts: out of scope (text only).
+- ACL / privacy: every session in the tree sees every artifact. Use a
+  separate root session for confidential work.
+- Garbage collection: operator-driven `rm -rf .agentm/artifacts/<old_root>/`.
+  Optional time-based sweep can be a follow-up.
+- Concurrent writers from multiple processes: today's `sub_agent` runs
+  children in-process, so an asyncio.Lock around id allocation suffices.
+  If we ever support out-of-process workers, swap in `fcntl.flock`.
+
+## Compatibility and migration
+
+- Backward compatible: scenarios that don't load `artifact_store` continue
+  to work exactly as today; sub_agent_lifecycle notification format
+  degrades gracefully when `artifact_ids` is empty.
+- The `inherit_extensions` mechanism already handles propagating into child
+  sessions.
+- Persona files without `artifact_kinds` frontmatter remain valid.
+- No data migration; the directory is created on first write.
+- Operator post-mortem: `cd .agentm/artifacts/<root>; ls; cat art_003*.md`
+  works without any tooling.
+
+## Effort estimate
+
+- `extensions/builtin/artifact_store.py`: ~150 lines (filesystem layer +
+  4 tools + MANIFEST + session-ready handler). Lower than the SQLite
+  version because there is no schema, no FTS5 fallback, no ORM.
+- `_ChildTask` extension in sub_agent: ~30 lines.
+- Notification block formatter update: ~20 lines in `sub_agent` itself.
+- rca scenario update: replace `update_hypothesis` / `remove_hypothesis`
+  with thin wrappers over `artifact_write(kind="hypothesis", ...)`,
+  preserving the existing tool API for compatibility.
+
+Total: roughly 200–250 lines of code plus this design doc.
+
+## Open questions
+
+1. **Sharing across root sessions.** RCA on dataset A and RCA on dataset B
+   today produce two independent root sessions. Should they share a
+   "RCA technique vault"? Probably yes, but as tier-3 evolution_substrate.
+
+2. **Artifact references in artifact bodies.** `body` is plain text. If a
+   worker writes "see art_002 for details" we are not enforcing the link
+   structurally — only via the explicit `parent_artifact_ids` field.
+   Tradeoff: enforcing creates a typed graph but pushes complexity into
+   tooling. Keep loose for v1.
+
+3. **Streaming artifacts.** A worker midway through a long query result
+   may want to commit a partial artifact. `artifact_write` is currently
+   one-shot. Streaming append would require a write-handle abstraction;
+   filesystem actually makes this trivial (open file in append mode), but
+   we defer until there is a concrete use case.
+
+4. **Slug collisions.** Two artifacts with title "Service span counts"
+   produce different ids but the same slug suffix; the id prefix
+   disambiguates the filename. No collision possible.

--- a/.claude/designs/sub-agent-lifecycle.md
+++ b/.claude/designs/sub-agent-lifecycle.md
@@ -1,0 +1,276 @@
+# Sub-Agent Lifecycle
+
+Status: design (not yet implemented)
+Owner: subagent + orchestration
+
+Reaches into: `core/abi/events.py`, `core/abi/loop.py`, `extensions/builtin/sub_agent.py`,
+`harness/events.py` (re-export only).
+
+## Problem
+
+`extensions/builtin/sub_agent.py` already lets a parent dispatch a child `AgentSession`
+via `dispatch_agent` and queries its status via `check_tasks`. The dispatch is
+asynchronous: `dispatch_agent` returns immediately with a `task_id`; the child runs in
+the background; results are not delivered to the parent unless the parent explicitly
+polls.
+
+Three concrete failure modes followed from this in the rca scenario:
+
+1. **Parent exits with unread findings.** The kernel terminates the loop the moment the
+   model emits a text-only response (`AgentLoop.run` line 327: empty `tool_calls` →
+   emit `agent_end`). If a child is still running or has just completed, its findings
+   are silently dropped and the child gets a 5-second grace before being aborted by
+   `_ChildTaskManager.on_session_shutdown`. The first rca trial showed this exactly: the
+   model dispatched three workers, said "Let me record the working hypothesis while
+   they run," and ended.
+
+2. **Polling burns the parent's turn budget.** Even when the model does poll, every
+   `check_tasks` call costs one parent LLM round-trip. With workers doing ten or twenty
+   tool calls of real investigation, the parent exhausts `LoopConfig.max_turns` (32)
+   waiting on no-op status snapshots. Second rca trial: 33 parent tool calls, 30 of them
+   `check_tasks` returning `running`, no progress on the actual hypothesis.
+
+3. **Findings are not retrievable.** Even after fixing the two above with a blocking
+   `check_tasks` and a hand-strengthened prompt, the original `check_tasks` payload
+   only returned `{task_id, status, error, final_message_count}` — no actual text from
+   the child. The parent had no API to reach into a completed child's output.
+
+The mechanical fix for (3) (add `final_text` to the payload, walked the child's last
+assistant message) and (2) (block-on-progress in `check_tasks`) ship today. The
+remaining structural problem is (1): an agent that asks a worker for help and then
+forgets to listen is a fragile contract.
+
+## Principle: runtime guards the boundary, agent owns the decision
+
+The decision of *when* to consume a child's findings is identical in shape to a Claude
+Code session deciding when to stop and ask its user. In both cases:
+
+- The reasoner (LLM) judges sufficiency, branching ambiguity, and commitment cost.
+- The runtime does not impose timing.
+- The runtime does enforce one floor: don't take an action whose unintended consequence
+  is irreversible. For Claude Code, that's "don't `git push --force` without auth."
+  For sub-agents, it is "don't `agent_end` while pending child findings are unread."
+
+The minimum-viable contract follows: the runtime guarantees that completed child
+findings reach the parent's message stream before the parent is allowed to terminate.
+Beyond that floor, *the parent decides*: it can keep working, it can synchronously
+wait, it can abort, or it can finalize.
+
+## Mechanism
+
+### One new core event
+
+`core.abi.events.BeforeAgentEndEvent`, mutable, fired immediately before
+`AgentLoop.run` declares `agent_end`:
+
+```python
+@dataclass(slots=True)
+class BeforeAgentEndEvent(Event):
+    """Fires after the LLM emits a text-only assistant turn but before the loop
+    declares ``agent_end``. Handlers may cancel the exit and append messages to
+    keep the loop alive for another turn.
+
+    Mutability: this event is intentionally **not frozen**. Handlers return either
+    ``None`` (allow exit) or ``{cancel: True, append: list[AgentMessage]}`` to
+    cancel the exit and inject one or more user-role messages into ``messages``
+    before the next turn begins. Multiple handlers may cancel; appended messages
+    are concatenated in handler-registration order.
+    """
+
+    messages: list[AgentMessage]   # the live history; do not mutate in-place
+    stop_reason: Literal["end_turn", "max_turns"]
+```
+
+`AgentLoop.run` change is roughly ten lines: when the assistant message has no
+tool-use blocks, emit `before_agent_end` first; if any handler returned
+`{cancel: True, append}`, append the messages and continue the loop instead of
+firing `agent_end`. `max_turns` is still respected — handlers cannot extend the
+budget; only the natural `end_turn` path is interceptable.
+
+### `sub_agent` extension uses the hook to enforce the floor
+
+`_ChildTaskManager` already tracks `running` / `completed` / `aborted` / `error` per
+task. We add a `read` flag (default false) flipped when the parent has consumed a
+task's `final_text`, plus a single `before_agent_end` handler:
+
+```
+on before_agent_end(messages, stop_reason):
+    pending  = tasks where status in {completed, error, aborted} and not read
+    running  = tasks where status == running
+
+    if not pending and not running:
+        return None                        # allow exit
+
+    notification_blocks = []
+
+    for task in pending:
+        notification_blocks.append(format_completed(task))
+        task.read = True
+
+    for task in running:
+        notification_blocks.append(format_pending(task))
+
+    if not notification_blocks:
+        return None
+
+    return {
+        "cancel": True,
+        "append": [user_message(notification_blocks)],
+    }
+```
+
+Two structured XML-ish blocks per task. They live inside one synthesized user
+message so the kernel sees them as a single conversational turn:
+
+```xml
+<subagent_result task_id="abc123" purpose="Map service topology">
+... worker's final text ...
+</subagent_result>
+
+<subagent_pending task_id="def456" purpose="Forensic on ts-auth-service" />
+```
+
+The parent is now woken up with: completed siblings' findings as plain content,
+plus a list of still-running children for it to decide about. The next LLM call
+sees them in the message history; it picks: write the final report (ignore
+pending), call `wait_subagent(task_id)` to block on a specific one,
+call `check_tasks` to block until any one progresses, or `abort_task` to kill.
+
+### `check_tasks` and `wait_subagent` are explicit waits
+
+Both are tools the LLM may call *during* the loop, when it knows it needs the
+answer to make the next move. Distinct from the `before_agent_end` floor, which
+fires unconditionally.
+
+- `check_tasks()` blocks until at least one running child changes state (already
+  implemented as part of (2)). Returns the full table with `final_text` for
+  completed entries; flips their `read` flag.
+- `wait_subagent(task_id)` blocks until that specific child reaches a terminal
+  state. Returns the same shape as one row of `check_tasks`. Flips `read`.
+
+There is no separate "pop result" tool. Reading via `check_tasks` /
+`wait_subagent` consumes the read flag the same way `before_agent_end` does;
+findings cannot be delivered twice.
+
+### `dispatch_agent` is unchanged
+
+It remains async and returns `{task_id, status: running, purpose}` immediately.
+Already supports `subagent_type` resolution against persona files. The contract
+"dispatch and forget — runtime delivers" is the new capability; the tool itself
+needs no signature change.
+
+## Three usage patterns, one mechanism
+
+| Pattern             | What the LLM does                              | What the runtime does                                                                  |
+|---------------------|------------------------------------------------|-----------------------------------------------------------------------------------------|
+| Fire and forget     | Dispatch, then continue with own SQL / notes    | At end of turn-stream, `before_agent_end` injects every completed child's `final_text` |
+| Explicit wait       | Dispatch, next turn `wait_subagent(id)`         | Blocks the tool call; returns final text on completion                                  |
+| Steered fan-out     | Dispatch N, loop `check_tasks` reading as ready | Each `check_tasks` blocks until one more makes progress; `inject_instruction` to steer  |
+
+The same `_ChildTaskManager` registry, the same `read` flag, the same
+notification format. No mode switch.
+
+## State machine
+
+```
+running ──(child finishes normally)──> completed (read=False)
+running ──(child raises)──────────────> error     (read=False)
+running ──(parent abort_task)─────────> aborted   (read=False)
+
+(any terminal, read=False) ──(check_tasks / wait_subagent / before_agent_end)──> read=True
+```
+
+The `read` flag is the single source of truth. It is never reset; once a task's
+findings have been delivered to the parent, they will not be redelivered.
+
+## Failure modes and edge cases
+
+- **Repeated `before_agent_end` cancels.** If the parent emits text after
+  consuming notifications and tries to end again, `before_agent_end` fires
+  again. Pending now empty (we just flipped them read), running may still
+  hold workers. The risk is a cancel-loop: LLM trained to not repeat itself
+  emits empty text → handler cancels → next turn LLM emits empty text again →
+  same cancel.
+  Decision: the LLM gets **one** "still-running notice" cancel. The
+  `_ChildTaskManager` keeps a `_running_only_cancels: int` counter,
+  incremented when the handler cancels solely because of running-no-pending,
+  reset to zero when the parent does anything else (tool call, non-empty
+  text). When the counter would hit 2, the handler instead **auto-aborts
+  every running child** (calling `abort_task` for each), waits for their
+  finalizers (bounded by the existing 5s grace), records aborted summaries
+  via the same notification block, and **does not cancel** — the loop exits.
+  This makes "agent gives up on pending workers" reachable in finite turns
+  without a new tool, and turns the ambiguous second cancel into an explicit,
+  loud abort visible in trajectory.
+
+- **`max_turns` reached.** `before_agent_end.stop_reason == "max_turns"`. The
+  hook still fires so findings are not silently lost, but the loop terminates
+  after handler runs regardless of `cancel`. Equivalent to "you ran out of
+  budget; here's what your workers had said." The handler still flips `read`.
+
+- **Child crashes during dispatch.** `_run_child` catches and sets
+  `status=error, error=<str>`. `before_agent_end` reports it like any other
+  terminal state; the parent decides whether to retry or skip.
+
+- **Parent shutdown with running children.** Existing
+  `on_session_shutdown` grace logic (5 s) is unchanged. `before_agent_end` runs
+  before shutdown, so well-behaved sessions never reach the grace cutoff with
+  unread completions.
+
+- **Two extensions both want to cancel `agent_end`.** `cost_budget` (e.g.) might
+  later use the same hook. Multiple handlers' appends are concatenated; the
+  kernel checks `cancel` as `any(handler returned cancel=True)`. Order is
+  registration order — same as every other event. No special arbitration.
+
+- **Dispatch from inside a child.** Allowed today (each session has its own
+  sub_agent install). Each manager only sees its own children. Nested cancels
+  follow the same rules at each level.
+
+- **Handler raises.** EventBus already swallows handler exceptions (logs;
+  contributes `None`). A buggy handler cannot prevent loop termination — the
+  same fail-open behavior as every other event channel.
+
+## What is *not* in this design
+
+- **Auto-sleep / polling cadence.** No timers, no exponential backoff. The
+  registry's terminal-state notifications are inherently
+  edge-triggered through `_run_child.finalize` → `_ChildTask.task` future.
+  `check_tasks` / `wait_subagent` await directly on those futures.
+
+- **Re-delivery / dead-letter.** A finding consumed by `before_agent_end` and
+  not actually attended to by the LLM is on the agent — exactly as a user-side
+  message that gets ignored is on the agent.
+
+- **Synchronous dispatch.** Considered (Claude Code shape); rejected because
+  AgentM's kernel runs `tool_calls` sequentially (`loop.py:340 for tc in
+  tool_calls`), so synchronous dispatch would lose parallel fan-out without
+  also adding parallel tool execution. Kept as a follow-up if and when the
+  kernel grows that primitive.
+
+- **Cross-extension result routing.** The notification block is a literal
+  user-role message. Extensions that want richer routing (e.g. inject only
+  into a specific tool_use_id's apparent tool_result) are not supported;
+  Anthropic's tool_use → tool_result pairing forbids late binding to a
+  pre-existing id.
+
+## Compatibility and migration
+
+- `dispatch_agent` signature unchanged.
+- `check_tasks` payload gains `final_text` (already shipping); blocking
+  semantics now load-bearing rather than optional. Tests that asserted
+  immediate return must adapt.
+- `inject_instruction`, `abort_task` unchanged.
+- `BeforeAgentEndEvent` is additive — extensions that don't register a
+  handler observe today's behavior.
+- `LoopConfig.max_turns` semantics unchanged. The hook does not bypass it.
+- Scenario manifests do not need to opt in. Loading `sub_agent` enables the
+  hook automatically.
+
+## Effort estimate
+
+- core: `BeforeAgentEndEvent` + ten lines in `AgentLoop.run`
+- `sub_agent`: ~50 lines (read flag + handler + `wait_subagent` tool)
+- prompt updates: trim rca/orchestrator.md polling section to match the new
+  pattern table
+
+Total: roughly 100–150 lines of code plus this design doc. No data migration.

--- a/.claude/index.yaml
+++ b/.claude/index.yaml
@@ -113,6 +113,27 @@ concepts:
     plans: ["plans/2026-05-01-pi-mono-migration.md"]
     tasks: []
 
+  sub_agent_lifecycle:
+    description: "Async sub-agent dispatch lifecycle: parent's kernel loop must not declare agent_end while a child has unread findings. Adds a single new core event BeforeAgentEndEvent (mutable; handlers return {cancel: True, append: list[AgentMessage]}) fired in AgentLoop.run when an assistant turn has no tool_use blocks. The sub_agent extension uses it as a 'runtime guards the boundary, agent owns the decision' floor: completed-but-unread children's final_text plus still-running children are concatenated into one synthesized user-role notification (<subagent_result task_id=... purpose=...>...</subagent_result> + <subagent_pending task_id=... purpose=... />). The parent then chooses: write final report, wait_subagent(id) to block on one, check_tasks to block until any one progresses, or abort_task. Single read flag per task is the source of truth (never reset; consumed by check_tasks / wait_subagent / before_agent_end). Three usage patterns share one mechanism — fire-and-forget (passive collection at exit), explicit wait (synchronous wait_subagent), steered fan-out (loop check_tasks reading as ready). Rejects synchronous dispatch (would lose parallel fan-out absent kernel-level parallel tool execution) and dead-letter / re-delivery (consumed-but-unattended findings are on the agent, same as ignored user messages). max_turns still strictly enforced; cost_budget and other extensions can layer on the same hook."
+    design: "designs/sub-agent-lifecycle.md"
+    related_concepts: [pluggable_architecture, extension_as_scenario, single_file_extension_contract, artifact_system, agent_team]
+    plans: []
+    tasks: []
+
+  artifact_system:
+    description: "Append-only typed artifact store for sub-agent findings — replaces lossy 'final_text blob' handoff with reference-based handoff. New extensions/builtin/artifact_store.py registers four tools (artifact_write, artifact_read, artifact_list, artifact_grep) backed by sqlite at <cwd>/.agentm/artifacts/<root_session_id>.db. Session-tree-scoped: every descendant of a root session shares one db; cross-root sharing deferred to evolution_substrate / git_backed_versioning. Data model: Artifact{artifact_id, parent_id, kind, title, body, created_by: ProvenanceRef{session_id, task_id, persona, timestamp}, tags, parent_artifact_ids}. Append-only by design — no artifact_edit / artifact_delete; revisions create new artifacts referencing predecessors. Integrates with sub_agent_lifecycle's notification block: workers return <summary>...</summary> + <artifacts><ref id=... kind=... title=.../></artifacts> instead of full final_text dump, so orchestrator context grows logarithmically rather than linearly with worker count. Personas declare expected artifact_kinds in frontmatter as documentation. Maps to MAST failure-mode taxonomy: defends context-loss-at-handoff, cascade context poisoning, supervisor context bloat, summarization drift, inconsistent shared state. Out of scope: binary artifacts, ACL beyond session-tree, transactional updates, reference-counted GC (uses time-based retention)."
+    design: "designs/artifact-system.md"
+    related_concepts: [sub_agent_lifecycle, agent_team, evolution_substrate, pluggable_architecture, single_file_extension_contract]
+    plans: []
+    tasks: []
+
+  agent_team:
+    description: "Composition pattern for multi-agent scenarios — explicitly NOT a Team SDK type, NOT a runtime mode switch. Built on four orthogonal pillars: (A) lifecycle floor from sub_agent_lifecycle, (B) shared memory tier from artifact_system, (C) brief contract via persona frontmatter input_schema (required/optional field-name list; sub_agent dispatch validates the prompt for <field>...</field> markers and rejects on missing required fields with structured error), (D) budget awareness via per-dispatch budget arg + scenario manifest team_profile (task_complexity: simple|comparison|deep_research → derived defaults for max_workers and per-worker max_tool_calls). Each pillar maps to specific named failure modes from the multi-agent literature (MAST taxonomy, Anthropic research-system lessons): context loss, cascade poisoning, supervisor context bloat, scope misinterpretation, token over/under-spend, etc. Core insight 'there is no mode switch': dispatch_agent + artifact_* + wait_subagent are always-loaded capabilities; LLM decides per-task whether to fan out, cache to artifacts, etc. — same shape as Claude Code's Agent tool. Runtime extension loading (api.reload_atom from self_modifiable_architecture) is orthogonal — for acquiring NEW capabilities mid-flight, not for switching team mode. Rejected: first-class Team type, peer-to-peer dispatch (orchestrator-only convention), built-in voting/arbitration (LLM does it), output schema enforcement (deferred), adaptive budget escalation. Persona frontmatter gains: input_schema, artifact_kinds, budget_defaults. Manifest gains: team_profile.task_complexity. All additions opt-in; existing scenarios continue to work."
+    design: "designs/agent-team.md"
+    related_concepts: [sub_agent_lifecycle, artifact_system, self_modifiable_architecture, extension_as_scenario, pluggable_architecture, single_file_extension_contract]
+    plans: []
+    tasks: []
+
   # === HISTORICAL ===
   # Pre-v2 architecture. Code deleted in Phase 2.5 (2026-04-30).
   # Designs preserved under designs/historical/ for archival reference only.


### PR DESCRIPTION
## Summary
- Add three coordinated design docs (`sub-agent-lifecycle.md`, `artifact-system.md`, `agent-team.md`) that together specify team-mode capability for AgentM
- Update `.claude/index.yaml` with 3 new concepts and cross-references (48 total)
- Implementation tracked in #57 → #58 → #59

These docs need to land on `main` so the open issues can reference them.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.claude/index.yaml'))"` parses
- [x] No code changes — pure documentation PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)