### PR TITLE
Fix atom reloader fail-stop paths

### DIFF
--- a/.claude/designs/self-modifiable-architecture.md
+++ b/.claude/designs/self-modifiable-architecture.md
@@ -240,9 +240,11 @@ agent calls api.reload_atom(name, new_source)
 
 Key properties:
 - **Atomicity**: validator runs *before* any file is written. The agent never sees a half-validated state.
-- **Reversibility**: every reload freezes the previous source; rollback is mechanical, not LLM-driven.
+- **Reversibility**: every reload freezes the previous source; rollback is mechanical, not LLM-driven. If installing the new source fails and rollback activation also fails, the in-memory loaded-atom registries keep the previously live `LoadedAtom` instead of purging the operational state; the failure is surfaced as `rollback_failure_state_preserved`.
 - **Auditability**: success and failure both produce catalog records (sister doc §6).
 - **Stale-ctx safety**: the old `install(api, ...)` closures invalidate via `assert_active()` (§6 below).
+- **Async boundary discipline**: reload/install/freeze are native async in the reloader; synchronous ExtensionAPI facades are only API-boundary adapters.
+- **Lifecycle symmetry**: harness-owned EventBus subscriptions registered by the reloader are explicitly unsubscribed during `AgentSession.shutdown()` before the bus is cleared.
 
 ### 5.2 What `freeze_current` does
 

--- a/.claude/index.yaml
+++ b/.claude/index.yaml
@@ -24,7 +24,7 @@ concepts:
     design: "designs/self-modifiable-architecture.md"
     related_concepts: [pluggable_architecture, extension_as_scenario, single_file_extension_contract, observability, evolution_substrate, git_backed_versioning]
     plans: []
-    tasks: []
+    tasks: ["tasks/2026-05-09-issue-79-atom-reloader-hardening.md"]
 
   evolution_substrate:
     description: "Constitution-owned data layer that binds every (atom, scenario) version to all observation data generated under it, so rollback / composition / optimization become evidence-driven, not error-driven. Adds .agentm/catalog/{atoms,scenarios}/<hash>/ with frozen source + manifest.yaml + metrics.jsonl + runs/ + decisions.jsonl. Active-set fingerprint in every observability session.start header binds traces to the exact loaded version set. Indexer (constitution-layer, idempotent, rebuildable from raw observability) aggregates per-(atom_hash, scenario, task_type) statistics. tool_catalog atom (tier-1 read API + propose_change as the only mediated write) exposes list_versions / get_manifest / compare / find_best / runs_for / decisions_for / propose_change to the agent. Hard problems addressed: statistical power (CI + inconclusive enforcement), confounding (experiment-mode lock), Goodhart (universal guard metrics + regressed flag), replayability (LLM response cache, Phase 3), catalog corruption (constitution-layer write-protect on .agentm/catalog/**). Phased: MVP = fingerprint + freeze + browse; Phase 2 = compare + decisions; Phase 3 = replay cache + experiment lock."

--- a/.claude/tasks/2026-05-09-issue-79-atom-reloader-hardening.md
+++ b/.claude/tasks/2026-05-09-issue-79-atom-reloader-hardening.md
@@ -1,0 +1,8 @@
+# Issue 79 Atom Reloader Hardening
+
+Status: implemented and tested
+
+- Preserved previous `LoadedAtom` registry entries when rollback activation fails after a reload install failure.
+- Replaced per-call coroutine bridge loops with native async reload/install/freeze implementations and sync API-boundary facades.
+- Added `AtomReloader.shutdown()` for reloader-owned EventBus subscriptions and wired `AgentSession.shutdown()` to call it before clearing the bus.
+- Added typed `LoadedAtom.import_kind` and uniform `owners_by_kind` registration ownership tracking.

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1,0 +1,21 @@
+requirements:
+  - id: REQ-079-atom-reloader-fail-stop
+    title: Atom reloader fail-stop hardening
+    description: >
+      Atom reload must preserve the previous live atom state when rollback also
+      fails, use native async reload/install/freeze boundaries, unregister
+      reloader-owned bus subscriptions during session shutdown, and track atom
+      registration ownership uniformly by kind.
+    priority: P0
+    status: tested
+    confidence: confirmed
+    code:
+      - path: src/agentm/harness/atom_reloader.py
+      - path: src/agentm/harness/session.py
+    tests:
+      - path: tests/integration/test_cli_observability_reload.py
+      - path: tests/unit/harness/test_transactional_reload.py
+    docs:
+      - path: .claude/designs/self-modifiable-architecture.md
+      - path: .claude/tasks/2026-05-09-issue-79-atom-reloader-hardening.md
+    depends_on: []

--- a/src/agentm/harness/atom_reloader.py
+++ b/src/agentm/harness/atom_reloader.py
@@ -41,7 +41,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from agentm.core._internal.catalog.hashing import compute_atom_hash
 from agentm.core._internal.catalog.manifest import is_constitution_path
@@ -84,6 +84,7 @@ class LoadedAtom:
     config: dict[str, Any]
     manifest: ExtensionManifest | None
     is_provider: bool = False
+    import_kind: Literal["module", "synthetic"] = "module"
 
 
 def _default_manifest(name: str) -> ExtensionManifest:
@@ -138,10 +139,13 @@ class AtomReloader:
         self._registrations_by_atom: dict[
             str, list[tuple[str, str, Any]]
         ] = {}
-        self._command_owners: dict[str, str] = {}
+        self.owners_by_kind: dict[str, dict[str, str]] = {}
+        self._subscription_unsubs: list[Callable[[], None]] = [
+            bus.on(ApiRegisterEvent.CHANNEL, self._track_registration)
+        ]
         self._api_factory: Callable[[str], _ExtensionAPIImpl] | None = None
-
-        bus.on(ApiRegisterEvent.CHANNEL, self._track_registration)
+        self._sync_loop: asyncio.AbstractEventLoop | None = None
+        self._sync_loop_thread: threading.Thread | None = None
 
     # --- Lifecycle wiring --------------------------------------------------
 
@@ -166,9 +170,16 @@ class AtomReloader:
     def loaded_by_name(self) -> dict[str, LoadedAtom]:
         return self._loaded_by_name
 
-    @property
-    def command_owners(self) -> dict[str, str]:
-        return self._command_owners
+    def shutdown(self) -> None:
+        for unsub in self._subscription_unsubs:
+            unsub()
+        self._subscription_unsubs.clear()
+        if self._sync_loop is not None:
+            self._sync_loop.call_soon_threadsafe(self._sync_loop.stop)
+        if self._sync_loop_thread is not None:
+            self._sync_loop_thread.join(timeout=1)
+        self._sync_loop = None
+        self._sync_loop_thread = None
 
     # --- Subscription tracking (called from ExtensionAPI.on / register) ----
 
@@ -201,8 +212,7 @@ class AtomReloader:
         self._registrations_by_atom.setdefault(event.extension, []).append(
             (event.kind, event.name, event.payload)
         )
-        if event.kind == "command":
-            self._command_owners[event.name] = event.extension
+        self.owners_by_kind.setdefault(event.kind, {})[event.name] = event.extension
 
     # --- Atom registry mutation -------------------------------------------
 
@@ -219,6 +229,12 @@ class AtomReloader:
             Path(module_file).resolve() if module_file else Path(".")
         )
         manifest = _module_manifest(module)
+        import_kind: Literal["module", "synthetic"] = (
+            "synthetic"
+            if module_path.startswith(discover_mod.USER_ATOM_MODULE_PREFIX)
+            or module_path.startswith(discover_mod.CONTRIB_ATOM_MODULE_PREFIX)
+            else "module"
+        )
         atom = LoadedAtom(
             name=_module_name(module_path, module),
             module_path=module_path,
@@ -226,6 +242,7 @@ class AtomReloader:
             config=dict(ext_cfg),
             manifest=manifest,
             is_provider=is_provider,
+            import_kind=import_kind,
         )
         self._loaded_by_module[module_path] = atom
         self._loaded_by_name[atom.name] = atom
@@ -245,8 +262,6 @@ class AtomReloader:
             elif kind == "command":
                 if self._commands.get(name) is payload:
                     self._commands.pop(name, None)
-                if self._command_owners.get(name) == owner:
-                    self._command_owners.pop(name, None)
             elif kind == "provider":
                 if self._providers.get(name) is payload:
                     self._providers.pop(name, None)
@@ -254,6 +269,8 @@ class AtomReloader:
             elif kind == "renderer":
                 if self._renderers.get(name) is payload:
                     self._renderers.pop(name, None)
+            if self.owners_by_kind.setdefault(kind, {}).get(name) == owner:
+                self.owners_by_kind[kind].pop(name, None)
 
     @staticmethod
     def _clear_module_bytecode(path: Path) -> None:
@@ -347,73 +364,53 @@ class AtomReloader:
             return manifest
 
     @staticmethod
-    def _finish_install_sync(
+    async def _finish_install(
         module_path: str,
         api: _ExtensionAPIImpl,
         ext_cfg: dict[str, Any],
     ) -> None:
-        """Run ``install(api, config)`` synchronously, awaiting if needed.
-
-        Reload happens from a synchronous call site (the agent's
-        ``api.reload_atom`` doesn't ``await``), but ``install`` itself can
-        be ``async``. We bounce into a fresh event loop on a worker thread
-        rather than mixing loops on the calling thread.
-        """
         result = load_extension(module_path, api, ext_cfg)
-        if not inspect.isawaitable(result):
-            return
+        if inspect.isawaitable(result):
+            await result
 
-        error: list[BaseException] = []
+    def _run_api_boundary(self, coro: Any) -> Any:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        loop = self._ensure_sync_loop()
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
-        def _runner() -> None:
-            async def _await_result() -> None:
-                await result
+    def _ensure_sync_loop(self) -> asyncio.AbstractEventLoop:
+        if self._sync_loop is not None and self._sync_loop.is_running():
+            return self._sync_loop
 
-            try:
-                asyncio.run(_await_result())
-            except BaseException as exc:  # pragma: no cover - exercised in caller
-                error.append(exc)
-
-        thread = threading.Thread(
-            target=_runner,
-            name=f"agentm-reload-{module_path.rsplit('.', 1)[-1]}",
-        )
-        thread.start()
-        thread.join()
-        if error:
-            raise error[0]
-
-    @staticmethod
-    def _run_coro_sync(coro: Any) -> Any:
-        """Await a coroutine from sync code, even if an event loop is active."""
-
-        result: list[Any] = []
-        error: list[BaseException] = []
+        ready = threading.Event()
 
         def _runner() -> None:
-            try:
-                result.append(asyncio.run(coro))
-            except BaseException as exc:  # pragma: no cover - exercised via caller
-                error.append(exc)
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._sync_loop = loop
+            ready.set()
+            loop.run_forever()
+            loop.close()
 
-        thread = threading.Thread(
+        self._sync_loop_thread = threading.Thread(
             target=_runner,
-            name="agentm-reload-async-bridge",
+            name="agentm-reloader-sync-loop",
+            daemon=True,
         )
-        thread.start()
-        thread.join()
-        if error:
-            raise error[0]
-        return result[0]
+        self._sync_loop_thread.start()
+        ready.wait()
+        assert self._sync_loop is not None
+        return self._sync_loop
 
-    def _activate_atom_install(self, atom: LoadedAtom) -> None:
+    async def _activate_atom_install(self, atom: LoadedAtom) -> None:
         if self._api_factory is None:
             raise RuntimeError(
                 "AtomReloader.set_api_factory must be called before reload_atom"
             )
         previous_api = self._apis.get(atom.module_path)
-        if previous_api is not None:
-            previous_api.mark_stale()
         # Capture per-channel rank BEFORE removal so reload can restore the
         # atom to its original slot. Without this, every reload silently
         # appends new handlers to the end of each channel's list, which
@@ -429,17 +426,19 @@ class AtomReloader:
         # have no package finder — once popped from ``sys.modules`` a plain
         # ``importlib.import_module`` cannot rediscover them. Re-establish
         # the sys.modules entry from the on-disk file before delegating to
-        # ``_finish_install_sync``; ``load_extension`` will then hit the
+        # ``_finish_install``; ``load_extension`` will then hit the
         # populated cache. Builtin atoms keep their normal import-finder
         # path: they aren't synthetic, so this branch is skipped and
         # ``import_module`` resolves them via ``sys.path`` as before.
-        if atom.module_path.startswith(self._AGENT_ATOM_MODULE_PREFIX):
+        if atom.import_kind == "synthetic":
             self._import_synthetic_module(atom.module_path, atom.file_path)
-        self._finish_install_sync(
+        await self._finish_install(
             atom.module_path,
             self._api_factory(atom.module_path),
             dict(atom.config),
         )
+        if previous_api is not None:
+            previous_api.mark_stale()
         self.record_loaded_atom(
             atom.module_path,
             atom.config,
@@ -519,6 +518,23 @@ class AtomReloader:
         agent_initiated: bool = True,
         rationale: str | None = None,
     ) -> ReloadResult:
+        return self._run_api_boundary(
+            self.reload_atom_async(
+                name,
+                new_source,
+                agent_initiated=agent_initiated,
+                rationale=rationale,
+            )
+        )
+
+    async def reload_atom_async(
+        self,
+        name: str,
+        new_source: str,
+        *,
+        agent_initiated: bool = True,
+        rationale: str | None = None,
+    ) -> ReloadResult:
         if self._api_factory is None:
             raise RuntimeError(
                 "AtomReloader.set_api_factory must be called before reload_atom"
@@ -572,13 +588,11 @@ class AtomReloader:
                 new_hash=None,
                 error=str(exc),
             )
-        write_result = self._run_coro_sync(
-            self._resource_writer.write(
-                str(atom.file_path),
-                new_source.encode("utf-8"),
-                rationale=rationale or f"reload {name}",
-                author="agent" if agent_initiated else "human",
-            )
+        write_result = await self._resource_writer.write(
+            str(atom.file_path),
+            new_source.encode("utf-8"),
+            rationale=rationale or f"reload {name}",
+            author="agent" if agent_initiated else "human",
         )
         if write_result.error is not None:
             return ReloadResult(
@@ -597,15 +611,38 @@ class AtomReloader:
         if advisory_mode:
             old_hash = self._advisory_hash(current_source)
             new_hash = self._advisory_hash(new_source)
+        event_new_hash = new_hash or self._advisory_hash(new_source)
+        previous_api = self._apis.get(atom.module_path)
+        previous_module = sys.modules.get(atom.module_path)
+        previous_tools = list(self._tools)
+        previous_commands = dict(self._commands)
+        previous_providers = dict(self._providers)
+        previous_renderers = dict(self._renderers)
+        previous_registrations = {
+            owner: list(registrations)
+            for owner, registrations in self._registrations_by_atom.items()
+        }
+        previous_handlers = {
+            owner: list(unsubs)
+            for owner, unsubs in self._handlers_by_atom.items()
+        }
+        previous_owners_by_kind = {
+            kind: dict(owners)
+            for kind, owners in self.owners_by_kind.items()
+        }
+        previous_subscriptions = {
+            channel: self._bus.subscriptions_for(channel)
+            for channel in self._bus.channels()
+        }
 
         try:
-            self._activate_atom_install(atom)
+            await self._activate_atom_install(atom)
             self._bus.emit_sync(
                 ExtensionReloadEvent.CHANNEL,
                 ExtensionReloadEvent(
                     name=name,
                     old_hash=old_hash,
-                    new_hash=new_hash,
+                    new_hash=event_new_hash,
                     trigger="agent" if agent_initiated else "human",
                     tier=effective_manifest.tier,
                 ),
@@ -631,20 +668,38 @@ class AtomReloader:
                     os.replace(rollback_tmp_name, atom.file_path)
                 elif write_result.commit_sha_before is not None:
                     self._restore_git_path(atom, write_result.commit_sha_before)
-                self._activate_atom_install(atom)
+                await self._activate_atom_install(atom)
             except Exception as rollback_exc:  # noqa: BLE001
-                self._loaded_by_module.pop(atom.module_path, None)
-                self._loaded_by_name.pop(atom.name, None)
-                self._apis.pop(atom.module_path, None)
+                for channel in self._bus.channels():
+                    if channel not in previous_subscriptions:
+                        self._bus.replace_subscriptions(channel, [])
+                for channel, subscriptions in previous_subscriptions.items():
+                    self._bus.replace_subscriptions(channel, list(subscriptions))
+                self._tools[:] = previous_tools
+                self._commands.clear()
+                self._commands.update(previous_commands)
+                self._providers.clear()
+                self._providers.update(previous_providers)
+                self._renderers.clear()
+                self._renderers.update(previous_renderers)
+                self._registrations_by_atom = previous_registrations
+                self._handlers_by_atom = previous_handlers
+                self.owners_by_kind = previous_owners_by_kind
+                self._loaded_by_module[atom.module_path] = atom
+                self._loaded_by_name[atom.name] = atom
+                if previous_api is not None:
+                    self._apis[atom.module_path] = previous_api
+                if previous_module is not None:
+                    sys.modules[atom.module_path] = previous_module
                 self._bus.emit_sync(
                     ExtensionReloadEvent.CHANNEL,
                     ExtensionReloadEvent(
                         name=name,
                         old_hash=old_hash,
-                        new_hash=new_hash,
+                        new_hash=event_new_hash,
                         trigger="agent" if agent_initiated else "human",
                         tier=effective_manifest.tier,
-                        error="rollback_failure",
+                        error="rollback_failure_state_preserved",
                     ),
                 )
                 return ReloadResult(
@@ -652,7 +707,10 @@ class AtomReloader:
                     name=name,
                     old_hash=old_hash,
                     new_hash=new_hash,
-                    error=f"{exc}; rollback failed: {rollback_exc}",
+                    error=(
+                        f"rollback_failure_state_preserved: {exc}; "
+                        f"rollback failed: {rollback_exc}"
+                    ),
                     rolled_back=True,
                 )
             return ReloadResult(
@@ -665,15 +723,16 @@ class AtomReloader:
             )
 
     def freeze_current(self, name: str) -> str:
+        return self._run_api_boundary(self.freeze_current_async(name))
+
+    async def freeze_current_async(self, name: str) -> str:
         atom = self._loaded_by_name[name]
         source = atom.file_path.read_text(encoding="utf-8")
-        result = self._run_coro_sync(
-            self._resource_writer.write(
-                str(atom.file_path),
-                source.encode("utf-8"),
-                rationale="freeze_current snapshot",
-                author="indexer",
-            )
+        result = await self._resource_writer.write(
+            str(atom.file_path),
+            source.encode("utf-8"),
+            rationale="freeze_current snapshot",
+            author="indexer",
         )
         if result.error is not None:
             raise RuntimeError(result.error)
@@ -729,9 +788,28 @@ class AtomReloader:
     # (no accidental shadowing of builtin atoms) and lets us discard it
     # cleanly on unload.
 
-    _AGENT_ATOM_MODULE_PREFIX = "_agentm_user_atom__"
-
     def install_atom(
+        self,
+        *,
+        name: str,
+        source: str,
+        target_path: str | None,
+        config: dict[str, Any] | None,
+        rationale: str | None,
+        agent_initiated: bool,
+    ) -> InstallAtomResult:
+        return self._run_api_boundary(
+            self.install_atom_async(
+                name=name,
+                source=source,
+                target_path=target_path,
+                config=config,
+                rationale=rationale,
+                agent_initiated=agent_initiated,
+            )
+        )
+
+    async def install_atom_async(
         self,
         *,
         name: str,
@@ -767,7 +845,7 @@ class AtomReloader:
             )
 
         ext_cfg = dict(config or {})
-        module_path = f"{self._AGENT_ATOM_MODULE_PREFIX}{name}"
+        module_path = f"{discover_mod.USER_ATOM_MODULE_PREFIX}{name}"
 
         target_file = self._resolve_install_target(name, target_path)
         if is_constitution_path(str(target_file)):
@@ -838,13 +916,11 @@ class AtomReloader:
 
         file_existed = target_file.exists()
         target_file.parent.mkdir(parents=True, exist_ok=True)
-        write_result = self._run_coro_sync(
-            self._resource_writer.write(
-                str(target_file),
-                source.encode("utf-8"),
-                rationale=rationale or f"install atom {name}",
-                author="agent" if agent_initiated else "human",
-            )
+        write_result = await self._resource_writer.write(
+            str(target_file),
+            source.encode("utf-8"),
+            rationale=rationale or f"install atom {name}",
+            author="agent" if agent_initiated else "human",
         )
         if write_result.error is not None:
             return InstallAtomResult(
@@ -891,7 +967,7 @@ class AtomReloader:
 
         try:
             api = self._api_factory(module_path)
-            self._finish_install_sync(module_path, api, ext_cfg)
+            await self._finish_install(module_path, api, ext_cfg)
         except Exception as exc:  # noqa: BLE001
             self._remove_handlers(module_path)
             self._remove_registrations(module_path)

--- a/src/agentm/harness/session.py
+++ b/src/agentm/harness/session.py
@@ -268,8 +268,8 @@ class AgentSession:
         return self._reloader.loaded_by_name
 
     @property
-    def _command_owners(self) -> dict[str, str]:
-        return self._reloader.command_owners
+    def _owners_by_kind(self) -> dict[str, dict[str, str]]:
+        return self._reloader.owners_by_kind
 
     # --- Construction -----------------------------------------------------
 
@@ -950,7 +950,7 @@ class AgentSession:
             return text, None
         cmd = self._commands.get(head)
         if cmd is not None:
-            owner = self._command_owners.get(head)
+            owner = self._owners_by_kind.setdefault("command", {}).get(head)
             api = self._apis[owner] if owner is not None else next(iter(self._apis.values()))
             stripped_args = rest.strip()
             result = cmd.handler(stripped_args, api)
@@ -1033,6 +1033,7 @@ class AgentSession:
                 ),
             )
 
+        self._reloader.shutdown()
         self._bus.clear()
 
         try:

--- a/tests/integration/test_cli_observability_reload.py
+++ b/tests/integration/test_cli_observability_reload.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Iterable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+_OLD_ATOM_SOURCE = '''
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm.core.abi import FunctionTool, TextContent, ToolResult
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+MANIFEST = ExtensionManifest(
+    name="flaky_atom",
+    description="CLI reload rollback regression atom",
+    registers=("tool:flaky_demo",),
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, object]) -> None:
+    marker = Path(__file__).with_suffix(".install_count")
+    count = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
+    if count >= 1:
+        raise RuntimeError("old rollback install exploded")
+    marker.write_text(str(count + 1), encoding="utf-8")
+
+    async def _execute(args: dict[str, object]) -> ToolResult:
+        return ToolResult(content=[TextContent(type="text", text="old-live")])
+
+    api.register_tool(
+        FunctionTool(
+            name="flaky_demo",
+            description="demo tool",
+            parameters={"type": "object", "properties": {}, "additionalProperties": False},
+            fn=_execute,
+        )
+    )
+'''
+
+
+_NEW_ATOM_SOURCE = '''
+from __future__ import annotations
+
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import ExtensionAPI
+
+MANIFEST = ExtensionManifest(
+    name="flaky_atom",
+    description="CLI reload rollback regression atom",
+    registers=("tool:flaky_demo",),
+)
+
+
+def install(api: ExtensionAPI, config: dict[str, object]) -> None:
+    raise RuntimeError("new install exploded")
+'''
+
+
+class _OpenAIStub(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    calls = 0
+    reload_source = ""
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return None
+
+    def do_POST(self) -> None:  # noqa: N802
+        type(self).calls += 1
+        length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(length)
+        if type(self).calls == 1:
+            chunks = _tool_call_chunks(type(self).reload_source)
+        else:
+            chunks = _final_answer_chunks()
+        body = _sse(chunks)
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _sse(chunks: Iterable[dict[str, Any] | str]) -> bytes:
+    lines: list[str] = []
+    for chunk in chunks:
+        if isinstance(chunk, str):
+            lines.append(f"data: {chunk}\n\n")
+        else:
+            lines.append(f"data: {json.dumps(chunk)}\n\n")
+    return "".join(lines).encode("utf-8")
+
+
+def _chunk(delta: dict[str, Any], finish_reason: str | None) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "agentm-test",
+        "choices": [
+            {"index": 0, "delta": delta, "finish_reason": finish_reason}
+        ],
+    }
+
+
+def _tool_call_chunks(source: str) -> list[dict[str, Any] | str]:
+    args = json.dumps(
+        {
+            "name": "flaky_atom",
+            "source": source,
+            "rationale": "exercise CLI rollback double failure",
+        }
+    )
+    return [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call-reload",
+                        "type": "function",
+                        "function": {"name": "reload_atom", "arguments": args},
+                    }
+                ],
+            },
+            None,
+        ),
+        _chunk({}, "tool_calls"),
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "agentm-test",
+            "choices": [],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+        "[DONE]",
+    ]
+
+
+def _final_answer_chunks() -> list[dict[str, Any] | str]:
+    return [
+        _chunk({"role": "assistant", "content": "done"}, None),
+        _chunk({}, "stop"),
+        "[DONE]",
+    ]
+
+
+def _write_cli_package(tmp_path: Path) -> str:
+    pkg = "cli_reload_pkg"
+    pkg_dir = tmp_path / pkg
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "flaky_atom.py").write_text(_OLD_ATOM_SOURCE, encoding="utf-8")
+    return pkg
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_cli_repo(tmp_path: Path, pkg: str) -> None:
+    (tmp_path / "core-manifest.yaml").write_text(
+        "version: 1\n"
+        "constitution:\n"
+        "  paths:\n"
+        "    - core-manifest.yaml\n"
+        "managed:\n"
+        "  globs:\n"
+        f"    - {pkg}/**.py\n"
+        "extension_api:\n"
+        "  current: 1\n"
+        "  semver_rules: {major: x, minor: x, patch: x}\n"
+        "  deprecation:\n"
+        "    grace: 1\n"
+        "reload:\n"
+        "  tier_2_atoms: []\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "add", "core-manifest.yaml", pkg)
+    _git(tmp_path, "commit", "-m", "seed cli reload fixture", "--quiet")
+
+
+def _trace_records(tmp_path: Path) -> list[dict[str, Any]]:
+    traces = list((tmp_path / ".agentm" / "observability").glob("*.jsonl"))
+    assert traces, "CLI run did not produce an observability trace"
+    records: list[dict[str, Any]] = []
+    for line in traces[0].read_text(encoding="utf-8").splitlines():
+        records.append(json.loads(line))
+    return records
+
+
+def test_cli_trace_records_rollback_double_failure(tmp_path: Path) -> None:
+    pkg = _write_cli_package(tmp_path)
+    _init_cli_repo(tmp_path, pkg)
+    _OpenAIStub.calls = 0
+    _OpenAIStub.reload_source = _NEW_ATOM_SOURCE
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAIStub)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env = os.environ.copy()
+        env.update(
+            {
+                "AGENTM_PROVIDER": "openai",
+                "AGENTM_MODEL": "agentm-test",
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": f"http://127.0.0.1:{server.server_port}/v1",
+            }
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from agentm.cli import main; main()",
+                "--cwd",
+                str(tmp_path),
+                "--extension",
+                f"{pkg}.flaky_atom",
+                "--extension",
+                "_agentm_contrib__tool_catalog",
+                "reload flaky atom",
+            ],
+            cwd=tmp_path,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert result.returncode == 0, result.stderr
+    atom_reload_records = [
+        record for record in _trace_records(tmp_path)
+        if record.get("kind") == "atom.reload"
+    ]
+    assert atom_reload_records
+    assert atom_reload_records[-1]["status"]["code"] == "ERROR"
+    assert (
+        atom_reload_records[-1]["status"]["message"]
+        == "rollback_failure_state_preserved"
+    )

--- a/tests/unit/harness/test_transactional_reload.py
+++ b/tests/unit/harness/test_transactional_reload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
+import sys
 import uuid
 
 import pytest
@@ -405,5 +406,193 @@ async def test_reload_invalidates_old_handlers(tmp_path: Path, monkeypatch: pyte
 
         await session.bus.emit("marker", "after")
         assert state.EVENTS == [("v1", "before"), ("v2", "after")]
+    finally:
+        await session.shutdown()
+
+@pytest.mark.asyncio
+async def test_reload_double_failure_preserves_loaded_atom_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _build_session(
+        tmp_path,
+        monkeypatch,
+        atom_source=_tool_source("tool_demo", "stable"),
+    )
+    module_path = f"{session._test_pkg}.tool_demo"  # type: ignore[attr-defined]
+    original_atom = session._loaded_atoms_by_name["tool_demo"]
+    original_api = session._apis[module_path]  # type: ignore[attr-defined]
+    original_module = sys.modules[module_path]
+    original_activate = session._reloader._activate_atom_install  # type: ignore[attr-defined]
+    calls = 0
+
+    async def fail_only_rollback(atom: _LoadedAtom) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await original_activate(atom)
+            return
+        raise RuntimeError("rollback activation exploded")
+
+    monkeypatch.setattr(
+        session._reloader,  # type: ignore[attr-defined]
+        "_activate_atom_install",
+        fail_only_rollback,
+    )
+    try:
+        result = session._apis[module_path].reload_atom(  # type: ignore[attr-defined]
+            "tool_demo",
+            _raising_source("tool_demo"),
+            rationale="exercise double failure",
+        )
+        assert result.ok is False
+        assert "rollback_failure_state_preserved" in (result.error or "")
+        assert session._loaded_atoms_by_name["tool_demo"] is original_atom
+        assert session._reloader.loaded_by_module[module_path] is original_atom  # type: ignore[attr-defined]
+        assert session._apis[module_path] is original_api  # type: ignore[attr-defined]
+        assert sys.modules[module_path] is original_module
+    finally:
+        await session.shutdown()
+
+
+_OWNER_KIND_SOURCE = '''
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from agentm.core.abi import FunctionTool, MessageEnd, Model, TextContent, ToolResult
+from agentm.extensions import ExtensionManifest
+from agentm.harness.extension import CommandSpec, ExtensionAPI, ProviderConfig
+
+MANIFEST = ExtensionManifest(
+    name="tool_demo",
+    description="owner tracking test atom",
+    registers=("tool:demo", "command:demo_cmd", "provider:demo_provider", "renderer:demo_renderer"),
+)
+
+
+async def _stream(**kwargs: Any) -> AsyncIterator[Any]:
+    yield MessageEnd(message=None)
+
+
+def _command(args: str, api: ExtensionAPI) -> None:
+    return None
+
+
+def install(api: ExtensionAPI, config: dict[str, object]) -> None:
+    async def _execute(args: dict[str, object]) -> ToolResult:
+        return ToolResult(content=[TextContent(type="text", text="owner")])
+
+    api.register_tool(
+        FunctionTool(
+            name="demo",
+            description="demo tool",
+            parameters={"type": "object", "properties": {}, "additionalProperties": False},
+            fn=_execute,
+        )
+    )
+    api.register_command("demo_cmd", CommandSpec(description="demo", handler=_command))
+    api.register_provider(
+        "demo_provider",
+        ProviderConfig(
+            stream_fn=_stream,
+            model=Model(id="demo", provider="demo", context_window=1024, max_output_tokens=128),
+            name="demo_provider",
+        ),
+    )
+    api.register_message_renderer("demo_renderer", lambda payload: "rendered")
+'''
+
+
+@pytest.mark.asyncio
+async def test_registration_owners_are_tracked_for_every_kind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _build_session(
+        tmp_path,
+        monkeypatch,
+        atom_source=_OWNER_KIND_SOURCE,
+    )
+    owner = f"{session._test_pkg}.tool_demo"  # type: ignore[attr-defined]
+    try:
+        assert session._owners_by_kind["tool"]["demo"] == owner  # type: ignore[attr-defined]
+        assert session._owners_by_kind["command"]["demo_cmd"] == owner  # type: ignore[attr-defined]
+        assert session._owners_by_kind["provider"]["demo_provider"] == owner  # type: ignore[attr-defined]
+        assert session._owners_by_kind["renderer"]["demo_renderer"] == owner  # type: ignore[attr-defined]
+    finally:
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_session_shutdown_unsubscribes_reloader_registration_handler(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentm.core.abi import EventBus
+
+    class NonClearingEventBus(EventBus):
+        def clear(self) -> None:
+            return None
+
+    bus = NonClearingEventBus()
+    session = await _build_session(
+        tmp_path,
+        monkeypatch,
+        atom_source=_tool_source("tool_demo", "v1"),
+        extra_extensions=[],
+    )
+    # Rebuild with an externally visible bus because _build_session intentionally
+    # keeps its fixture compact for the other reload tests.
+    await session.shutdown()
+
+    pkg = _write_package(tmp_path)
+    (tmp_path / pkg / "tool_demo.py").write_text(_tool_source("tool_demo", "v1"), encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    session = await AgentSession.create(
+        AgentSessionConfig(
+            cwd=str(tmp_path),
+            bus=bus,
+            extensions=[(f"{pkg}.tool_demo", {})],
+            provider=(f"{pkg}.provider", {}),
+            resource_loader=InMemoryResourceLoader(),
+        )
+    )
+    track_handler = session._reloader._track_registration  # type: ignore[attr-defined]
+    assert any(
+        sub.handler == track_handler
+        for subs in bus._handlers.values()
+        for sub in subs
+    )
+
+    await session.shutdown()
+
+    assert not any(
+        sub.handler == track_handler
+        for subs in bus._handlers.values()
+        for sub in subs
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_installed_atom_records_synthetic_import_kind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _build_session(
+        tmp_path,
+        monkeypatch,
+        atom_source=_tool_source("tool_demo", "v1"),
+    )
+    api = session._apis[f"{session._test_pkg}.tool_demo"]  # type: ignore[attr-defined]
+    try:
+        result = api.install_atom(
+            name="helper_atom",
+            source=_tool_source("helper_atom", "helper", registers=("tool:helper",)).replace('name="demo"', 'name="helper"'),
+        )
+        assert result.ok is True
+        assert session._loaded_atoms_by_name["helper_atom"].import_kind == "synthetic"
     finally:
         await session.shutdown()


### PR DESCRIPTION
Fixes #79

## Scope
- Layer/axis touched: harness extension/reload mechanism (`AtomReloader`, `AgentSession.shutdown`) on the ExtensionAPI/EventBus policy axis.
- Atom impact: no built-in atom source changes; this hardens atom lifecycle bookkeeping and runtime reload/install/freeze paths.
- Requirement: satisfies `REQ-079-atom-reloader-fail-stop` in `project-index.yaml`.

## Changes
- Preserve prior loaded atom/module/API/registry/bus bookkeeping when reload install fails and rollback activation also fails, reporting `rollback_failure_state_preserved`.
- Replace `_run_coro_sync` with native async reload/install/freeze methods plus sync API-boundary facades.
- Add `AtomReloader.shutdown()` and call it from `AgentSession.shutdown()` before `bus.clear()`.
- Add `LoadedAtom.import_kind` and replace synthetic reload dispatch with `atom.import_kind == "synthetic"`.
- Replace command-only owner tracking with `owners_by_kind` across tool/command/provider/renderer registrations.

## Tests
- Added unit regressions for rollback double-failure state preservation, shutdown unsubscription, typed synthetic import kind, and uniform owner tracking.
- Added CLI-level observability regression in `tests/integration/test_cli_observability_reload.py`: drives `agentm` with a natural-language prompt against a local OpenAI-compatible stub, triggers `reload_atom`, then inspects `.agentm/observability/<trace>.jsonl` for `atom.reload` with `rollback_failure_state_preserved`.

## Docs
- Updated `.claude/designs/self-modifiable-architecture.md` and `.claude/index.yaml`.
- Added `.claude/tasks/2026-05-09-issue-79-atom-reloader-hardening.md`.

## Validation
- `uv run ruff check src/`
- `uv run mypy src/`
- `uv run ruff check tests/integration/test_cli_observability_reload.py tests/unit/harness/test_transactional_reload.py`
- `uv run mypy tests/integration/test_cli_observability_reload.py tests/unit/harness/test_transactional_reload.py`
- `uv run pytest --tb=short` — 104 passed / 14 deselected
- `uv run pytest tests/unit/extensions/test_extension_contract.py --tb=short` — §11 validator coverage passes
- `uv run python /home/ddq/.claude/plugins/cache/autoharness/autoharness/1.1.3/scripts/validate_index.py project-index.yaml`
