### PR TITLE
Fix shared presenter rendering

### DIFF
--- a/.claude/designs/pluggable-architecture.md
+++ b/.claude/designs/pluggable-architecture.md
@@ -409,3 +409,20 @@ Quick lookup for implementation. All paths relative to `pi-mono/packages/`.
    c. Implement minimal `EventBus` + 6 critical events (`input`, `before_agent_start`, `tool_call`, `tool_result`, `context`, `agent_end`).
    d. Refactor existing `AgentRuntime` to be the harness orchestrator.
 3. Acceptance: a smoke-test scenario that swaps `StreamFn` (mock LLM) and constructs the session with `BashOperations` (in-memory FS) without modifying core.
+
+### 5.1 Shared Presenter Rendering
+
+CLI and Textual remain presenters, so shared display decisions live in pure
+`agentm.core.lib.render` helpers rather than in either mode. The helpers produce
+headless strings and token reports only; they do not import Rich, Textual,
+harness, filesystem state, or pricing tables.
+
+Cost is a policy concern exposed as an ExtensionAPI service named
+`cost_query`. The `cost_budget` atom owns pricing configuration and registers a
+service with `estimate(usage, provider=...)`; presenters call it opportunistically
+and fall back to token-only output when the service is absent.
+
+Tool-result display uses tool-declared metadata (`metadata["result_format"]`) or
+`api.register_tool_renderer(tool_name, renderer)`. Presenters may choose their
+surface-specific rich widget for a returned format, but they must not infer atom
+identity from exact tool-name strings.

--- a/.claude/index.yaml
+++ b/.claude/index.yaml
@@ -450,3 +450,10 @@ concepts:
     related_concepts: [orchestrator, middleware_system, scenario_protocol, loop_resilience, trajectory_judger, service_profile]
     plans: []
     tasks: []
+
+  shared_presenter_rendering:
+    description: "Shared headless rendering contract for presenter surfaces: core/lib/render.py owns AssistantMessage text extraction, tool result text extraction, raw token UsageReport/FinalReport summaries, and tool result format selection from metadata or registered renderer hints. Cost remains a policy service (`cost_query`) registered by cost_budget and consumed opportunistically by CLI/TUI; missing service yields token-only output. Presenters map headless output to their own UI widgets without importing atom-private pricing or string-matching builtin tool identities."
+    design: "designs/pluggable-architecture.md"
+    related_concepts: [pluggable_architecture, self_modifiable_architecture, tool_event_narrowing]
+    plans: []
+    tasks: ["tasks/2026-05-09-issue-97-shared-rendering.md"]

--- a/.claude/tasks/2026-05-09-issue-97-shared-rendering.md
+++ b/.claude/tasks/2026-05-09-issue-97-shared-rendering.md
@@ -1,0 +1,5 @@
+# Issue 97 shared rendering
+
+- Added `core.lib.render` as the headless text/usage renderer consumed by CLI and TUI.
+- Added the `cost_query` service contract and registered it from `cost_budget` so presenters no longer import atom-private pricing.
+- Moved tool-result diff selection to tool metadata / registered renderers and declared the edit tool's diff hint in its metadata.

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -402,3 +402,38 @@ requirements:
       - path: .claude/tasks/2026-05-09-issue-96-cli-provider-session-seams.md
     depends_on:
       - REQ-094-ai-provider-descriptor-registry
+  - id: REQ-097-shared-presenter-rendering
+    title: CLI and TUI consume shared headless render helpers
+    description: >
+      CLI and Textual presenters must render assistant text, tool results,
+      final token summaries, and optional cost estimates through shared core.lib
+      helpers and ExtensionAPI services instead of duplicate block walks,
+      atom-private pricing imports, or tool-name-specific diff heuristics.
+      Tool result formatting must be declared as tool metadata or registered via
+      a tool renderer service hook, and missing cost services must degrade to a
+      token-only summary.
+    priority: P1
+    status: tested
+    confidence: confirmed
+    code:
+      - path: src/agentm/core/lib/render.py
+      - path: src/agentm/core/abi/services.py
+      - path: src/agentm/core/abi/tool.py
+      - path: src/agentm/harness/extension.py
+      - path: src/agentm/harness/session.py
+      - path: src/agentm/harness/session_factory.py
+      - path: src/agentm/harness/session_runtime.py
+      - path: src/agentm/cli.py
+      - path: src/agentm/modes/textual_app.py
+      - path: src/agentm/extensions/builtin/cost_budget.py
+      - path: src/agentm/extensions/builtin/tool_edit.py
+    tests:
+      - path: tests/unit/core/lib/test_render.py
+      - path: tests/unit/extensions/test_issue_88_hygiene.py
+      - path: tests/integration/test_textual_tui.py
+      - path: tests/unit/core/catalog/test_indexer.py
+    docs:
+      - path: .claude/designs/pluggable-architecture.md
+      - path: .claude/tasks/2026-05-09-issue-97-shared-rendering.md
+    depends_on:
+      - REQ-086-atom-rework-infra

--- a/src/agentm/cli.py
+++ b/src/agentm/cli.py
@@ -20,11 +20,7 @@ from dotenv import load_dotenv
 from agentm.ai import DEFAULT_PROVIDER_REGISTRY, ProviderRegistry
 from agentm.core.abi.events import DiagnosticEvent, EventBus
 from agentm.core.abi.session_store import SessionState, SessionStore
-from agentm.core.abi.messages import (
-    AssistantMessage,
-    TextContent,
-    ToolCallBlock,
-)
+from agentm.core.lib.render import final_summary
 from agentm.harness.events import ExtensionInstallEvent
 
 
@@ -38,39 +34,30 @@ for _candidate in (_cur, *_cur.parents):
         break
 
 
-def _print_final(final_messages: list) -> None:
-    text_blocks: list[str] = []
-    tool_calls = 0
-    in_tok = out_tok = cache_r = cache_w = 0
-    assistant_turns = 0
-    for msg in final_messages:
-        if isinstance(msg, AssistantMessage):
-            for block in msg.content:
-                if isinstance(block, TextContent):
-                    text_blocks.append(block.text)
-                elif isinstance(block, ToolCallBlock):
-                    tool_calls += 1
-            usage = getattr(msg, "usage", None)
-            if usage is not None:
-                in_tok += usage.input_tokens
-                out_tok += usage.output_tokens
-                cache_r += usage.cache_read
-                cache_w += usage.cache_write
-                assistant_turns += 1
-
+def _print_final(
+    final_messages: list[Any],
+    *,
+    cost_service: Any | None = None,
+    provider: str | None = None,
+) -> None:
+    report = final_summary(final_messages)
     typer.echo("\n" + "=" * 60)
     typer.echo("AGENT FINAL OUTPUT")
     typer.echo("=" * 60)
-    typer.echo("\n\n".join(text_blocks) if text_blocks else "<no text output>")
+    typer.echo(report.text if report.text else "<no text output>")
     typer.echo("=" * 60)
-    typer.echo(f"messages={len(final_messages)} tool_calls={tool_calls}")
-    if assistant_turns:
+    typer.echo(f"messages={report.message_count} tool_calls={report.tool_calls}")
+    usage = report.usage
+    if usage.assistant_turns:
+        estimate = getattr(cost_service, "estimate", None)
+        cost = estimate(usage, provider=provider) if callable(estimate) else None
+        suffix = f" cost={cost.currency} {cost.amount:.6f}" if cost is not None else ""
+        turns = "turn" if usage.assistant_turns == 1 else "turns"
         typer.echo(
-            f"tokens: in={in_tok} out={out_tok} "
-            f"cache_r={cache_r} cache_w={cache_w} "
-            f"(over {assistant_turns} turn{'s' if assistant_turns != 1 else ''})"
+            f"tokens: in={usage.input_tokens} out={usage.output_tokens} "
+            f"cache_r={usage.cache_read} cache_w={usage.cache_write} "
+            f"(over {usage.assistant_turns} {turns}){suffix}"
         )
-
 
 def _parse_tools(value: str | None) -> list[str] | None:
     if value is None:
@@ -280,11 +267,14 @@ async def _run(
     session = await AgentSession.create(config)
     try:
         final = await session.prompt(prompt)
+        cost_service = session.get_service("cost_query")
+        provider_name = session.model.provider if session.model is not None else None
+        if not quiet:
+            _print_final(final, cost_service=cost_service, provider=provider_name)
     finally:
         await session.shutdown()
 
     if not quiet:
-        _print_final(final)
         sid = session_manager.get_session_id()
         if sid:
             typer.echo(

--- a/src/agentm/core/abi/__init__.py
+++ b/src/agentm/core/abi/__init__.py
@@ -54,6 +54,7 @@ from .events import (
 from .loop import AgentLoop, LoopConfig
 from .provider import ProviderResolver
 from .retry import RetryPolicy
+from .services import CostBreakdown, CostQueryService
 from .session_store import SessionState, SessionStore
 from .messages import (
     AgentMessage,
@@ -107,6 +108,8 @@ __all__ = [
     "ProviderResolver",
     # retry
     "RetryPolicy",
+    "CostBreakdown",
+    "CostQueryService",
     # session store
     "SessionState",
     "SessionStore",

--- a/src/agentm/core/abi/services.py
+++ b/src/agentm/core/abi/services.py
@@ -1,0 +1,19 @@
+"""Published service protocols shared by extensions and presenters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class CostBreakdown:
+    amount: float
+    currency: str = "usd"
+
+
+class CostQueryService(Protocol):
+    def estimate(self, usage: Any, *, provider: str | None = None) -> CostBreakdown: ...
+
+
+__all__ = ["CostBreakdown", "CostQueryService"]

--- a/src/agentm/core/abi/tool.py
+++ b/src/agentm/core/abi/tool.py
@@ -37,6 +37,7 @@ FILE_OP_METADATA_KEY = "file_op"
 FILE_OP_READ = "read"
 FILE_OP_WRITE = "write"
 FILE_OP_EDIT = "edit"
+TOOL_RESULT_FORMAT_METADATA_KEY = "result_format"
 
 
 @dataclass(slots=True)
@@ -133,6 +134,7 @@ __all__ = [
     "FILE_OP_METADATA_KEY",
     "FILE_OP_READ",
     "FILE_OP_WRITE",
+    "TOOL_RESULT_FORMAT_METADATA_KEY",
     "Tool",
     "ToolContinue",
     "ToolOutcome",

--- a/src/agentm/core/lib/render.py
+++ b/src/agentm/core/lib/render.py
@@ -1,0 +1,175 @@
+"""Shared headless rendering helpers for presenter surfaces."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+from agentm.core.abi.messages import (
+    AgentMessage,
+    AssistantMessage,
+    TextContent,
+    ToolCallBlock,
+    ToolResultBlock,
+    ToolResultMessage,
+    Usage,
+)
+from agentm.core.abi.tool import TOOL_RESULT_FORMAT_METADATA_KEY, Tool, ToolResult
+
+RESULT_FORMAT_METADATA_KEY = TOOL_RESULT_FORMAT_METADATA_KEY
+
+
+class ToolResultRenderer(Protocol):
+    """Optional text renderer registered by an extension for one tool."""
+
+    def __call__(self, result: ToolResult | ToolResultBlock | ToolResultMessage) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class UsageReport:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read: int = 0
+    cache_write: int = 0
+    assistant_turns: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class FinalReport:
+    text: str
+    message_count: int
+    tool_calls: int
+    usage: UsageReport
+
+
+def assistant_text(msg: AssistantMessage) -> str:
+    return "\n".join(block.text for block in msg.content if isinstance(block, TextContent))
+
+
+def tool_call_text(call: ToolCallBlock) -> str:
+    try:
+        args = json.dumps(call.arguments, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        args = str(call.arguments)
+    return f"{call.name}({args})"
+
+
+def tool_result_text(
+    result: ToolResult | ToolResultBlock | ToolResultMessage,
+    *,
+    tool_name: str | None = None,
+    renderers: Mapping[str, ToolResultRenderer] | None = None,
+) -> str:
+    if tool_name is not None and renderers is not None:
+        renderer = renderers.get(tool_name)
+        if renderer is not None:
+            return renderer(result)
+    parts: list[str] = []
+    for block in _tool_result_content(result):
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def usage_summary(messages: Iterable[AssistantMessage]) -> UsageReport:
+    input_tokens = output_tokens = cache_read = cache_write = assistant_turns = 0
+    for msg in messages:
+        usage = msg.usage
+        if usage is None:
+            continue
+        input_tokens += usage.input_tokens
+        output_tokens += usage.output_tokens
+        cache_read += usage.cache_read
+        cache_write += usage.cache_write
+        assistant_turns += 1
+    return UsageReport(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read=cache_read,
+        cache_write=cache_write,
+        assistant_turns=assistant_turns,
+    )
+
+
+def final_summary(messages: Iterable[AgentMessage]) -> FinalReport:
+    materialized = list(messages)
+    assistant_messages = [msg for msg in materialized if isinstance(msg, AssistantMessage)]
+    text = "\n\n".join(
+        chunk for msg in assistant_messages if (chunk := assistant_text(msg))
+    )
+    tool_calls = sum(
+        1
+        for msg in assistant_messages
+        for block in msg.content
+        if isinstance(block, ToolCallBlock)
+    )
+    return FinalReport(
+        text=text,
+        message_count=len(materialized),
+        tool_calls=tool_calls,
+        usage=usage_summary(assistant_messages),
+    )
+
+
+def usage_report_from_usage(usage: Usage) -> UsageReport:
+    return UsageReport(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read=usage.cache_read,
+        cache_write=usage.cache_write,
+        assistant_turns=1,
+    )
+
+
+def tool_result_format(
+    tool_name: str,
+    text: str,
+    *,
+    tool: Tool | None = None,
+    renderers: Mapping[str, ToolResultRenderer] | None = None,
+) -> str:
+    if renderers is not None and tool_name in renderers:
+        return "text"
+    metadata = getattr(tool, "metadata", None)
+    if isinstance(metadata, Mapping):
+        result_format = metadata.get(RESULT_FORMAT_METADATA_KEY)
+        if isinstance(result_format, str) and result_format:
+            return result_format
+    stripped = text.lstrip()
+    if stripped.startswith("--- ") or stripped.startswith("+++ "):
+        return "diff"
+    if "```" in text or "# " in text or "- " in text:
+        return "markdown"
+    return "text"
+
+
+def _tool_result_content(
+    result: ToolResult | ToolResultBlock | ToolResultMessage,
+) -> list[Any]:
+    if isinstance(result, ToolResultMessage):
+        content: list[Any] = []
+        for block in result.content:
+            content.extend(block.content)
+        return content
+    raw_content = getattr(result, "content", None)
+    if isinstance(raw_content, list):
+        return cast(list[Any], raw_content)
+    return []
+
+
+__all__ = [
+    "FinalReport",
+    "RESULT_FORMAT_METADATA_KEY",
+    "ToolResultRenderer",
+    "UsageReport",
+    "assistant_text",
+    "final_summary",
+    "tool_call_text",
+    "tool_result_format",
+    "tool_result_text",
+    "usage_report_from_usage",
+    "usage_summary",
+]

--- a/src/agentm/extensions/builtin/cost_budget.py
+++ b/src/agentm/extensions/builtin/cost_budget.py
@@ -12,7 +12,7 @@ import json
 from dataclasses import fields, is_dataclass
 from typing import Any
 
-from agentm.core.abi import BeforeSendToLlmEvent, BudgetExhausted, TurnEndEvent
+from agentm.core.abi import BeforeSendToLlmEvent, BudgetExhausted, CostBreakdown, TurnEndEvent
 from agentm.core.abi.events import DiagnosticEvent
 from agentm.extensions import ExtensionManifest
 from agentm.harness.events import BeforeAgentStartEvent, CostBudgetExceededEvent
@@ -93,6 +93,18 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
         "used": 0.0,
         "overflowed": False,
     }
+
+    class _CostQueryService:
+        def estimate(self, usage: Any, *, provider: str | None = None) -> CostBreakdown:
+            selected = provider or (api.model.provider if api.model is not None else "")
+            input_price, output_price = pricing.get(selected, (0.0, 0.0))
+            amount = (
+                (getattr(usage, "input_tokens", 0) / 1_000_000.0) * input_price
+                + (getattr(usage, "output_tokens", 0) / 1_000_000.0) * output_price
+            )
+            return CostBreakdown(amount=amount, currency=currency)
+
+    api.set_service("cost_query", _CostQueryService())
 
     async def _pricing_for(provider: str) -> tuple[float, float]:
         configured = pricing.get(provider)

--- a/src/agentm/extensions/builtin/tool_edit.py
+++ b/src/agentm/extensions/builtin/tool_edit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Final
 
 from agentm.core.abi import FunctionTool, TextContent, ToolResult
+from agentm.core.abi.tool import TOOL_RESULT_FORMAT_METADATA_KEY
 from agentm.extensions import ExtensionManifest
 from agentm.harness.extension import ExtensionAPI
 
@@ -77,7 +78,7 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
             description="Replace text in a UTF-8 text file.",
             parameters=_PARAMETERS,
             fn=_execute,
-            metadata={"file_op": "edit"},
+            metadata={"file_op": "edit", TOOL_RESULT_FORMAT_METADATA_KEY: "diff"},
         )
     )
 def _ok(text: str) -> ToolResult:

--- a/src/agentm/harness/extension.py
+++ b/src/agentm/harness/extension.py
@@ -376,6 +376,7 @@ class ExtensionAPI(Protocol):
     def register_message_renderer(
         self, custom_type: str, renderer: Renderer
     ) -> None: ...
+    def register_tool_renderer(self, tool_name: str, renderer: Renderer) -> None: ...
 
     # --- Actions ------------------------------------------------------------
     def send_user_message(self, content: str | list[Any]) -> None: ...
@@ -661,6 +662,11 @@ class _ExtensionAPIImpl:
         self._assert_active()
         self._renderers[custom_type] = renderer
         self._emit_register("renderer", custom_type, renderer)
+
+    def register_tool_renderer(self, tool_name: str, renderer: Renderer) -> None:
+        self._assert_active()
+        self._renderers[f"tool:{tool_name}"] = renderer
+        self._emit_register("renderer", f"tool:{tool_name}", renderer)
 
     # --- Actions -----------------------------------------------------------
 

--- a/src/agentm/harness/session.py
+++ b/src/agentm/harness/session.py
@@ -105,6 +105,7 @@ class AgentSession:
         self._providers = runtime.providers
         self._renderers = runtime.renderers
         self._apis = runtime.apis
+        self._services = runtime.services
         self._reloader = runtime.reloader
         self._extension_api = (
             next(iter(runtime.apis.values())) if runtime.apis else None
@@ -164,6 +165,23 @@ class AgentSession:
     @property
     def cwd(self) -> str:
         return self._cwd
+
+    def get_service(self, name: str) -> Any | None:
+        return self._services.get(name)
+
+    @property
+    def tool_renderers(self) -> dict[str, Any]:
+        return {
+            name.removeprefix("tool:"): renderer
+            for name, renderer in self._renderers.items()
+            if name.startswith("tool:")
+        }
+
+    def find_tool(self, name: str) -> Tool | None:
+        for tool in self._tools:
+            if tool.name == name:
+                return tool
+        return None
 
     @property
     def session_id(self) -> str:

--- a/src/agentm/harness/session_factory.py
+++ b/src/agentm/harness/session_factory.py
@@ -284,6 +284,7 @@ async def create_agent_session(
         providers=providers,
         renderers=renderers,
         apis=apis,
+        services=services,
         reloader=reloader,
         pending_user_messages=pending_user_messages,
     )

--- a/src/agentm/harness/session_runtime.py
+++ b/src/agentm/harness/session_runtime.py
@@ -37,6 +37,7 @@ class SessionRuntime:
     providers: dict[str, ProviderConfig]
     renderers: dict[str, Renderer]
     apis: dict[str, _ExtensionAPIImpl]
+    services: dict[str, Any]
     reloader: AtomReloader
     pending_user_messages: list[str | list[Any]]
 

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -30,7 +30,6 @@ from agentm.core.abi import (
     LlmRequestStartEvent,
     MessageEnd,
     StreamDeltaEvent,
-    TextContent,
     TextDelta,
     ThinkingDelta,
     ToolCallArgsDelta,
@@ -38,6 +37,13 @@ from agentm.core.abi import (
     ToolCallStart,
     ToolResultEvent,
     Usage,
+    Tool,
+)
+from agentm.core.lib.render import (
+    assistant_text as render_assistant_text,
+    tool_result_format,
+    tool_result_text as render_tool_result_text,
+    usage_report_from_usage,
 )
 from agentm.harness import AgentSession, AgentSessionConfig
 from agentm.harness.events import (
@@ -101,6 +107,12 @@ class _SessionLike(Protocol):
 
     @property
     def model(self) -> Any: ...
+
+    @property
+    def tool_renderers(self) -> dict[str, Any]: ...
+
+    def find_tool(self, name: str) -> Tool | None: ...
+    def get_service(self, name: str) -> Any | None: ...
 
 
 @dataclass(slots=True)
@@ -293,23 +305,38 @@ class ToolCallBlock(Collapsible):
         self.title = f"{self.tool_name}({_format_args_inline(self.args)})"
         self._render_body(None)
 
-    def set_result(self, *, result: Any, duration_ms: int) -> None:
+    def set_result(
+        self,
+        *,
+        result: Any,
+        duration_ms: int,
+        tool: Tool | None = None,
+        renderers: dict[str, Any] | None = None,
+    ) -> None:
         self.duration_ms = duration_ms
         self.ok = not getattr(result, "is_error", False)
-        self.result_text = _tool_result_text(result)
+        self.result_text = render_tool_result_text(
+            result, tool_name=self.tool_name, renderers=renderers
+        )
         status = "✓" if self.ok else "✗"
         self.title = (
             f"{self.tool_name}({_format_args_inline(self.args)})"
             f"  {status} {duration_ms}ms"
         )
         self.collapsed = self.ok and _line_count(self.result_text) < 20
-        self._render_body(result)
+        self._render_body(result, tool=tool, renderers=renderers)
         if self.ok:
             self.remove_class("failed")
         else:
             self.add_class("failed")
 
-    def _render_body(self, result: Any | None) -> None:
+    def _render_body(
+        self,
+        result: Any | None,
+        *,
+        tool: Tool | None = None,
+        renderers: dict[str, Any] | None = None,
+    ) -> None:
         args_text = _format_full_args(self.args) if self.args else "{}"
         if result is None:
             renderable: Any = Group(
@@ -318,7 +345,9 @@ class ToolCallBlock(Collapsible):
             )
             self.body_kind = "text"
         else:
-            result_renderable = _render_tool_result(self.tool_name, self.result_text)
+            result_renderable = _render_tool_result(
+                self.tool_name, self.result_text, tool=tool, renderers=renderers
+            )
             self.body_kind = type(result_renderable).__name__
             ok = not getattr(result, "is_error", False)
             renderable = Group(
@@ -1016,12 +1045,19 @@ class AgentMApp(App[int]):
         status = self._header
         status.tokens_in = usage.input_tokens
         status.tokens_out = usage.output_tokens
-        model = self._session.model
-        pricing = getattr(model, "metadata", {}).get("pricing", (0.0, 0.0))
-        status.cost_usd = (
-            (usage.input_tokens / 1_000_000.0) * pricing[0]
-            + (usage.output_tokens / 1_000_000.0) * pricing[1]
-        )
+        cost_service = self._session.get_service("cost_query")
+        estimate = getattr(cost_service, "estimate", None)
+        if callable(estimate):
+            provider = (
+                self._session.model.provider
+                if self._session.model is not None
+                else None
+            )
+            status.cost_usd = estimate(
+                usage_report_from_usage(usage), provider=provider
+            ).amount
+        else:
+            status.cost_usd = 0.0
 
     def _render_child_delta(self, delta: Any) -> None:
         if not self._child_turns:
@@ -1096,13 +1132,20 @@ class AgentMApp(App[int]):
         state = self._tool_states.get(event.tool_call_id)
         duration_ms = 0
         if state is not None:
-            duration_ms = max(0, int((time.perf_counter_ns() - state.start_ns) / 1_000_000))
+            duration_ms = max(
+                0, int((time.perf_counter_ns() - state.start_ns) / 1_000_000)
+            )
 
         async def _apply() -> None:
             block = await turn.ensure_tool(event.tool_call_id, event.tool_name)
             if state is not None and state.args is not None:
                 block.args = dict(state.args)
-            block.set_result(result=event.result, duration_ms=duration_ms)
+            block.set_result(
+                result=event.result,
+                duration_ms=duration_ms,
+                tool=self._session.find_tool(event.tool_name),
+                renderers=self._session.tool_renderers,
+            )
 
         self.run_worker(_apply(), exclusive=False)
         self.set_phase("tool")
@@ -1322,43 +1365,28 @@ async def run(config: AgentSessionConfig, *, theme: str = "dark") -> int:
 
 
 def _assistant_text(message: AssistantMessage) -> str:
-    chunks: list[str] = []
-    for block in message.content:
-        if isinstance(block, TextContent):
-            chunks.append(block.text)
-    return "\n".join(chunks)
+    return render_assistant_text(message)
 
 
 def _tool_result_text(result: Any) -> str:
-    content = getattr(result, "content", None) or []
-    parts: list[str] = []
-    for block in content:
-        text = getattr(block, "text", None)
-        if isinstance(text, str):
-            parts.append(text)
-    if not parts:
-        return ""
-    return "\n\n".join(parts)
+    return render_tool_result_text(result)
 
 
-def _looks_like_markdown(text: str) -> bool:
-    return "```" in text or "# " in text or "- " in text
-
-
-def _looks_like_diff(tool_name: str, text: str) -> bool:
-    if tool_name == "tool_edit":
-        return True
-    stripped = text.lstrip()
-    return stripped.startswith("--- ") or stripped.startswith("+++ ")
-
-
-def _render_tool_result(tool_name: str, text: str) -> Any:
-    if _looks_like_diff(tool_name, text):
+def _render_tool_result(
+    tool_name: str,
+    text: str,
+    *,
+    tool: Tool | None = None,
+    renderers: dict[str, Any] | None = None,
+) -> Any:
+    result_format = tool_result_format(
+        tool_name, text, tool=tool, renderers=renderers
+    )
+    if result_format == "diff":
         return Syntax(text, "diff", word_wrap=True)
-    if _looks_like_markdown(text):
+    if result_format == "markdown":
         return Markdown(text)
     return Text(text)
-
 
 def _format_args_preview(args: dict[str, Any]) -> str:
     return _dump_json(args)

--- a/tests/integration/test_textual_tui.py
+++ b/tests/integration/test_textual_tui.py
@@ -592,7 +592,7 @@ async def test_T9_cli_dispatches_to_textual_runner(
         no_skills=True,
         no_prompt_templates=True,
         tool_allowlist=None,
-        provider="fake",
+        provider="anthropic",
         model="fake-model",
         cwd="/tmp/textual",
     )

--- a/tests/integration/test_textual_tui.py
+++ b/tests/integration/test_textual_tui.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -29,7 +29,9 @@ from agentm.harness import AgentSessionConfig
 from agentm.harness.events import ChildSessionEndEvent, ChildSessionStartEvent, ExtensionInstallEvent
 from agentm.modes.textual_app import (
     AgentMApp,
+    PromptInput,
     SlashCommandEntry,
+    StatusHeader,
     ToolCallBlock,
     TurnContainer,
 )
@@ -57,6 +59,15 @@ class _FakeSession:
         self._scripts = scripts
         self.prompts: list[str] = []
         self.shutdown_called = False
+        self.tool_renderers: dict[str, Any] = {}
+
+    def find_tool(self, name: str) -> Any | None:
+        del name
+        return None
+
+    def get_service(self, name: str) -> Any | None:
+        del name
+        return None
 
     async def prompt(
         self,
@@ -273,7 +284,7 @@ async def test_T1_golden_path_updates_stream_and_status(tmp_path: Path) -> None:
     async with app.run_test() as pilot:
         await pilot.press("h", "i", "enter")
         await pilot.pause(0.2)
-        status = app.query_one("#status-header")
+        status = cast(StatusHeader, app.query_one("#status-header"))
         assert "turn 1" in status.current_text
         assert "in 128" in status.current_text
         assert "out 32" in status.current_text
@@ -289,7 +300,7 @@ async def test_T2_escape_soft_cancels_and_keeps_partial_text(tmp_path: Path) -> 
         await pilot.pause(0.1)
         await pilot.press("escape")
         await pilot.pause(0.1)
-        status = app.query_one("#status-header")
+        status = cast(StatusHeader, app.query_one("#status-header"))
         assert "idle" in status.current_text
         assert app._last_assistant_text == "partial"
         assert app._prompt_task is None
@@ -318,7 +329,7 @@ async def test_T4_slash_palette_opens_filters_and_inserts_selection(tmp_path: Pa
         assert app.screen_stack[-1].__class__.__name__ == "CommandPaletteScreen"
         await pilot.press("h", "e", "l", "p", "enter")
         await pilot.pause(0.05)
-        prompt = app.query_one("#prompt-input")
+        prompt = cast(PromptInput, app.query_one("#prompt-input"))
         assert prompt.text == "/help"
 
 
@@ -343,7 +354,7 @@ async def test_T6_shift_enter_inserts_newline(tmp_path: Path) -> None:
     async with app.run_test() as pilot:
         await pilot.press("h", "i", "shift+enter", "t", "h", "e", "r", "e")
         await pilot.pause(0.05)
-        prompt = app.query_one("#prompt-input")
+        prompt = cast(PromptInput, app.query_one("#prompt-input"))
         assert prompt.text == "hi\nthere"
 
 
@@ -576,10 +587,12 @@ async def test_T9_cli_dispatches_to_textual_runner(
 
     rc = await _run_interactive(
         scenario=None,
+        extra_extensions=[],
         no_extensions=True,
         no_skills=True,
         no_prompt_templates=True,
         tool_allowlist=None,
+        provider="fake",
         model="fake-model",
         cwd="/tmp/textual",
     )

--- a/tests/unit/core/catalog/test_indexer.py
+++ b/tests/unit/core/catalog/test_indexer.py
@@ -341,6 +341,7 @@ async def test_shutdown_indexes_observability_trace_when_present(
         providers={},
         renderers={},
         apis={},
+        services={},
         reloader=reloader,
         pending_user_messages=[],
     )

--- a/tests/unit/core/lib/test_render.py
+++ b/tests/unit/core/lib/test_render.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import cast
+
+from agentm.core.abi import (
+    AssistantMessage,
+    TextContent,
+    ToolCallBlock,
+    Tool,
+    ToolResult,
+    Usage,
+)
+from agentm.core.lib.render import (
+    assistant_text,
+    final_summary,
+    tool_call_text,
+    tool_result_format,
+    tool_result_text,
+)
+
+
+def test_assistant_and_tool_result_text_are_stable() -> None:
+    message = AssistantMessage(
+        role="assistant",
+        content=[
+            TextContent(type="text", text="hello"),
+            ToolCallBlock(
+                type="tool_call", id="tc-1", name="read", arguments={"path": "x"}
+            ),
+            TextContent(type="text", text="world"),
+        ],
+        timestamp=1.0,
+        usage=Usage(input_tokens=3, output_tokens=5, cache_read=7, cache_write=11),
+    )
+    result = ToolResult(
+        content=[TextContent(type="text", text="ok"), TextContent(type="text", text="done")]
+    )
+
+    assert assistant_text(message) == "hello\nworld"
+    assert (
+        tool_call_text(cast(ToolCallBlock, message.content[1]))
+        == 'read({"path": "x"})'
+    )
+    assert tool_result_text(result) == "ok\n\ndone"
+
+    report = final_summary([message])
+    assert report.text == "hello\nworld"
+    assert report.tool_calls == 1
+    assert report.usage.input_tokens == 3
+    assert report.usage.cache_write == 11
+
+
+def test_tool_result_format_uses_metadata_hint_instead_of_tool_name() -> None:
+    class _Tool:
+        name = "anything"
+        metadata = {"result_format": "diff"}
+
+    assert (
+        tool_result_format("anything", "Updated 'x'", tool=cast(Tool, _Tool()))
+        == "diff"
+    )
+    assert tool_result_format("tool_edit", "Updated 'x'") == "text"

--- a/tests/unit/core/lib/test_render.py
+++ b/tests/unit/core/lib/test_render.py
@@ -19,6 +19,9 @@ from agentm.core.lib.render import (
 )
 
 
+# Shared presenter rendering is load-bearing for the pluggability boundary:
+# CLI/TUI must consume core helpers without atom-private pricing or tool-name
+# branches, otherwise disabling/replacing atoms breaks presenter surfaces.
 def test_assistant_and_tool_result_text_are_stable() -> None:
     message = AssistantMessage(
         role="assistant",

--- a/tests/unit/extensions/test_issue_88_hygiene.py
+++ b/tests/unit/extensions/test_issue_88_hygiene.py
@@ -87,12 +87,17 @@ async def test_cost_budget_warns_once_for_unpriced_provider() -> None:
     diagnostics: list[DiagnosticEvent] = []
     bus.on(DiagnosticEvent.CHANNEL, diagnostics.append)
 
+    services: dict[str, Any] = {}
+
     class _Api:
         events = bus
         model = Model(id="m", provider="unknown", context_window=1000, max_output_tokens=10)
 
         def on(self, channel: str, handler: Callable[..., Any]) -> None:
             bus.on(channel, handler)
+
+        def set_service(self, name: str, obj: Any) -> None:
+            services[name] = obj
 
     cost_budget.install(cast(Any, _Api()), {"limit": 1.0, "pricing": {}})
     event = BeforeSendToLlmEvent(
@@ -108,6 +113,9 @@ async def test_cost_budget_warns_once_for_unpriced_provider() -> None:
     warnings = [item for item in diagnostics if item.level == "warning"]
     assert len(warnings) == 1
     assert "unknown" in warnings[0].message
+    assert (
+        services["cost_query"].estimate(event.model, provider="unknown").amount == 0.0
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #97

## What changed
- Layer/axis touched: presenter rendering in CLI/TUI, core pure helper utilities, ExtensionAPI service/renderer surfaces, and the policy atom `cost_budget`.
- Added `agentm.core.lib.render` for assistant text, tool-call text, tool-result text, raw usage summaries, and final summaries.
- Added `CostQueryService` / `CostBreakdown` and registered `cost_query` from `cost_budget`; CLI/TUI now degrade to token-only output when the service is absent.
- Added `api.register_tool_renderer(...)` and moved edit diff rendering to a `result_format` metadata hint on the edit tool instead of Textual string-matching `tool_edit`.
- Fixed the Textual dispatch regression test to use a provider descriptor available in the default registry while still monkeypatching the runner.

## Requirement and docs
- Satisfies `REQ-097-shared-presenter-rendering` in `project-index.yaml`.
- Updated `.claude/designs/pluggable-architecture.md` with shared presenter rendering rules.
- Added `.claude/tasks/2026-05-09-issue-97-shared-rendering.md` and linked `.claude/index.yaml`.

## Test justification
- `tests/unit/core/lib/test_render.py` protects a load-bearing pluggability boundary: presenters must share pure core rendering helpers and avoid atom-private pricing imports or tool-name branches, otherwise disabling/replacing atoms can break CLI/TUI behavior.

## Validation
- `uv run ruff check src/`
- `uv run ruff check tests/integration/test_textual_tui.py tests/unit/core/lib/test_render.py src/`
- `uv run mypy src/`
- `uv run pytest -m ui --tb=short`
- `uv run pytest --tb=short`
- `uv run python -m agentm.extensions.validate src/agentm/extensions/builtin/cost_budget.py src/agentm/extensions/builtin/tool_edit.py`
- `python3 /home/ddq/.claude/plugins/cache/autoharness/autoharness/1.1.3/scripts/validate_index.py project-index.yaml`
