### PR TITLE
Fix issue #123 misc tail cleanups

### DIFF
--- a/src/agentm/ai/oauth/types.py
+++ b/src/agentm/ai/oauth/types.py
@@ -10,14 +10,16 @@ from typing import Any, Awaitable, Callable, Protocol
 class OAuthCredentials:
     """Persisted credentials for an OAuth provider session.
 
-    ``expires`` is an absolute unix timestamp in milliseconds (matches
-    pi-mono). Additional provider-specific fields (e.g. ``account_id``)
-    can be stashed in ``extra``.
+    ``expires_at_ms`` is an absolute unix timestamp in **milliseconds**
+    (mirrors pi-mono's JS-native ``Date.now()`` units; the explicit ``_ms``
+    suffix prevents the second/millisecond ambiguity that caused issue #123
+    E14). Additional provider-specific fields (e.g. ``account_id``) can be
+    stashed in ``extra``.
     """
 
     refresh: str
     access: str
-    expires: int
+    expires_at_ms: int
     extra: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/agentm/extensions/builtin/inherit_provider.py
+++ b/src/agentm/extensions/builtin/inherit_provider.py
@@ -14,6 +14,11 @@ from typing import Any, Final
 from agentm.extensions import ExtensionManifest
 from agentm.harness.extension import ExtensionAPI, ExtensionLoadError, ProviderConfig
 
+# Config key the spawn factory uses to hand the parent provider over. Public
+# so the factory and tests can reference it without a magic-string copy.
+PARENT_PROVIDER_CONFIG_KEY: Final = "provider"
+
+
 MANIFEST = ExtensionManifest(
     name="inherit_provider",
     description=(
@@ -25,25 +30,20 @@ MANIFEST = ExtensionManifest(
     config_schema={
         "type": "object",
         "properties": {
-            "provider": {
+            PARENT_PROVIDER_CONFIG_KEY: {
                 "description": (
                     "ProviderConfig instance from the parent session. "
                     "Injected by the spawn factory; not user-settable."
                 ),
             },
         },
-        "required": ["provider"],
+        "required": [PARENT_PROVIDER_CONFIG_KEY],
         "additionalProperties": False,
     },
     requires=(),  # Leaf provider shim: consumes only injected config.
     api_version=1,
     tier=1,
 )
-
-
-# Config key the spawn factory uses to hand the parent provider over. Public
-# so the factory and tests can reference it without a magic-string copy.
-PARENT_PROVIDER_CONFIG_KEY = "provider"
 
 
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:

--- a/src/agentm/extensions/builtin/tool_bash.py
+++ b/src/agentm/extensions/builtin/tool_bash.py
@@ -11,6 +11,8 @@ from agentm.extensions import ExtensionManifest
 from agentm.harness.extension import ExtensionAPI
 
 
+_DEFAULT_TIMEOUT_SECONDS: Final[float] = 120.0
+
 MANIFEST = ExtensionManifest(
     name="tool_bash",
     description="Register the bash tool backed by BashOperations.",
@@ -19,7 +21,11 @@ MANIFEST = ExtensionManifest(
         "type": "object",
         "properties": {
             "bash_ops": {"type": "object"},
-            "default_timeout": {"type": "number", "minimum": 0, "default": 120.0},
+            "default_timeout": {
+                "type": "number",
+                "minimum": 0,
+                "default": _DEFAULT_TIMEOUT_SECONDS,
+            },
         },
         "additionalProperties": True,
     },
@@ -39,7 +45,7 @@ _PARAMETERS: Final[dict[str, Any]] = {
 
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     bash_ops = _coerce_bash_ops(api, config.get("bash_ops"))
-    default_timeout = float(config.get("default_timeout", 120.0))
+    default_timeout = float(config.get("default_timeout", _DEFAULT_TIMEOUT_SECONDS))
 
     parameters = {
         **_PARAMETERS,

--- a/src/agentm/extensions/validate.py
+++ b/src/agentm/extensions/validate.py
@@ -287,6 +287,29 @@ def _check_ast_rules(
 
     ignored_lines = {ignore.lineno for ignore in tree.type_ignores}
 
+    # §11.4.D7 — atoms that opt into the ``inherit_provider`` config protocol
+    # must reach for the parent-provider key via ``PARENT_PROVIDER_CONFIG_KEY``,
+    # never the bare ``"provider"`` literal. The constant is the only canonical
+    # link between the spawn factory and the atom; bare literals silently drift.
+    if _imports_parent_provider_config_key(tree):
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value == "provider"
+            ):
+                issues.append(
+                    ValidationIssue(
+                        module_path=module_path,
+                        rule="11.4.D7-inherit-provider-bare-literal",
+                        message=(
+                            "use PARENT_PROVIDER_CONFIG_KEY rather than the "
+                            "bare \"provider\" string when reading the "
+                            "inherit_provider config payload"
+                        ),
+                    )
+                )
+
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _is_private_api_getattr(node):
             issues.append(
@@ -536,6 +559,22 @@ def _is_api_registry_mutating_call(node: ast.Call) -> bool:
     return _is_api_registry_mutation_target(receiver)
 
 
+def _imports_parent_provider_config_key(tree: ast.Module) -> bool:
+    """True if the module imports ``PARENT_PROVIDER_CONFIG_KEY``.
+
+    Used by §11.4.D7 to scope the bare-``"provider"``-literal check to atoms
+    that are actually wired into the ``inherit_provider`` protocol; otherwise
+    any string literal containing ``"provider"`` would false-positive.
+    """
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "PARENT_PROVIDER_CONFIG_KEY":
+                    return True
+    return False
+
+
 def _is_agentm_fstring_import(node: ast.Call) -> bool:
     func = node.func
     is_dynamic_import = False
@@ -597,8 +636,19 @@ def _annotation_is_final(node: ast.expr) -> bool:
 
 
 def _dynamic_import_target(node: ast.Call) -> str | None:
-    """Return the constant module name passed to ``importlib.import_module``
-    or ``__import__``, or ``None`` if the call is unrelated or non-constant."""
+    """Return the (best-effort) module name passed to ``importlib.import_module``
+    or ``__import__``, or ``None`` if the call is unrelated or non-recognised.
+
+    Recognises:
+
+    * pure ``ast.Constant`` string arguments — returned verbatim;
+    * ``ast.JoinedStr`` (f-string) whose first segment is a constant string
+      starting with ``"agentm."`` — returned as the literal prefix so that
+      ``_classify_import`` can detect dynamic imports targeting forbidden
+      ``agentm.*`` namespaces (e.g. ``f"agentm.harness.{name}"``). The
+      remaining ``FormattedValue`` segments are conservatively treated as
+      unknown and only the static prefix is returned.
+    """
 
     func = node.func
     is_dynamic_import = False
@@ -612,6 +662,16 @@ def _dynamic_import_target(node: ast.Call) -> str | None:
     first = node.args[0]
     if isinstance(first, ast.Constant) and isinstance(first.value, str):
         return first.value
+    if isinstance(first, ast.JoinedStr) and first.values:
+        prefix = first.values[0]
+        if (
+            isinstance(prefix, ast.Constant)
+            and isinstance(prefix.value, str)
+            and prefix.value.startswith("agentm.")
+        ):
+            # Strip a trailing dot so ``_classify_import`` matches the namespace
+            # without anchoring on a partial component.
+            return prefix.value.rstrip(".")
     return None
 
 

--- a/src/agentm/llm/openai.py
+++ b/src/agentm/llm/openai.py
@@ -749,10 +749,32 @@ def install(api: Any, config: dict[str, Any]) -> None:
         model_kwargs["max_output_tokens"] = int(config["max_output_tokens"])
     model = _build_model(model_id, **model_kwargs)
 
-    name = config.get("name") or "openai"
+    raw_name = config.get("name")
+    base_url = config.get("base_url")
+    if raw_name is None:
+        if _is_non_canonical_base_url(base_url):
+            raise DuplicateProviderError(
+                "agentm.llm.openai.install: config['name'] is required when "
+                f"base_url={base_url!r} is set to a non-canonical "
+                "OpenAI-compatible endpoint. Multiple custom endpoints "
+                "default to the bare 'openai' registry name and would "
+                "silently overwrite each other. Pass an explicit "
+                "config['name'] (e.g. 'doubao', 'litellm', 'deepseek')."
+            )
+        name = "openai"
+    else:
+        name = raw_name
     if not isinstance(name, str) or not name:
         raise ValueError(
             "agentm.llm.openai.install: config['name'] must be a non-empty string."
+        )
+
+    existing = getattr(api, "_providers", None)
+    if isinstance(existing, dict) and name in existing:
+        raise DuplicateProviderError(
+            f"agentm.llm.openai.install: provider name {name!r} is already "
+            "registered in this session. Choose a unique config['name'] for "
+            "each OpenAI-compatible endpoint."
         )
 
     api.register_provider(
@@ -761,4 +783,39 @@ def install(api: Any, config: dict[str, Any]) -> None:
     )
 
 
-__all__ = ["OpenAIStreamFn", "install"]
+# Canonical OpenAI base URLs — anything else is treated as a custom endpoint
+# (LiteLLM, DeepSeek, Doubao, vLLM, Ollama, ...). When ``name`` is omitted for
+# such an endpoint the provider would otherwise silently register under the
+# default key ``"openai"`` and overwrite an earlier custom registration.
+_CANONICAL_OPENAI_BASE_URLS: frozenset[str] = frozenset(
+    {
+        "https://api.openai.com/v1",
+        "https://api.openai.com/v1/",
+        "https://api.openai.com",
+        "https://api.openai.com/",
+    }
+)
+
+
+def _is_non_canonical_base_url(base_url: object) -> bool:
+    if base_url is None:
+        return False
+    if not isinstance(base_url, str) or not base_url.strip():
+        return False
+    return base_url.rstrip("/") not in {url.rstrip("/") for url in _CANONICAL_OPENAI_BASE_URLS}
+
+
+class DuplicateProviderError(ValueError):
+    """Raised when an OpenAI-compatible provider would shadow an existing one.
+
+    Two situations trigger this:
+
+    * ``config['base_url']`` points at a non-canonical (custom) OpenAI-compatible
+      endpoint and ``config['name']`` was not supplied — the install would
+      otherwise default to the bare ``"openai"`` registry key and silently
+      collide with another custom endpoint registered in the same session.
+    * The session already has a provider registered under the requested name.
+    """
+
+
+__all__ = ["DuplicateProviderError", "OpenAIStreamFn", "install"]

--- a/tests/unit/test_issue_123_misc_cleanups.py
+++ b/tests/unit/test_issue_123_misc_cleanups.py
@@ -1,0 +1,207 @@
+"""Regression tests for issue #123 misc tail cleanups.
+
+Locks down five small cleanups so that subsequent refactors cannot silently
+re-introduce the original drift:
+
+* C13 — ``tool_bash`` default timeout is sourced from a single module
+  constant (no parallel literal in schema vs runtime).
+* C15 — ``inherit_provider`` exports ``PARENT_PROVIDER_CONFIG_KEY`` and the
+  validator flags atoms that read the config via the bare ``"provider"``
+  literal alongside the constant import.
+* D5 — ``_dynamic_import_target`` recognises one level of ``f"agentm.{...}"``
+  template and routes it through the import allow-list.
+* E10 — registering two non-canonical OpenAI-compatible providers without an
+  explicit ``name`` raises ``DuplicateProviderError``.
+* E14 — ``OAuthCredentials`` exposes the millisecond-suffixed
+  ``expires_at_ms`` field.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentm.ai.oauth.types import OAuthCredentials
+from agentm.extensions.builtin import inherit_provider, tool_bash
+from agentm.extensions.validate import (
+    _dynamic_import_target,
+    _imports_parent_provider_config_key,
+)
+from agentm.llm.openai import DuplicateProviderError
+
+
+# --- C13 -------------------------------------------------------------------
+
+
+def test_tool_bash_default_timeout_single_source_of_truth() -> None:
+    """Schema default and runtime fallback must read the same constant."""
+
+    schema_default = (
+        tool_bash.MANIFEST.config_schema["properties"]["default_timeout"]["default"]
+    )
+    assert schema_default == tool_bash._DEFAULT_TIMEOUT_SECONDS
+
+    # The install() runtime fallback reads from the same constant: scan the
+    # source for a literal ``120`` / ``120.0`` to ensure it has been removed.
+    src = Path(tool_bash.__file__).read_text(encoding="utf-8")
+    install_index = src.index("def install(")
+    install_body = src[install_index:]
+    assert "120.0" not in install_body
+    assert "120)" not in install_body
+
+
+# --- C15 -------------------------------------------------------------------
+
+
+def test_inherit_provider_exports_constant_and_uses_it_in_schema() -> None:
+    assert inherit_provider.PARENT_PROVIDER_CONFIG_KEY == "provider"
+    schema = inherit_provider.MANIFEST.config_schema
+    # Schema is built via the constant — ensure required[] mentions exactly
+    # one canonical key.
+    assert schema["required"] == [inherit_provider.PARENT_PROVIDER_CONFIG_KEY]
+    assert inherit_provider.PARENT_PROVIDER_CONFIG_KEY in schema["properties"]
+
+
+def test_validator_flags_bare_provider_literal_in_inherit_provider_consumer() -> None:
+    """An atom that imports PARENT_PROVIDER_CONFIG_KEY but also uses the
+    bare \"provider\" string literal trips the §11.4.D7 rule."""
+
+    from agentm.extensions.validate import _check_ast_rules
+
+    src = (
+        "from agentm.extensions.builtin.inherit_provider import "
+        "PARENT_PROVIDER_CONFIG_KEY\n"
+        "def install(api, config):\n"
+        "    config['provider']  # noqa\n"
+    )
+    bad_file = Path(__file__).parent / "_issue_123_bad_consumer.py"
+    bad_file.write_text(src, encoding="utf-8")
+    try:
+        issues = _check_ast_rules("test.bad_consumer", bad_file)
+    finally:
+        bad_file.unlink(missing_ok=True)
+
+    assert any(
+        issue.rule == "11.4.D7-inherit-provider-bare-literal"
+        for issue in issues
+    ), issues
+
+
+def test_validator_does_not_flag_atoms_that_skip_the_constant() -> None:
+    """Atoms that never import PARENT_PROVIDER_CONFIG_KEY are out of scope —
+    rule must not fire on incidental ``"provider"`` strings elsewhere in the
+    catalog."""
+
+    src = (
+        "def install(api, config):\n"
+        "    return 'provider'  # unrelated literal\n"
+    )
+    tree = ast.parse(src)
+    assert _imports_parent_provider_config_key(tree) is False
+
+
+# --- D5 --------------------------------------------------------------------
+
+
+def test_dynamic_import_target_returns_constant_string() -> None:
+    tree = ast.parse('importlib.import_module("agentm.harness.session")')
+    call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    assert _dynamic_import_target(call) == "agentm.harness.session"
+
+
+def test_dynamic_import_target_recognises_agentm_fstring_prefix() -> None:
+    """f-string with ``agentm.`` constant prefix is treated as a dynamic
+    import targeting that namespace, so ``_classify_import`` can apply the
+    forbidden-prefix list."""
+
+    tree = ast.parse('importlib.import_module(f"agentm.harness.{name}")')
+    call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    target = _dynamic_import_target(call)
+    assert target is not None
+    assert target.startswith("agentm.harness")
+
+
+def test_dynamic_import_target_ignores_non_agentm_fstring() -> None:
+    tree = ast.parse('importlib.import_module(f"other.{name}")')
+    call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    assert _dynamic_import_target(call) is None
+
+
+# --- E10 -------------------------------------------------------------------
+
+
+class _StubApi:
+    def __init__(self) -> None:
+        self._providers: dict[str, Any] = {}
+        self.events = None
+
+    def get_service(self, _name: str) -> Any:
+        return None
+
+    def register_provider(self, name: str, config: Any) -> None:
+        self._providers[name] = config
+
+
+def test_openai_install_rejects_default_name_for_non_canonical_base_url() -> None:
+    """Two custom endpoints would both default to ``"openai"`` — refuse."""
+
+    from agentm.llm import openai as openai_mod
+
+    api = _StubApi()
+    with pytest.raises(DuplicateProviderError):
+        openai_mod.install(
+            api,
+            {
+                "model": "doubao-seed",
+                "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            },
+        )
+
+
+def test_openai_install_accepts_explicit_name_for_non_canonical_base_url() -> None:
+    from agentm.llm import openai as openai_mod
+
+    api = _StubApi()
+    openai_mod.install(
+        api,
+        {
+            "model": "doubao-seed",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            "name": "doubao",
+        },
+    )
+    assert "doubao" in api._providers
+
+
+def test_openai_install_detects_duplicate_name_in_session() -> None:
+    from agentm.llm import openai as openai_mod
+
+    api = _StubApi()
+    openai_mod.install(
+        api,
+        {
+            "model": "gpt-4o",
+            "base_url": "https://api.openai.com/v1",
+        },
+    )
+    with pytest.raises(DuplicateProviderError):
+        openai_mod.install(
+            api,
+            {
+                "model": "gpt-4o-mini",
+                "base_url": "https://api.openai.com/v1",
+            },
+        )
+
+
+# --- E14 -------------------------------------------------------------------
+
+
+def test_oauth_credentials_uses_expires_at_ms_field() -> None:
+    creds = OAuthCredentials(refresh="r", access="a", expires_at_ms=1_700_000_000_000)
+    assert creds.expires_at_ms == 1_700_000_000_000
+    # Old name is gone — guard against silent reintroduction.
+    assert not hasattr(creds, "expires")


### PR DESCRIPTION
Closes #123 (sub-issue of #73).

## Summary

- **C13** `tool_bash`: introduce `_DEFAULT_TIMEOUT_SECONDS = 120.0`; the schema default and runtime fallback now read the same constant.
- **C15** `inherit_provider`: schema keys built from `PARENT_PROVIDER_CONFIG_KEY`; validator §11.4.D7 flags atoms that import the constant but still use the bare `"provider"` literal.
- **D5** `extensions.validate._dynamic_import_target`: recognise `f"agentm.{...}"` templates so `_classify_import` can apply the forbidden-prefix list to dynamic imports inside that namespace.
- **E10** `llm/openai.install`: raise new `DuplicateProviderError` when a non-canonical OpenAI-compatible `base_url` is wired without explicit `name`, or when the requested name is already registered in the session.
- **E14** `ai/oauth/types`: rename `OAuthCredentials.expires` to `expires_at_ms` to make the millisecond unit explicit.

## Test plan

- [x] `uv run pytest --tb=short -q` (200 passed, 15 deselected)
- [x] `uv run ruff check src/`
- [x] `uv run mypy src/`
- [x] New regression suite `tests/unit/test_issue_123_misc_cleanups.py` (11 cases) locks down each cleanup so future refactors cannot silently re-introduce the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)