### PR TITLE
Fix issue #121 TUI dispatch + minimal flag

### DIFF
--- a/.claude/designs/self-modifiable-architecture.md
+++ b/.claude/designs/self-modifiable-architecture.md
@@ -22,9 +22,9 @@ A stronger property follows from this boundary, and the constitution split is de
 
 > **`core/abi/` + `core/lib/` + `llm/` + stdlib must be sufficient to launch a working agent loop.** No import from `agentm.harness` or `agentm.extensions` may be required.
 
-This is not just "agent cannot break core" — it is "core alone yields a usable agent". When the autonomy layer is corrupted (a self-edited atom misbehaves, a scenario YAML is malformed, an extension reload leaves harness in an inconsistent state), the operator still has a path to launch an agent: the minimal mode at `src/agentm/minimal.py`, exposed by `agentm --minimal`. That agent has only stdlib-backed tools (`read_file`, `write_file`, `bash`, `list_dir`) and no observability or session state, but it launches, accepts a prompt, calls tools, and returns — enough to inspect and repair whatever is broken above.
+This is not just "agent cannot break core" — it is "core alone yields a usable agent". When the autonomy layer is corrupted (a self-edited atom misbehaves, a scenario YAML is malformed, an extension reload leaves harness in an inconsistent state), the operator still has a path to launch an agent: invoke `agentm --no-extensions "<prompt>"` to bypass atom discovery entirely, leaving only the kernel + provider + loop. That floor has no tool environment, skills, or observability, but it launches, accepts a prompt, and returns — enough to inspect and repair whatever is broken above.
 
-The invariant is enforced structurally (the import graph of `agentm.minimal` is clean of `harness`/`extensions`) and is the load-bearing reason for keeping `core/abi/` and `core/lib/` import-closed. Future PRs that introduce a `harness` import into `core/abi/` or `core/lib/` should be rejected on this basis alone.
+The invariant is enforced structurally (no `harness`/`extensions` import in `core/abi/`, `core/lib/`, or `llm/`) and is the load-bearing reason for keeping `core/abi/` and `core/lib/` import-closed. Future PRs that introduce a `harness` import into `core/abi/` or `core/lib/` should be rejected on this basis alone.
 
 ---
 

--- a/.claude/index.yaml
+++ b/.claude/index.yaml
@@ -45,7 +45,7 @@ concepts:
     design: "designs/textual-tui.md"
     related_concepts: [pluggable_architecture, observability]
     plans: []
-    tasks: ["tasks/2026-05-09-issue-98-textual-tui-registries.md", "tasks/2026-05-09-issue-99-presenter-seams.md"]
+    tasks: ["tasks/2026-05-09-issue-98-textual-tui-registries.md", "tasks/2026-05-09-issue-99-presenter-seams.md", "tasks/2026-05-09-issue-121-tui-registries.md"]
 
   observability:
     description: "Per-session OTel-flavored JSONL diagnostic stream complementary to trajectory. Single principle: every signal goes through the bus. EventBus exposes EventBusObserver + emit_sync (sync handlers only, async skipped). New bus events: ApiRegisterEvent / ApiSendUserMessageEvent (harness, emit_sync from ExtensionAPI), LlmRequestStartEvent / LlmRequestEndEvent (kernel, around stream_fn drain in AgentLoop with try/except for error path), ExtensionInstallEvent (harness, around load_extension). observability builtin is a pure subscriber + Observer installed via ExtensionAPI.add_observer; no EventBus or ExtensionAPI monkey-patching. Records: session.start/ready/end, extension.install, api.register, api.send_user_message, llm.request.start/end, event.dispatch, handler.invoke, turn.summary. Writes to <cwd>/.agentm/observability/<trace_id>.jsonl, flushed per record. evolution_substrate extends session.start with active-set fingerprint binding the trace to exact (core, scenario, atom_versions) tuple."

--- a/.claude/tasks/2026-05-09-issue-121-tui-registries.md
+++ b/.claude/tasks/2026-05-09-issue-121-tui-registries.md
@@ -1,0 +1,36 @@
+# Issue #121 — TUI dispatch + minimal flag follow-up
+
+Closes the residual items from #73 §F that survived #98 / #99:
+
+| Sub-item | Action |
+|----------|--------|
+| **F2** `--minimal` doc/impl drift | `agentm.minimal` and `--minimal` are gone. Removed the line from `CLAUDE.md`, the README "Minimal mode (recovery floor)" section, and the `agentm --minimal` reference in `.claude/designs/self-modifiable-architecture.md`. The recovery-floor invariant is now phrased as "use `agentm --no-extensions` to bypass atom discovery". |
+| **F4** builtin command registry | Already done by #98 — `BuiltinCommandRegistry` + `register_extension_command` replaced the old `_BUILTIN_COMMANDS` dict + if-ladder. No further work needed for this PR. |
+| **F5** delta dispatch table | Already done by #98 — `_DELTA_HANDLERS` and `_CHILD_DELTA_HANDLERS` (`dict[type[StreamDelta], Callable]`) plus `_lookup_delta_handler` replaced the `isinstance` ladder. No further work needed. |
+| **F7** `is_self_modify` on `ExtensionReloadEvent` | Already done — `harness/events.py` defines `is_self_modify: bool = False`, the harness reloader sets it from `agent_initiated`, and `textual_app.handle_extension_reload` reads `event.is_self_modify` directly. The `_SELF_MODIFY_TRIGGERS` whitelist is gone. |
+| **F8** phase glyphs | Moved the canonical glyph table out of `modes/textual_app.py` into a new `agentm.core.abi.presenter` module (`Phase`, `PHASE_GLYPHS` exported from `core.abi`). `DefaultTheme` now defaults `phase_glyphs` to the kernel-owned mapping. Custom themes can still override; the TUI no longer owns the constant. |
+
+## Files touched
+
+- `CLAUDE.md` — drop `--minimal` from the build commands table.
+- `README.md` — replace "Minimal mode" section with a "Recovery floor" pointer to `--no-extensions`.
+- `.claude/designs/self-modifiable-architecture.md` — update the recovery-floor paragraph (no more `agentm.minimal`).
+- `src/agentm/core/abi/presenter.py` — **new**: `Phase` literal + `PHASE_GLYPHS` `MappingProxyType`.
+- `src/agentm/core/abi/__init__.py` — export `Phase`, `PHASE_GLYPHS`.
+- `src/agentm/modes/textual_app.py` — import kernel `Phase` / `PHASE_GLYPHS`; `DefaultTheme.phase_glyphs` defaults to the kernel mapping.
+- `.claude/index.yaml` — append this task to `textual_tui.tasks`.
+
+## Gates
+
+- `uv run pytest --tb=short -q` — 188 passed.
+- `uv run pytest -m ui --tb=short -q` — 15 passed.
+- `uv run ruff check src/` — clean.
+- `uv run mypy src/` — clean (110 files).
+
+## Notes
+
+The presenter glyph table sits in `core.abi` rather than as event-payload
+data because it is a stable view-contract (every presenter wants the same
+phase taxonomy), not a per-event signal. AC permitted either path; the
+frozen-export route requires no event-bus surgery and keeps the TUI side
+purely declarative.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,7 @@ boundary contract in `.claude/designs/pluggable-architecture.md`.
 
 ```bash
 uv sync                                # install deps
-uv run agentm "<prompt>"               # full mode (loads general_purpose scenario)
-uv run agentm --minimal "<prompt>"     # recovery floor (stdlib tools only)
+uv run agentm "<prompt>"               # full mode (auto-discovers builtin atoms)
 uv run pytest                          # run tests (excludes nested workspaces, ui)
 uv run pytest -m ui                    # Textual TUI tests (opt-in)
 uv run ruff check src/                 # lint

--- a/README.md
+++ b/README.md
@@ -192,31 +192,21 @@ final_messages = await session.prompt("explain core/abi/loop.py")
 await session.shutdown()
 ```
 
-### Minimal mode (recovery floor)
+### Recovery floor
+
+When the autonomy layer is broken (a corrupted atom, a regressing
+scenario, a harness bug), use `--no-extensions` to drive the kernel
+without any atoms loaded — the agent still launches with provider +
+loop and can be steered toward diagnosis:
 
 ```bash
-uv run agentm --minimal "list files in src/"               # all 4 stdlib tools
-uv run agentm --minimal --tools read_file,bash "..."       # subset
-uv run agentm --minimal --tools "" "summarize this idea"   # chat-only
+uv run agentm --no-extensions "explain core/abi/loop.py"
 ```
 
-Minimal mode bypasses the harness and extensions entirely — it drives
-`AgentLoop` directly with stdlib-backed tools (`read_file`, `write_file`,
-`bash`, `list_dir`). The dependency cone is exactly
-`core/abi` + `core/lib` + `llm` + stdlib. **Use it when something above
-core is broken** (a corrupted atom, a regressing scenario, a harness bug):
-the agent still launches, and you can give it instructions to diagnose
-and fix the autonomy layer.
-
-```python
-from agentm.minimal import run_minimal
-
-final = await run_minimal(
-    prompt="explain core/abi/loop.py",
-    model="claude-sonnet-4-6",
-    tool_names=["read_file"],
-)
-```
+The dependency cone in this mode is `core/abi` + `core/lib` + `llm` +
+harness. No tool environment, no skills, no observability — exactly the
+"core alone yields a usable agent" floor described in
+`.claude/designs/self-modifiable-architecture.md`.
 
 Every full-mode feature (skills, prompt templates, compaction, observability,
 permission gates, ...) is opt-in through a scenario recipe or extension config —

--- a/src/agentm/core/abi/__init__.py
+++ b/src/agentm/core/abi/__init__.py
@@ -52,6 +52,7 @@ from .events import (
     TurnStartEvent,
 )
 from .loop import AgentLoop, LoopConfig
+from .presenter import PHASE_GLYPHS, Phase
 from .provider import ProviderConfig, ProviderManifest, ProviderResolver
 from .retry import RetryPolicy
 from .services import CostBreakdown, CostQueryService
@@ -104,6 +105,9 @@ __all__ = [
     # loop
     "AgentLoop",
     "LoopConfig",
+    # presenter view contract
+    "PHASE_GLYPHS",
+    "Phase",
     # provider
     "ProviderConfig",
     "ProviderManifest",

--- a/src/agentm/core/abi/presenter.py
+++ b/src/agentm/core/abi/presenter.py
@@ -1,0 +1,36 @@
+"""Presenter-facing view constants exported by the kernel.
+
+The CLI and TUI render an evolving "phase" (idle / thinking / streaming /
+tool / subagent) alongside the model name and turn counter. Earlier
+revisions hardcoded the glyph table in ``modes/textual_app.py``, which
+meant every presenter that wanted parity (a textual app, a curses wrapper,
+a JSON status line for an HTTP gateway) had to copy-paste the same five
+strings. The framework's posture is "kernel exports the contract,
+presenters consume it" — so the canonical phase set lives here.
+
+This module is pure data: no imports beyond ``typing``. It is part of
+``core.abi``'s public surface and follows the same stability promise as
+the event taxonomy. Adding a phase is a constitution change.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Final, Literal, Mapping
+
+Phase = Literal["idle", "thinking", "streaming", "tool", "subagent"]
+
+# The default UTF-8 glyph table. Wrapped in ``MappingProxyType`` so callers
+# cannot mutate the canonical surface at runtime; presenters that want a
+# different look should compose a private dict, not patch this one.
+PHASE_GLYPHS: Final[Mapping[Phase, str]] = MappingProxyType(
+    {
+        "idle": "●",        # ●
+        "thinking": "◐",    # ◐
+        "streaming": "◑",   # ◑
+        "tool": "▶",        # ▶
+        "subagent": "↳",    # ↳
+    }
+)
+
+__all__ = ["Phase", "PHASE_GLYPHS"]

--- a/src/agentm/modes/textual_app.py
+++ b/src/agentm/modes/textual_app.py
@@ -5,8 +5,8 @@ import base64
 import json
 import sys
 import time
-from collections.abc import Awaitable, Callable, Iterable, Sequence
-from dataclasses import dataclass
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, Literal, Protocol, TypeVar
 
@@ -26,10 +26,12 @@ from textual.widgets import Collapsible, Input, OptionList, Static, TextArea
 from textual.widgets.option_list import Option
 
 from agentm.core.abi import (
+    PHASE_GLYPHS,
     AssistantMessage,
     LlmRequestEndEvent,
     LlmRequestStartEvent,
     MessageEnd,
+    Phase as KernelPhase,
     StreamDeltaEvent,
     TextDelta,
     ThinkingDelta,
@@ -61,7 +63,9 @@ from agentm.harness import (
 )
 
 
-Phase = Literal["idle", "thinking", "streaming", "tool", "subagent"]
+# Re-export the kernel ``Phase`` literal under the legacy presenter name
+# so existing module consumers (tests, themes) keep their imports.
+Phase = KernelPhase
 CommandHandler = Callable[["AgentMApp", str], Awaitable[None] | None]
 KeyMap = Sequence[Binding]
 PromptFailure = Exception
@@ -69,23 +73,23 @@ PromptFailure = Exception
 
 class Theme(Protocol):
     @property
-    def phase_glyphs(self) -> dict[Phase, str]: ...
+    def phase_glyphs(self) -> Mapping[Phase, str]: ...
 
 
 @dataclass(frozen=True, slots=True)
 class DefaultTheme:
-    phase_glyphs: dict[Phase, str]
+    """Default presenter theme.
+
+    The glyph table comes from ``agentm.core.abi.PHASE_GLYPHS`` — the
+    kernel owns the canonical phase set so multiple presenters render
+    consistently. A custom theme can supply its own ``phase_glyphs`` to
+    override the look without forking the kernel.
+    """
+
+    phase_glyphs: Mapping[Phase, str] = field(default_factory=lambda: PHASE_GLYPHS)
 
 
-DEFAULT_THEME = DefaultTheme(
-    phase_glyphs={
-        "idle": "●",
-        "thinking": "◐",
-        "streaming": "◑",
-        "tool": "▶",
-        "subagent": "↳",
-    }
-)
+DEFAULT_THEME = DefaultTheme()
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Closes #121 — wraps up the residual items from #73 §F that survived #98 / #99.

## Summary
- **F2**: `agentm.minimal` and `--minimal` no longer exist. Removed the stale references from `CLAUDE.md`, `README.md` (the "Minimal mode (recovery floor)" section), and `.claude/designs/self-modifiable-architecture.md`. The recovery floor is now phrased as `agentm --no-extensions`.
- **F4 / F5 / F7**: already shipped via #98 — `BuiltinCommandRegistry` replaced the hand-written dict + if-ladder, `_DELTA_HANDLERS` / `_CHILD_DELTA_HANDLERS` `dict[type, Callable]` replaced the `isinstance` ladder, and `ExtensionReloadEvent.is_self_modify` (set by the harness) replaced the `_SELF_MODIFY_TRIGGERS` whitelist. Verified in this PR's task note; no new code needed.
- **F8**: lifted `Phase` + `PHASE_GLYPHS` out of `modes/textual_app.py` into a new `agentm.core.abi.presenter` module (`MappingProxyType` so callers cannot mutate the canonical surface). Re-exported from `agentm.core.abi` so any presenter — TUI, CLI status line, future HTTP gateway — pulls the same glyph table. `DefaultTheme.phase_glyphs` defaults to the kernel mapping; custom themes can still override.

## Why `core.abi` and not an event payload
The AC permitted either route. Phase is a stable view-contract (every presenter wants the same five phases), not a per-event signal — a frozen export keeps the bus surface untouched and lets the TUI side stay purely declarative.

## Files
- `CLAUDE.md`, `README.md`, `.claude/designs/self-modifiable-architecture.md` — drop `--minimal` / `agentm.minimal` references.
- `src/agentm/core/abi/presenter.py` — new module: `Phase` literal + `PHASE_GLYPHS` `MappingProxyType`.
- `src/agentm/core/abi/__init__.py` — export `Phase`, `PHASE_GLYPHS`.
- `src/agentm/modes/textual_app.py` — import the kernel-owned mapping; `DefaultTheme` defaults to it.
- `.claude/index.yaml` + `.claude/tasks/2026-05-09-issue-121-tui-registries.md` — concept-graph upkeep.

## Test plan
- [x] `uv run pytest --tb=short -q` — 188 passed
- [x] `uv run pytest -m ui --tb=short -q` — 15 passed
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/` — clean (110 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)