### PR TITLE
Fix issue #122 contrib cleanup batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 *.so
 .Python
+.pytest_cache/
 
 # Distribution / packaging
 dist/

--- a/contrib/extensions/cc/plugins.py
+++ b/contrib/extensions/cc/plugins.py
@@ -12,9 +12,13 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agentm.core.abi.events import DiagnosticEvent
 from agentm.extensions import ExtensionManifest
 from agentm.harness.events import ResourcesDiscoverEvent
 from agentm.harness.extension import ExtensionAPI
+
+
+_RECOGNIZED_SCOPES: frozenset[str] = frozenset({"user", "project"})
 
 
 MANIFEST = ExtensionManifest(
@@ -57,15 +61,23 @@ def _resolve_install_paths(
     registry_path: Path,
     cwd: str,
     exclude: set[str],
-) -> list[Path]:
+) -> tuple[list[Path], list[str]]:
+    """Return (install_paths, unknown_scope_keys).
+
+    Unknown scopes are silently dropped from the path list but their
+    ``<plugin>@<marketplace>`` keys are returned so the caller can surface
+    a diagnostic.
+    """
+
     if not registry_path.is_file():
-        return []
+        return [], []
     try:
         data = json.loads(registry_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return []
+        return [], []
     cwd_resolved = str(Path(cwd).resolve())
     result: list[Path] = []
+    unknown_scopes: list[str] = []
     for key, entries in (data.get("plugins") or {}).items():
         if key in exclude or not isinstance(entries, list):
             continue
@@ -83,19 +95,35 @@ def _resolve_install_paths(
                 if str(Path(project_path).resolve()) != cwd_resolved:
                     continue
             elif scope != "user":
+                if isinstance(scope, str) and scope not in _RECOGNIZED_SCOPES:
+                    unknown_scopes.append(f"{key}:{scope}")
                 continue
             path = Path(install_path)
             if path.is_dir():
                 result.append(path)
-    return result
+    return result, unknown_scopes
 
 
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     registry_path = Path(config.get("registry_path") or _default_registry_path())
     exclude = set(config.get("exclude") or ())
 
-    def _on_discover(_event: ResourcesDiscoverEvent) -> dict[str, Any] | None:
-        install_paths = _resolve_install_paths(registry_path, api.cwd, exclude)
+    async def _on_discover(_event: ResourcesDiscoverEvent) -> dict[str, Any] | None:
+        install_paths, unknown_scopes = _resolve_install_paths(
+            registry_path, api.cwd, exclude
+        )
+        for scope_key in unknown_scopes:
+            await api.events.emit(
+                DiagnosticEvent.CHANNEL,
+                DiagnosticEvent(
+                    level="warning",
+                    source="cc.plugins",
+                    message=(
+                        f"ignored installed plugin entry with unrecognized "
+                        f"scope: {scope_key} (expected 'user' or 'project')"
+                    ),
+                ),
+            )
         if not install_paths:
             return None
         resource_dirs: dict[str, list[str]] = {

--- a/contrib/extensions/llmharness/pyproject.toml
+++ b/contrib/extensions/llmharness/pyproject.toml
@@ -3,10 +3,17 @@ name = "llmharness"
 version = "0.1.0"
 description = "LLM-as-harness: cognitive-audit AgentM extension that supervises a running main agent via TurnEndEvent → child diagnostic session → BeforeAgentStart reminder injection."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "rca-autorl" }]
-dependencies = []
+# ``pyyaml`` is the only third-party runtime import outside the AgentM
+# workspace (used by ``audit.cards`` for card-corpus loading). ``agentm``
+# is consumed by ``adapters/agentm.py`` but is supplied by the parent
+# AgentM workspace at install time (path-installed by rca-autorl) rather
+# than as a PyPI dependency, so it is intentionally not listed here.
+dependencies = [
+  "pyyaml>=6",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/contrib/scenarios/plan_mode/tool_submit_plan.py
+++ b/contrib/scenarios/plan_mode/tool_submit_plan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from agentm.core.abi import FunctionTool, TextContent, ToolResult
+from agentm.core.abi.events import DiagnosticEvent
 from agentm.extensions import ExtensionManifest
 from agentm.harness.events import PlanSubmittedEvent
 from agentm.harness.extension import ExtensionAPI
@@ -32,17 +33,26 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
 
     async def _execute(args: dict[str, Any]) -> ToolResult:
         plan = str(args["plan"])
+        # Narrow catch: only persistence (``append_entry``) and event-bus
+        # ``emit`` can raise here, and both surface as ``OSError`` (FS
+        # failure) or ``RuntimeError`` (bus closed / state misuse). Anything
+        # else is a programming error and should propagate so the harness
+        # diagnostic stream sees it.
         try:
             plan_id = api.session.append_entry("plan", {"text": plan})
             await api.events.emit(
                 "plan_submitted",
                 PlanSubmittedEvent(plan_id=plan_id, plan_text=plan),
             )
-            return ToolResult(
-                content=[TextContent(type="text", text="plan submitted")],
-                extras={"plan_submitted": True, "plan_id": plan_id},
+        except (OSError, RuntimeError, ValueError) as exc:
+            await api.events.emit(
+                DiagnosticEvent.CHANNEL,
+                DiagnosticEvent(
+                    level="error",
+                    source="tool_submit_plan",
+                    message=f"submit_plan persistence failed: {exc!r}",
+                ),
             )
-        except Exception as exc:
             return ToolResult(
                 content=[
                     TextContent(
@@ -52,6 +62,10 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
                 ],
                 is_error=True,
             )
+        return ToolResult(
+            content=[TextContent(type="text", text="plan submitted")],
+            extras={"plan_submitted": True, "plan_id": plan_id},
+        )
 
     api.register_tool(
         FunctionTool(

--- a/contrib/scenarios/rca/README.md
+++ b/contrib/scenarios/rca/README.md
@@ -17,3 +17,31 @@ The root `agentm` package stays free of RCA, observability, and DuckDB concerns.
 - Changes to `src/agentm/` for RCA-specific behavior
 - DuckDB or observability dependencies added to the SDK
 - Tight coupling from the SDK back into RCA
+
+## Eval-config environment variables
+
+The YAML configs under `contrib/scenarios/rca/eval/` and
+`contrib/scenarios/rca_single/eval/` use shell-style ``${VAR:-default}``
+placeholders for paths and model identifiers so the same config is portable
+across machines. The external `rca llm-eval` runner does **not** expand them
+itself — pre-process the file with `envsubst` (or `gettext-base`) before
+piping it in:
+
+```bash
+RCA_DATASET_ROOT=/abs/path/to/rca \
+MODEL_NAME=Doubao-Seed-2.0-pro \
+JUDGE_MODEL=Doubao-Seed-2.0-pro \
+envsubst < contrib/scenarios/rca/eval/config.yaml \
+  | uv run rca llm-eval run - -a agentm -l 1
+```
+
+Recognized variables:
+
+| Variable            | Used in                          | Default                |
+|---------------------|----------------------------------|------------------------|
+| `RCA_DATASET_ROOT`  | `source_path`                    | (required, no default) |
+| `MODEL_NAME`        | top-level `model_name`           | `Doubao-Seed-2.0-pro`  |
+| `JUDGE_MODEL`       | `judge_model.model_provider.model` | `Doubao-Seed-2.0-pro` |
+
+`RCA_DATASET_ROOT` has no default — set it explicitly or the resulting YAML
+will contain an empty string and the runner will reject the config.

--- a/contrib/scenarios/rca/eval/config.yaml
+++ b/contrib/scenarios/rca/eval/config.yaml
@@ -1,9 +1,17 @@
 # LLM eval config for the AgentM rca scenario.
-# Run with: uv run rca llm-eval run contrib/scenarios/rca/eval/config.yaml -a agentm -l 1
+#
+# Path / model placeholders use shell-style ``${VAR:-default}`` syntax.
+# Expand before passing to ``rca llm-eval``:
+#
+#   RCA_DATASET_ROOT=/path/to/rca \
+#   envsubst < contrib/scenarios/rca/eval/config.yaml \
+#     | uv run rca llm-eval run - -a agentm -l 1
+#
+# See contrib/scenarios/rca/README.md for the full env-var contract.
 
 exp_id: "agentm-rca-smoke"
 agent_type: "agentm"
-model_name: "Doubao-Seed-2.0-pro"
+model_name: "${MODEL_NAME:-Doubao-Seed-2.0-pro}"
 
 data:
   # Must match a registered processer name (case-insensitive) so the
@@ -19,7 +27,7 @@ data:
 # Dataset layout: each sample lives at <source_path>/<source>/ (parquet
 # files + causal_graph.json + injection.json). Override the default
 # ".../converted" suffix.
-source_path: "/home/ddq/AoyangSpace/dataset/rca"
+source_path: "${RCA_DATASET_ROOT}"
 source_path_pattern: "{source_path}/{source}"
 
 concurrency: 5
@@ -33,5 +41,5 @@ judge_concurrency: 5
 judge_model:
   model_provider:
     type: "chat.completions"
-    model: "Doubao-Seed-2.0-pro"
+    model: "${JUDGE_MODEL:-Doubao-Seed-2.0-pro}"
     api_format: "anthropic"

--- a/contrib/scenarios/rca_single/eval/config.yaml
+++ b/contrib/scenarios/rca_single/eval/config.yaml
@@ -1,11 +1,17 @@
 # Single-agent rca eval config — A/B baseline vs the multi-agent rca scenario.
-# Run with:
-#   uv run rca llm-eval run contrib/scenarios/rca_single/eval/config.yaml \
-#     -a agentm -l 10 --ak scenario=rca_single
+#
+# Path / model placeholders use shell-style ``${VAR:-default}`` syntax.
+# Expand before passing to ``rca llm-eval``:
+#
+#   RCA_DATASET_ROOT=/path/to/rca \
+#   envsubst < contrib/scenarios/rca_single/eval/config.yaml \
+#     | uv run rca llm-eval run - -a agentm -l 10 --ak scenario=rca_single
+#
+# See contrib/scenarios/rca/README.md for the full env-var contract.
 
 exp_id: "agentm-rca-single-smoke"
 agent_type: "agentm"
-model_name: "Doubao-Seed-2.0-pro"
+model_name: "${MODEL_NAME:-Doubao-Seed-2.0-pro}"
 
 data:
   dataset: "RCABench"
@@ -14,7 +20,7 @@ data:
   gt_field: "answer"
   tags: ["openrca2-lite"]
 
-source_path: "/home/ddq/AoyangSpace/dataset/rca"
+source_path: "${RCA_DATASET_ROOT}"
 source_path_pattern: "{source_path}/{source}"
 
 concurrency: 5
@@ -23,5 +29,5 @@ judge_concurrency: 5
 judge_model:
   model_provider:
     type: "chat.completions"
-    model: "Doubao-Seed-2.0-pro"
+    model: "${JUDGE_MODEL:-Doubao-Seed-2.0-pro}"
     api_format: "anthropic"

--- a/contrib/scenarios/rca_single/eval/config_100.yaml
+++ b/contrib/scenarios/rca_single/eval/config_100.yaml
@@ -5,7 +5,7 @@
 
 exp_id: "agentm-rca-single-100"
 agent_type: "agentm"
-model_name: "Doubao-Seed-2.0-pro"
+model_name: "${MODEL_NAME:-Doubao-Seed-2.0-pro}"
 
 data:
   dataset: "RCABench"
@@ -14,7 +14,7 @@ data:
   gt_field: "answer"
   tags: ["openrca2-lite"]
 
-source_path: "/home/ddq/AoyangSpace/dataset/rca"
+source_path: "${RCA_DATASET_ROOT}"
 source_path_pattern: "{source_path}/{source}"
 
 concurrency: 5
@@ -23,5 +23,5 @@ judge_concurrency: 5
 judge_model:
   model_provider:
     type: "chat.completions"
-    model: "Doubao-Seed-2.0-pro"
+    model: "${JUDGE_MODEL:-Doubao-Seed-2.0-pro}"
     api_format: "anthropic"

--- a/contrib/scenarios/rca_single/eval/config_ops_lite_100.yaml
+++ b/contrib/scenarios/rca_single/eval/config_ops_lite_100.yaml
@@ -8,7 +8,7 @@
 
 exp_id: "agentm-rca-single-ops-lite-100"
 agent_type: "agentm"
-model_name: "Doubao-Seed-2.0-pro"
+model_name: "${MODEL_NAME:-Doubao-Seed-2.0-pro}"
 
 data:
   dataset: "ops-lite"
@@ -28,5 +28,5 @@ judge_concurrency: 5
 judge_model:
   model_provider:
     type: "chat.completions"
-    model: "Doubao-Seed-2.0-pro"
+    model: "${JUDGE_MODEL:-Doubao-Seed-2.0-pro}"
     api_format: "anthropic"

--- a/contrib/scenarios/rca_single/eval/ingest_ops_lite.py
+++ b/contrib/scenarios/rca_single/eval/ingest_ops_lite.py
@@ -14,16 +14,30 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from rcabench_platform.v3.sdk.llm_eval.db import DatasetSample
-from rcabench_platform.v3.sdk.llm_eval.utils.sqlmodel_utils import SQLModelUtils
-from sqlmodel import select
-
-
 DATASET_NAME = "ops-lite"
 CASES_DIR = Path("datasets/ops-lite/cases").resolve()
 
 
 def main() -> None:
+    # Optional deps are imported lazily so the surrounding rca_single
+    # scenario stays importable for tooling that walks the contrib tree on
+    # machines where rcabench-platform / sqlmodel are absent. Surface a
+    # single actionable SystemExit instead of a bare ``ImportError`` at
+    # module load.
+    try:
+        from rcabench_platform.v3.sdk.llm_eval.db import DatasetSample
+        from rcabench_platform.v3.sdk.llm_eval.utils.sqlmodel_utils import (
+            SQLModelUtils,
+        )
+        from sqlmodel import select
+    except ImportError as exc:
+        raise SystemExit(
+            "ingest_ops_lite.py needs the rcabench-platform + sqlmodel "
+            "packages installed. Run this script from a venv where "
+            "`uv run rca llm-eval` works (typically the rca-autorl "
+            f"workspace). Original error: {exc}"
+        ) from exc
+
     if not CASES_DIR.is_dir():
         raise SystemExit(f"missing dataset dir: {CASES_DIR}")
 

--- a/contrib/scenarios/trajectory_analysis/tool_trajectory_loader.py
+++ b/contrib/scenarios/trajectory_analysis/tool_trajectory_loader.py
@@ -73,38 +73,42 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
 
     async def _load(args: dict[str, Any]) -> ToolResult:
         path = str(args["path"])
+        # Narrow: ``read_file`` raises ``OSError`` on missing/permission,
+        # ``_parse_jsonl`` raises ``json.JSONDecodeError`` /
+        # ``UnicodeDecodeError`` on malformed payloads. Anything else
+        # propagates.
         try:
             events = _parse_jsonl(await file_ops.read_file(path))
-            loaded[path] = events
-            current_path[0] = path
-            return _json_result(
-                {"path": path, "event_count": len(events), "loaded": True}
-            )
-        except Exception as exc:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             return _error(f"Failed to load trajectory {path!r}: {exc}")
+        loaded[path] = events
+        current_path[0] = path
+        return _json_result(
+            {"path": path, "event_count": len(events), "loaded": True}
+        )
 
     async def _summarize(args: dict[str, Any]) -> ToolResult:
         try:
             path, events = _resolve_loaded(loaded, current_path[0], args.get("path"))
-            channels = Counter(str(item.get("channel", "unknown")) for item in events)
-            return _json_result(
-                {
-                    "path": path,
-                    "event_count": len(events),
-                    "channels": dict(sorted(channels.items())),
-                }
-            )
-        except Exception as exc:
+        except ValueError as exc:
             return _error(f"Failed to summarize trajectory: {exc}")
+        channels = Counter(str(item.get("channel", "unknown")) for item in events)
+        return _json_result(
+            {
+                "path": path,
+                "event_count": len(events),
+                "channels": dict(sorted(channels.items())),
+            }
+        )
 
     async def _find(args: dict[str, Any]) -> ToolResult:
         predicate = str(args["predicate"])
         try:
             _path, events = _resolve_loaded(loaded, current_path[0], args.get("path"))
-            matches = [event for event in events if _matches(event, predicate)]
-            return _json_result(matches)
-        except Exception as exc:
+        except ValueError as exc:
             return _error(f"Failed to find trajectory event: {exc}")
+        matches = [event for event in events if _matches(event, predicate)]
+        return _json_result(matches)
 
     async def _compare(args: dict[str, Any]) -> ToolResult:
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -672,6 +672,9 @@ wheels = [
 name = "llmharness"
 version = "0.1.0"
 source = { editable = "contrib/extensions/llmharness" }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -684,6 +687,7 @@ dev = [
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Closes #122 (sub-issue of #73 §G).

## Summary
- **G1/G2** rca + rca_single eval YAMLs now use `${RCA_DATASET_ROOT}` / `${MODEL_NAME:-Doubao-Seed-2.0-pro}` / `${JUDGE_MODEL:-Doubao-Seed-2.0-pro}` placeholders. `contrib/scenarios/rca/README.md` documents the `envsubst`-based usage and the variable contract.
- **G7** `.gitignore` picks up `.pytest_cache/`. `eval.db` is already covered by `*.db*`; neither file is tracked on origin/main.
- **G8/G9** `contrib/extensions/llmharness/pyproject.toml` lists `pyyaml>=6` as the actual third-party runtime dep and bumps `requires-python` to `>=3.12` to match what `adapters/agentm.py` consumes.
- **G10** `plan_mode/tool_submit_plan.py` narrows `except Exception` to `(OSError, RuntimeError, ValueError)` and emits a `DiagnosticEvent` so unexpected failures surface.
- **G11** `trajectory_analysis/tool_trajectory_loader.py` narrows the load catch to `(OSError, JSONDecodeError, UnicodeDecodeError)` and summarize/find to `ValueError`, matching the existing narrow `KeyError` in compare.
- **G14** `contrib/extensions/cc/plugins.py` emits `DiagnosticEvent(level="warning", source="cc.plugins", ...)` for installed-plugin entries whose scope is not `user` or `project`.
- **G16** `rca_single/eval/ingest_ops_lite.py` moves the `rcabench-platform` / `sqlmodel` imports into `main()` under `try/except ImportError`, raising `SystemExit` with an actionable message.

## Test plan
- [x] `uv run pytest --tb=short -q` → 200 passed / 15 deselected
- [x] `uv run ruff check contrib/` → clean
- [x] `uv run mypy src/` → clean
- [x] Smoke `import` of every touched contrib atom (`tool_submit_plan`, `tool_trajectory_loader`, `cc.plugins`) succeeds
- [ ] Manual smoke of `envsubst < contrib/scenarios/rca/eval/config.yaml | rca llm-eval run -` on a host with `RCA_DATASET_ROOT` set (out of CI scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)