### PR TITLE
feat(channels): Phase 1 — wire protocol + outbox + socket server + peer-cred auth

### DIFF
--- a/.claude/designs/client-server-architecture.md
+++ b/.claude/designs/client-server-architecture.md
@@ -194,19 +194,22 @@ Every JSON body wraps:
 
 ```json
 {
-  "v": "v0",
+  "v": 1,
   "id": "client-msg-12",
   "kind": "<kind>",
-  "ts": "2026-05-11T14:32:18Z",
+  "ts": 1746974538.42,
   "body": { ... }
 }
 ```
 
-* `v` — protocol version. Servers reject unknown majors.
+* `v` — integer wire-protocol version. Current: `1`. Servers reject
+  unknown versions immediately. Integer (not `"v0"` string) so
+  validation is a single equality check.
 * `id` — sender-assigned, opaque. Used to correlate replies/acks.
 * `kind` — discriminator (one of the kinds in §4.3).
-* `ts` — ISO 8601 UTC, advisory; servers use their own clock for
-  ordering when authoritative.
+* `ts` — float, epoch seconds. Advisory; servers use their own clock
+  for ordering when authoritative. (Float over ISO string for the
+  same reason as `v`: cheap validation, one canonical representation.)
 * `body` — kind-specific payload.
 
 ### 4.3 Kinds
@@ -279,12 +282,12 @@ op appears, we add it then.
 
 ```json
 {
-  "v":"v0", "id":"h1", "kind":"hello", "ts":"...",
+  "v":1, "id":"h1", "kind":"hello", "ts":1746974538.42,
   "body":{
     "peer_kind":"chat_client",
     "peer_name":"feishu",
     "peer_version":"0.1.0",
-    "wire_versions":["v0"],
+    "wire_versions":[1],
     "auth": {"method":"token","token":"..."} ,
     "capabilities":["streaming","buttons","markdown"]
   }
@@ -295,12 +298,12 @@ op appears, we add it then.
 
 ```json
 {
-  "v":"v0", "id":"h2", "kind":"hello", "ts":"...",
+  "v":1, "id":"h2", "kind":"hello", "ts":1746974538.42,
   "body":{
     "peer_kind":"agent_worker",
     "peer_name":"worker-gpu-1",
     "peer_version":"0.2.0",
-    "wire_versions":["v0"],
+    "wire_versions":[1],
     "auth": {"method":"token","token":"..."} ,
     "capabilities":{
       "scenarios":["general_purpose","rca","feishu_chat"],
@@ -316,10 +319,10 @@ op appears, we add it then.
 
 ```json
 {
-  "v":"v0", "id":"w1", "kind":"welcome", "ts":"...", "in_reply_to":"h1",
+  "v":1, "id":"w1", "kind":"welcome", "ts":1746974538.42, "in_reply_to":"h1",
   "body":{
     "server_version":"0.2.0",
-    "wire_version":"v0",
+    "wire_version":1,
     "peer_id":"feishu-a8f3e2",
     "session_resume": ["feishu:c123","feishu:c456"]
   }
@@ -379,11 +382,22 @@ an in-memory ring:
   before we recorded it) treats it as a no-op and re-acks.
   Idempotency-key field on `outbound` is the envelope `id`; peers
   dedup on `(server_peer_id, id)`.
-* **Bounded write-burst control.** When the outbox depth for a
-  peer exceeds `peer_outbox_high_water` (default 1000), inbound
-  *destined for that peer* triggers a `slow_consumer` event;
-  upstream peers (agent workers) get a flow-control hint to throttle
-  via `presence`.
+* **Bounded write-burst observation.** When the outbox depth for a
+  peer exceeds `peer_outbox_high_water` (default 1000), the delivery
+  worker emits a `slow_consumer` log line and sets an observational
+  `backpressure` flag on the peer session. v1 does **not** stop
+  pulling from the outbox under back-pressure (doing so would
+  deadlock the queue — the only way to drain it is to keep pulling).
+  Real back-pressure (gating enqueue at the producer) is a v2
+  concern, gated on whether a producer ever genuinely overruns
+  consumers in practice.
+* **Delivery-loop disconnect.** A single write failure
+  (BrokenPipeError / ConnectionResetError) terminates the peer's
+  delivery loop and tears down the peer session. The outbox row is
+  nack'd with backoff so it redelivers on reconnect — retrying the
+  same write against a dead writer would exhaust max_attempts in
+  milliseconds. (Implementation: `_ConnectionLost` sentinel in
+  `WireServer._delivery_loop`.)
 * **Crash recovery.** Gateway restart re-opens SQLite, finds
   `status=in_flight OR pending`, resets them to `pending`, the
   delivery worker resumes from there. No message is lost; some may
@@ -442,7 +456,7 @@ a 30-second outage into a slow drain.
 
    ```json
    {
-     "v":"v0", "id":"b1", "kind":"delivery_batch", "ts":"...",
+     "v":1, "id":"b1", "kind":"delivery_batch", "ts":1746974538.42,
      "body":{
        "reason":"reconnect_catchup",
        "session_key":"feishu:c123",

--- a/contrib/channels/pyproject.toml
+++ b/contrib/channels/pyproject.toml
@@ -33,3 +33,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agentm_channels"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/contrib/channels/src/agentm_channels/auth/__init__.py
+++ b/contrib/channels/src/agentm_channels/auth/__init__.py
@@ -1,0 +1,17 @@
+"""Authenticator implementations for the wire server.
+
+The :class:`Authenticator` :class:`typing.Protocol` lives in
+:mod:`agentm_channels.server` (the consumer). Concrete impls go here
+so we can grow the set without bloating ``server.py``.
+
+v1 ships a single concrete impl: :class:`UnixPeerCredAuthenticator`.
+Per ``.claude/designs/client-server-architecture.md`` §6, bearer-token
+and mTLS auth are deferred — Unix peer-cred + single-host gateway is
+the only supported deployment shape in v1.
+"""
+
+from __future__ import annotations
+
+from .peercred import UnixPeerCredAuthenticator
+
+__all__ = ["UnixPeerCredAuthenticator"]

--- a/contrib/channels/src/agentm_channels/auth/peercred.py
+++ b/contrib/channels/src/agentm_channels/auth/peercred.py
@@ -1,0 +1,126 @@
+"""Unix peer-credential :class:`Authenticator`.
+
+The connecting process's uid is read from the kernel (no token, no
+trust in client-supplied identity claims) and matched against an
+allow-list. Linux uses ``SO_PEERCRED``; macOS / *BSD use
+``os.getpeereid``.
+
+Design rationale (``.claude/designs/client-server-architecture.md``
+§5, §6): a Unix-socket gateway on a trusted host doesn't need bearer
+tokens — the kernel is a stronger authenticator than anything we can
+ship in user space. The token field on ``hello`` is ignored in this
+mode by design (defense-in-depth tokens are a v2 follow-up).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import struct
+import sys
+from typing import Any
+
+log = logging.getLogger("agentm_channels.auth")
+
+
+# Linux SO_PEERCRED struct ucred = (pid, uid, gid), three native ints.
+_UCRED_FMT = "3i"
+_UCRED_SIZE = struct.calcsize(_UCRED_FMT)
+
+
+def _peer_uid(sock: Any) -> int | None:
+    """Return the connecting process's uid, or ``None`` on failure.
+
+    Linux: ``SO_PEERCRED`` (kernel-vouched). macOS / *BSD: ``getpeereid``.
+    Wrapped in try/except OSError so an unsupported platform / closed
+    socket simply yields ``None`` instead of crashing the handshake.
+    """
+    if sys.platform.startswith("linux"):
+        try:
+            data = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, _UCRED_SIZE)
+        except OSError:
+            return None
+        try:
+            _pid, uid, _gid = struct.unpack(_UCRED_FMT, data)
+        except struct.error:
+            return None
+        return int(uid)
+    # macOS / *BSD fallback.
+    getpeereid = getattr(os, "getpeereid", None)
+    if getpeereid is None:
+        return None
+    try:
+        uid, _gid = getpeereid(sock.fileno())
+    except OSError:
+        return None
+    return int(uid)
+
+
+class UnixPeerCredAuthenticator:
+    """Allow connections by kernel-vouched peer uid.
+
+    Args:
+        allowed_uids: ``None`` accepts any local uid; an explicit empty
+            set denies all (useful for a circuit-breaker config); a
+            populated set is the allow-list.
+
+    Tokens in the ``hello`` envelope are ignored on purpose — the
+    kernel is the source of truth in peer-cred mode.
+    """
+
+    def __init__(self, allowed_uids: set[int] | None = None) -> None:
+        self._allowed_uids = allowed_uids
+
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,  # noqa: ARG002 — peer-cred ignores tokens by design
+        transport: asyncio.StreamWriter,
+    ) -> bool:
+        sock = transport.get_extra_info("socket")
+        # asyncio wraps the kernel socket in :class:`asyncio.TransportSocket`,
+        # which proxies ``getsockopt`` and ``fileno`` — both of which is
+        # all peer-cred lookup needs.
+        if sock is None or not hasattr(sock, "fileno"):
+            log.warning(
+                "peer-cred reject: peer=%s kind=%s — no socket on transport",
+                peer_id,
+                peer_kind,
+            )
+            return False
+        uid = _peer_uid(sock)
+        if uid is None:
+            log.warning(
+                "peer-cred reject: peer=%s kind=%s — could not read peer uid "
+                "(unsupported platform?)",
+                peer_id,
+                peer_kind,
+            )
+            return False
+        if self._allowed_uids is None:
+            log.info(
+                "peer-cred accept: peer=%s kind=%s uid=%d (any-uid policy)",
+                peer_id,
+                peer_kind,
+                uid,
+            )
+            return True
+        if uid in self._allowed_uids:
+            log.info(
+                "peer-cred accept: peer=%s kind=%s uid=%d", peer_id, peer_kind, uid
+            )
+            return True
+        log.warning(
+            "peer-cred reject: peer=%s kind=%s uid=%d not in allow-list %s",
+            peer_id,
+            peer_kind,
+            uid,
+            sorted(self._allowed_uids),
+        )
+        return False
+
+
+__all__ = ["UnixPeerCredAuthenticator"]

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -57,21 +57,28 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import signal
 import sys
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from agentm.ai import DEFAULT_PROVIDER_REGISTRY
 from agentm.core.abi import EventBus
 
 from .approval import ApprovalPolicy
+from .auth import UnixPeerCredAuthenticator
 from .bus import MessageBus
 from .gateway import Gateway, GatewayConfig
 from .manager import ChannelManager
+from .outbox import SqliteInbox, SqliteOutbox
+from .server import WireServer
+from .wire_bridge import WireBridge
 
 
 def _default_provider() -> str:
@@ -217,6 +224,84 @@ def _build_session_factory(
     return factory
 
 
+# -------- --bind resolution -------------------------------------------
+
+
+@dataclass(frozen=True)
+class BindSpec:
+    """Resolved ``--bind`` configuration. ``allow_uids`` of ``None``
+    means any-uid (peer-cred reads the kernel uid but doesn't filter)."""
+
+    socket_path: str
+    allow_uids: frozenset[int] | None
+
+
+def _resolve_bind(
+    args: argparse.Namespace, cfg: dict[str, Any]
+) -> BindSpec | None:
+    """Merge CLI flags > yaml ``bind:`` section > absent.
+
+    Returns ``None`` when neither side requests a wire bind. Raises
+    :class:`SystemExit` (exit code 2) on invalid input — TCP scheme,
+    or conflicting allow-uid flags.
+    """
+    cli_url = args.bind
+    yaml_bind = cfg.get("bind") if isinstance(cfg.get("bind"), dict) else None
+    yaml_url = (yaml_bind or {}).get("socket")
+    url = cli_url or yaml_url
+    if not url:
+        return None
+    parsed = urlparse(str(url))
+    if parsed.scheme != "unix":
+        raise SystemExit(
+            f"--bind scheme {parsed.scheme!r} not supported; only unix:// is "
+            "available in v1 (TCP is deferred per "
+            ".claude/designs/client-server-architecture.md §5.2)."
+        )
+    # urlparse on ``unix:///abs/path`` gives netloc="" and path="/abs/path".
+    socket_path = parsed.path or parsed.netloc
+    if not socket_path:
+        raise SystemExit(
+            f"--bind {url!r} has no socket path; use unix:///abs/path/to/sock"
+        )
+
+    cli_uids = list(args.bind_allow_uid or ())
+    cli_any = bool(args.bind_allow_any_uid)
+    if cli_uids and cli_any:
+        raise SystemExit(
+            "--bind-allow-uid and --bind-allow-any-uid are mutually exclusive."
+        )
+
+    if cli_uids or cli_any:
+        # CLI side made an explicit decision; YAML is ignored to keep
+        # the precedence rule honest.
+        allow_uids: frozenset[int] | None = (
+            None if cli_any else frozenset(int(x) for x in cli_uids)
+        )
+    elif yaml_bind is not None and (
+        "allow_uids" in yaml_bind or "allow_any_uid" in yaml_bind
+    ):
+        if yaml_bind.get("allow_any_uid") and yaml_bind.get("allow_uids"):
+            raise SystemExit(
+                "bind.allow_uids and bind.allow_any_uid are mutually exclusive."
+            )
+        if yaml_bind.get("allow_any_uid"):
+            allow_uids = None
+        else:
+            raw = yaml_bind.get("allow_uids") or []
+            if not isinstance(raw, list):
+                raise SystemExit("bind.allow_uids must be a list of integers.")
+            try:
+                allow_uids = frozenset(int(x) for x in raw)
+            except (TypeError, ValueError) as exc:
+                raise SystemExit(f"bind.allow_uids: invalid entry: {exc}") from exc
+    else:
+        # Most-secure default: current process uid only.
+        allow_uids = frozenset({os.geteuid()})
+
+    return BindSpec(socket_path=socket_path, allow_uids=allow_uids)
+
+
 # -------- argv ---------------------------------------------------------
 
 
@@ -287,6 +372,38 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     p.add_argument(
+        "--bind",
+        default=None,
+        help=(
+            "Run the wire-protocol server on the given URL (v1 supports "
+            "only ``unix:///abs/path/to/sock``; TCP is deferred). Coexists "
+            "with --terminal and the v0 channels: section. Authentication "
+            "is Unix peer-cred; by default only the current process's uid "
+            "may connect — override with --bind-allow-uid or "
+            "--bind-allow-any-uid."
+        ),
+    )
+    p.add_argument(
+        "--bind-allow-uid",
+        action="append",
+        type=int,
+        default=None,
+        metavar="UID",
+        help=(
+            "Add a uid to the peer-cred allow-list. Repeatable. Ignored "
+            "unless --bind is set. Mutually exclusive with "
+            "--bind-allow-any-uid."
+        ),
+    )
+    p.add_argument(
+        "--bind-allow-any-uid",
+        action="store_true",
+        help=(
+            "Accept any local peer uid. Use only on a fully trusted host. "
+            "Mutually exclusive with --bind-allow-uid."
+        ),
+    )
+    p.add_argument(
         "--check",
         action="store_true",
         help=(
@@ -338,6 +455,8 @@ async def _arun(args: argparse.Namespace) -> int:
     else:
         cwd = args.cwd
 
+    bind_spec = _resolve_bind(args, cfg)
+
     if args.terminal:
         # Terminal mode overrides any YAML/env channels — explicit flag
         # is unambiguous about intent (local validation, single user).
@@ -355,12 +474,12 @@ async def _arun(args: argparse.Namespace) -> int:
             args.log_level = "WARNING"
     else:
         channels_cfg = cfg.get("channels") or _channels_from_env(dict(os.environ))
-        if not channels_cfg:
+        if not channels_cfg and bind_spec is None:
             raise SystemExit(
                 "no channels configured. Pass --config <yaml> with a "
                 "`channels:` section, set LARK_APP_ID / LARK_APP_SECRET for "
-                "the one-liner Feishu mode, or run with --terminal for local "
-                "validation."
+                "the one-liner Feishu mode, run with --terminal for local "
+                "validation, or run with --bind unix:///… to accept wire peers."
             )
 
     provider = args.provider or cfg.get("provider") or _default_provider()
@@ -401,6 +520,12 @@ async def _arun(args: argparse.Namespace) -> int:
         ),
     )
 
+    state_dir = (
+        args.state_dir
+        or (Path(cfg["state_dir"]) if "state_dir" in cfg else None)
+        or (Path(cwd) / ".agentm" / "channels")
+    )
+
     if args.check:
         # ``--check`` is a dry-run gate: everything above has already
         # parsed config, validated YAML, instantiated channels (which
@@ -409,6 +534,22 @@ async def _arun(args: argparse.Namespace) -> int:
         # structurally OK. No channels are started → no LLM calls, no
         # network, no side effects.
         logger.info("config OK: channels=%s", sorted(manager.channels))
+        check_payload: dict[str, Any] = {
+            "kind": "check",
+            "channels": sorted(manager.channels),
+            "state_dir": str(state_dir),
+        }
+        if bind_spec is not None:
+            check_payload["bind"] = {
+                "socket": f"unix://{bind_spec.socket_path}",
+                "allow_uids": (
+                    sorted(bind_spec.allow_uids)
+                    if bind_spec.allow_uids is not None
+                    else None
+                ),
+            }
+        sys.stdout.write(json.dumps(check_payload) + "\n")
+        sys.stdout.flush()
         return EXIT_OK
 
     stop_event = asyncio.Event()
@@ -421,6 +562,36 @@ async def _arun(args: argparse.Namespace) -> int:
 
     await manager.start()
     await gateway.start()
+
+    wire_server: WireServer | None = None
+    wire_outbox: SqliteOutbox | None = None
+    wire_inbox: SqliteInbox | None = None
+    if bind_spec is not None:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        wire_outbox = SqliteOutbox(str(state_dir / "wire-outbox.sqlite"))
+        wire_inbox = SqliteInbox(str(state_dir / "wire-inbox.sqlite"))
+        bridge = WireBridge(bus=bus, manager=manager, outbox=wire_outbox)
+        authenticator = UnixPeerCredAuthenticator(
+            allowed_uids=set(bind_spec.allow_uids)
+            if bind_spec.allow_uids is not None
+            else None
+        )
+        wire_server = WireServer(
+            socket_path=bind_spec.socket_path,
+            outbox=wire_outbox,
+            inbox=wire_inbox,
+            on_inbound=bridge.handle_inbound,
+            authenticator=authenticator,
+        )
+        await wire_server.start()
+        logger.info(
+            "wire server bound at unix://%s (allow_uids=%s)",
+            bind_spec.socket_path,
+            sorted(bind_spec.allow_uids)
+            if bind_spec.allow_uids is not None
+            else "any",
+        )
+
     logger.info(
         "gateway running with channels: %s", sorted(manager.channels) or "(none)"
     )
@@ -449,6 +620,12 @@ async def _arun(args: argparse.Namespace) -> int:
         finally:
             if not signal_wait.done():
                 signal_wait.cancel()
+            if wire_server is not None:
+                await wire_server.stop()
+            if wire_outbox is not None:
+                wire_outbox.close()
+            if wire_inbox is not None:
+                wire_inbox.close()
             await gateway.stop()
             await manager.stop()
         return EXIT_OK
@@ -457,6 +634,12 @@ async def _arun(args: argparse.Namespace) -> int:
         await stop_event.wait()
     finally:
         logger.info("gateway shutting down")
+        if wire_server is not None:
+            await wire_server.stop()
+        if wire_outbox is not None:
+            wire_outbox.close()
+        if wire_inbox is not None:
+            wire_inbox.close()
         await gateway.stop()
         await manager.stop()
     return EXIT_OK

--- a/contrib/channels/src/agentm_channels/client.py
+++ b/contrib/channels/src/agentm_channels/client.py
@@ -1,0 +1,251 @@
+"""In-tree asyncio wire client.
+
+Used by Phase 1 integration tests and (in Phase 2+) by extracted
+channel processes. No reconnect logic — callers handle reconnect; the
+server-side outbox makes that safe (see §4.5 of the design doc).
+
+The on_outbound callback fires once per delivered envelope. For
+``delivery_batch`` frames (catch-up), the client iterates ``items``
+in order and invokes the callback for each item synchronously
+inside the read loop, so the application sees ordering as published.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from agentm_channels.wire import (
+    KIND_BYE,
+    KIND_DELIVERY_BATCH,
+    KIND_ERROR,
+    KIND_HELLO,
+    KIND_INBOUND,
+    KIND_OUTBOUND,
+    KIND_PING,
+    KIND_PONG,
+    KIND_WELCOME,
+    WIRE_VERSION,
+    Envelope,
+    InvalidEnvelope,
+    WireError,
+    decode_stream,
+    encode,
+)
+
+log = logging.getLogger("agentm_channels.client")
+
+OutboundHandler = Callable[[Envelope], Awaitable[None]]
+
+
+class AuthError(Exception):
+    """Server rejected our hello (auth_failed / duplicate_peer / etc.)."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class WireClient:
+    """Asyncio Unix-socket client to a :class:`WireServer`."""
+
+    def __init__(
+        self,
+        socket_path: str,
+        peer_id: str,
+        peer_kind: str,
+        *,
+        token: str | None = None,
+        on_outbound: OutboundHandler | None = None,
+    ) -> None:
+        self._socket_path = socket_path
+        self._peer_id = peer_id
+        self._peer_kind = peer_kind
+        self._token = token
+        self._on_outbound = on_outbound
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._read_task: asyncio.Task[None] | None = None
+        self._errors: asyncio.Queue[Envelope] = asyncio.Queue()
+        self._closed = False
+        self._welcome: Envelope | None = None
+
+    # -- lifecycle ----------------------------------------------------
+
+    async def connect(self) -> None:
+        self._reader, self._writer = await asyncio.open_unix_connection(
+            path=self._socket_path
+        )
+        hello = Envelope(
+            v=WIRE_VERSION,
+            id=f"hello-{self._peer_id}-{int(time.time() * 1000)}",
+            kind=KIND_HELLO,
+            ts=time.time(),
+            body={
+                "peer_id": self._peer_id,
+                "peer_kind": self._peer_kind,
+                "token": self._token,
+                "capabilities": {},
+            },
+        )
+        self._writer.write(encode(hello))
+        await self._writer.drain()
+        # Await first server frame: welcome or error.
+        first = await _read_one_frame(self._reader)
+        if first is None:
+            raise ConnectionRefusedError("server closed before welcome")
+        if first.kind == KIND_ERROR:
+            body = first.body if isinstance(first.body, dict) else {}
+            code = str(body.get("code", "unknown"))
+            message = str(body.get("message", ""))
+            with contextlib.suppress(Exception):
+                self._writer.close()
+                await self._writer.wait_closed()
+            raise AuthError(code, message)
+        if first.kind != KIND_WELCOME:
+            raise ConnectionRefusedError(f"expected welcome, got {first.kind!r}")
+        self._welcome = first
+        self._read_task = asyncio.create_task(self._read_loop(), name=f"client-read:{self._peer_id}")
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._writer is not None and not self._writer.is_closing():
+            bye = Envelope(
+                v=WIRE_VERSION,
+                id=f"bye-{self._peer_id}-{int(time.time() * 1000)}",
+                kind=KIND_BYE,
+                ts=time.time(),
+                body={},
+            )
+            with contextlib.suppress(Exception):
+                self._writer.write(encode(bye))
+                await self._writer.drain()
+            with contextlib.suppress(Exception):
+                self._writer.close()
+                await self._writer.wait_closed()
+        if self._read_task is not None:
+            self._read_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._read_task
+
+    # -- IO -----------------------------------------------------------
+
+    async def send(self, env: Envelope) -> None:
+        if self._writer is None:
+            raise RuntimeError("client not connected")
+        self._writer.write(encode(env))
+        await self._writer.drain()
+
+    async def send_inbound(self, body: dict[str, Any], env_id: str | None = None) -> None:
+        """Convenience: build + send an ``inbound`` envelope."""
+        env = Envelope(
+            v=WIRE_VERSION,
+            id=env_id or f"in-{self._peer_id}-{int(time.time() * 1000_000)}",
+            kind=KIND_INBOUND,
+            ts=time.time(),
+            body=body,
+        )
+        await self.send(env)
+
+    async def ping(self) -> None:
+        env = Envelope(
+            v=WIRE_VERSION,
+            id=f"ping-{self._peer_id}-{int(time.time() * 1000)}",
+            kind=KIND_PING,
+            ts=time.time(),
+            body={},
+        )
+        await self.send(env)
+
+    async def errors(self) -> Envelope:
+        """Block until the server emits an ``error`` envelope, then return it."""
+        return await self._errors.get()
+
+    def welcome(self) -> Envelope | None:
+        return self._welcome
+
+    # -- read loop ----------------------------------------------------
+
+    async def _read_loop(self) -> None:
+        assert self._reader is not None
+        buf = b""
+        try:
+            while True:
+                chunk = await self._reader.read(65536)
+                if not chunk:
+                    return
+                buf += chunk
+                try:
+                    envelopes, buf = decode_stream(buf)
+                except (InvalidEnvelope, WireError):
+                    log.exception("client received malformed frame")
+                    return
+                for env in envelopes:
+                    await self._dispatch(env)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("client read loop crashed for peer=%s", self._peer_id)
+
+    async def _dispatch(self, env: Envelope) -> None:
+        if env.kind == KIND_OUTBOUND:
+            if self._on_outbound is not None:
+                await self._on_outbound(env)
+            return
+        if env.kind == KIND_DELIVERY_BATCH:
+            items = (env.body or {}).get("items", []) if isinstance(env.body, dict) else []
+            if self._on_outbound is not None:
+                for item in items:
+                    try:
+                        sub = Envelope.from_dict(item)
+                    except (InvalidEnvelope, WireError):
+                        log.exception("client: bad item in delivery_batch")
+                        continue
+                    await self._on_outbound(sub)
+            return
+        if env.kind == KIND_PONG:
+            return
+        if env.kind == KIND_ERROR:
+            await self._errors.put(env)
+            return
+        # ping from server (future use): reply pong
+        if env.kind == KIND_PING:
+            if self._writer is not None:
+                pong = Envelope(
+                    v=WIRE_VERSION,
+                    id=f"pong-{self._peer_id}-{int(time.time() * 1000)}",
+                    kind=KIND_PONG,
+                    ts=time.time(),
+                    body={"echo_id": env.id},
+                )
+                self._writer.write(encode(pong))
+                with contextlib.suppress(Exception):
+                    await self._writer.drain()
+            return
+
+
+async def _read_one_frame(reader: asyncio.StreamReader) -> Envelope | None:
+    try:
+        header = await reader.readexactly(4)
+    except asyncio.IncompleteReadError:
+        return None
+    length = int.from_bytes(header, "big")
+    try:
+        body = await reader.readexactly(length)
+    except asyncio.IncompleteReadError:
+        return None
+    try:
+        envelopes, _rest = decode_stream(header + body)
+    except (InvalidEnvelope, WireError):
+        return None
+    return envelopes[0] if envelopes else None
+
+
+__all__ = ["AuthError", "WireClient"]

--- a/contrib/channels/src/agentm_channels/outbox/__init__.py
+++ b/contrib/channels/src/agentm_channels/outbox/__init__.py
@@ -1,0 +1,25 @@
+"""Durable outbox + idempotent inbox for the channels gateway.
+
+See ``.claude/designs/client-server-architecture.md`` §4.5. The
+package exposes two ``typing.Protocol``s as the only extension
+surface; default implementations are SQLite-backed.
+"""
+
+from __future__ import annotations
+
+from .errors import OutboxClosed, OutboxError
+from .policy import exponential_backoff
+from .protocol import InboxLog, OutboxRecord, OutboxStore
+from .sqlite import LEASE_TTL_SECONDS, SqliteInbox, SqliteOutbox
+
+__all__ = [
+    "LEASE_TTL_SECONDS",
+    "InboxLog",
+    "OutboxClosed",
+    "OutboxError",
+    "OutboxRecord",
+    "OutboxStore",
+    "SqliteInbox",
+    "SqliteOutbox",
+    "exponential_backoff",
+]

--- a/contrib/channels/src/agentm_channels/outbox/errors.py
+++ b/contrib/channels/src/agentm_channels/outbox/errors.py
@@ -1,0 +1,14 @@
+"""Outbox error types."""
+
+from __future__ import annotations
+
+
+class OutboxError(Exception):
+    """Base error for the outbox package."""
+
+
+class OutboxClosed(OutboxError):
+    """Raised when an operation is attempted on a closed outbox/inbox."""
+
+
+__all__ = ["OutboxClosed", "OutboxError"]

--- a/contrib/channels/src/agentm_channels/outbox/policy.py
+++ b/contrib/channels/src/agentm_channels/outbox/policy.py
@@ -1,0 +1,35 @@
+"""Retry policy as free functions.
+
+Kept separate from the outbox storage (mechanism) so callers — the
+server's delivery worker — pick the delay and pass it to
+:meth:`OutboxStore.nack`. Policy belongs to the caller; the store
+just persists what it's told.
+"""
+
+from __future__ import annotations
+
+import random
+
+
+def exponential_backoff(
+    attempts: int,
+    base: float = 1.0,
+    cap: float = 60.0,
+    jitter_ratio: float = 0.1,
+) -> float:
+    """Exponential backoff with proportional jitter.
+
+    ``min(cap, base * 2 ** (attempts - 1)) * (1 +/- jitter_ratio)``.
+    ``attempts`` is 1 after the first failure. ``jitter_ratio`` is the
+    fraction of the base delay added or subtracted uniformly.
+    """
+    if attempts < 1:
+        attempts = 1
+    raw = base * (2 ** (attempts - 1))
+    delay = min(cap, raw)
+    if jitter_ratio:
+        delay *= 1.0 + random.uniform(-jitter_ratio, jitter_ratio)
+    return max(0.0, delay)
+
+
+__all__ = ["exponential_backoff"]

--- a/contrib/channels/src/agentm_channels/outbox/protocol.py
+++ b/contrib/channels/src/agentm_channels/outbox/protocol.py
@@ -1,0 +1,121 @@
+"""Outbox / inbox extension protocols.
+
+Two ``typing.Protocol`` definitions form the only extension surface
+for durable delivery in the gateway. The default SQLite implementation
+lives in :mod:`agentm_channels.outbox.sqlite`. A contrib backend
+(Redis Streams, NATS JetStream, ...) only needs to satisfy these
+Protocols.
+
+See ``.claude/designs/client-server-architecture.md`` §4.5 for the
+delivery semantics this surface supports (at-least-once outbound,
+at-most-once-with-ack inbound, dead-letter on retry exhaustion).
+
+Mechanism only — retry/backoff policy lives in
+:mod:`agentm_channels.outbox.policy` so callers (the server) decide
+when to nack vs dead_letter and what delay to set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from agentm_channels.wire import Envelope
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxRecord:
+    """A leased outbox row handed to a delivery worker.
+
+    ``id`` is the storage-assigned row id used by ack/nack/dead_letter.
+    ``attempts`` is the attempt count *including* the lease that
+    produced this record (i.e. starts at 1 on first lease).
+    """
+
+    id: int
+    peer_id: str
+    envelope: Envelope
+    attempts: int
+    enqueued_at: float
+    next_retry_at: float
+
+
+@runtime_checkable
+class OutboxStore(Protocol):
+    """Durable per-peer queue. At-least-once delivery."""
+
+    def enqueue(self, peer_id: str, env: Envelope) -> None:
+        """Append ``env`` to ``peer_id``'s queue.
+
+        Idempotent on ``(peer_id, env.id)``: a duplicate enqueue is a
+        silent no-op so producer retry is safe.
+        """
+        ...
+
+    def lease(
+        self, peer_id: str, batch_max: int, now: float
+    ) -> list[OutboxRecord]:
+        """Lease up to ``batch_max`` ready records for ``peer_id``.
+
+        A record is *ready* when ``next_retry_at <= now`` and no
+        unexpired lease holds it. Leasing increments ``attempts`` and
+        marks the record leased until ``now + LEASE_TTL``. Returns
+        records ordered by enqueue order (FIFO).
+        """
+        ...
+
+    def ack(self, record_ids: list[int]) -> None:
+        """Permanently remove successfully-delivered records."""
+        ...
+
+    def nack(self, record_ids: list[int], next_retry_at: float) -> None:
+        """Release the lease and reschedule for later retry.
+
+        ``next_retry_at`` is computed by the caller (see
+        :mod:`agentm_channels.outbox.policy`).
+        """
+        ...
+
+    def dead_letter(self, record_id: int, reason: str) -> None:
+        """Move a record to the dead-letter table.
+
+        Caller invokes this after the retry policy says "give up".
+        """
+        ...
+
+    def pending_count(self, peer_id: str) -> int:
+        """Total rows queued for ``peer_id`` regardless of lease state."""
+        ...
+
+    def close(self) -> None:
+        """Release storage resources."""
+        ...
+
+
+@runtime_checkable
+class InboxLog(Protocol):
+    """Idempotent receive ledger for ``peer -> server`` inbound.
+
+    Mirrors the design's at-most-once-with-ack-on-process model
+    (§4.5.1): the server records the envelope before processing and
+    treats duplicates as no-op acks.
+    """
+
+    def record_seen(self, peer_id: str, envelope_id: str, ts: float) -> bool:
+        """Record an inbound envelope id.
+
+        Returns ``True`` if newly inserted, ``False`` if it was already
+        present (the caller should re-ack without reprocessing).
+        """
+        ...
+
+    def prune(self, older_than: float) -> int:
+        """Drop entries older than ``older_than``. Returns rows removed."""
+        ...
+
+    def close(self) -> None:
+        """Release storage resources."""
+        ...
+
+
+__all__ = ["InboxLog", "OutboxRecord", "OutboxStore"]

--- a/contrib/channels/src/agentm_channels/outbox/sqlite.py
+++ b/contrib/channels/src/agentm_channels/outbox/sqlite.py
@@ -1,0 +1,281 @@
+"""SQLite WAL-backed default implementations of OutboxStore + InboxLog.
+
+One SQLite file holds the outbox, dead-letter and inbox tables. WAL
+mode + ``synchronous=NORMAL`` gives durable writes with reasonable
+concurrency for a single-process server.
+
+Crash recovery model
+--------------------
+Each lease sets ``leased_until = now + LEASE_TTL_SECONDS``. If the
+server crashes between lease and ack, the row stays in the outbox
+with an expired lease; the next :meth:`SqliteOutbox.lease` call after
+``leased_until`` reissues it. There is no recovery thread inside the
+store — the store is mechanism, not a daemon.
+
+Thread safety
+-------------
+Each store/inbox owns a single sqlite3 connection opened with
+``check_same_thread=False`` and serialises mutating operations behind
+a ``threading.Lock``. The server-side delivery worker calls into the
+store via ``asyncio.to_thread`` so this synchronous API stays simple.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from typing import Any
+
+from agentm_channels.wire import Envelope
+
+from .errors import OutboxClosed
+from .protocol import OutboxRecord
+
+LEASE_TTL_SECONDS: float = 30.0
+
+
+_OUTBOX_SCHEMA = """
+CREATE TABLE IF NOT EXISTS outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    peer_id TEXT NOT NULL,
+    envelope_id TEXT NOT NULL,
+    envelope_json TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    enqueued_at REAL NOT NULL,
+    next_retry_at REAL NOT NULL DEFAULT 0,
+    leased_until REAL NOT NULL DEFAULT 0,
+    UNIQUE(peer_id, envelope_id)
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_peer_ready
+    ON outbox(peer_id, next_retry_at, leased_until);
+
+CREATE TABLE IF NOT EXISTS dead_letter (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    peer_id TEXT NOT NULL,
+    envelope_id TEXT NOT NULL,
+    envelope_json TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    reason TEXT NOT NULL,
+    moved_at REAL NOT NULL
+);
+"""
+
+_INBOX_SCHEMA = """
+CREATE TABLE IF NOT EXISTS inbox_seen (
+    peer_id TEXT NOT NULL,
+    envelope_id TEXT NOT NULL,
+    seen_at REAL NOT NULL,
+    PRIMARY KEY (peer_id, envelope_id)
+);
+"""
+
+
+def _open(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+class SqliteOutbox:
+    """Default OutboxStore implementation. See module docstring."""
+
+    def __init__(self, path: str, *, lease_ttl: float = LEASE_TTL_SECONDS) -> None:
+        self._path = path
+        self._lease_ttl = lease_ttl
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = _open(path)
+        self._conn.executescript(_OUTBOX_SCHEMA)
+
+    # -- internal -----------------------------------------------------
+
+    def _c(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise OutboxClosed("outbox is closed")
+        return self._conn
+
+    # -- OutboxStore --------------------------------------------------
+
+    def enqueue(self, peer_id: str, env: Envelope) -> None:
+        payload = json.dumps(env.to_dict(), separators=(",", ":"))
+        with self._lock:
+            c = self._c()
+            c.execute(
+                "INSERT OR IGNORE INTO outbox "
+                "(peer_id, envelope_id, envelope_json, attempts, "
+                " enqueued_at, next_retry_at, leased_until) "
+                "VALUES (?, ?, ?, 0, ?, 0, 0)",
+                (peer_id, env.id, payload, env.ts),
+            )
+
+    def lease(
+        self, peer_id: str, batch_max: int, now: float
+    ) -> list[OutboxRecord]:
+        if batch_max <= 0:
+            return []
+        with self._lock:
+            c = self._c()
+            rows = c.execute(
+                "SELECT id, envelope_json, attempts, enqueued_at, next_retry_at "
+                "FROM outbox "
+                "WHERE peer_id = ? AND next_retry_at <= ? AND leased_until <= ? "
+                "ORDER BY id ASC LIMIT ?",
+                (peer_id, now, now, batch_max),
+            ).fetchall()
+            if not rows:
+                return []
+            ids = [int(r[0]) for r in rows]
+            placeholders = ",".join("?" * len(ids))
+            c.execute(
+                f"UPDATE outbox SET attempts = attempts + 1, leased_until = ? "
+                f"WHERE id IN ({placeholders})",
+                (now + self._lease_ttl, *ids),
+            )
+            out: list[OutboxRecord] = []
+            for row in rows:
+                rid, env_json, attempts, enqueued_at, next_retry_at = row
+                env = Envelope.from_dict(json.loads(env_json))
+                out.append(
+                    OutboxRecord(
+                        id=int(rid),
+                        peer_id=peer_id,
+                        envelope=env,
+                        attempts=int(attempts) + 1,
+                        enqueued_at=float(enqueued_at),
+                        next_retry_at=float(next_retry_at),
+                    )
+                )
+            return out
+
+    def ack(self, record_ids: list[int]) -> None:
+        if not record_ids:
+            return
+        with self._lock:
+            c = self._c()
+            placeholders = ",".join("?" * len(record_ids))
+            c.execute(
+                f"DELETE FROM outbox WHERE id IN ({placeholders})",
+                tuple(record_ids),
+            )
+
+    def nack(self, record_ids: list[int], next_retry_at: float) -> None:
+        if not record_ids:
+            return
+        with self._lock:
+            c = self._c()
+            placeholders = ",".join("?" * len(record_ids))
+            c.execute(
+                f"UPDATE outbox SET leased_until = 0, next_retry_at = ? "
+                f"WHERE id IN ({placeholders})",
+                (next_retry_at, *record_ids),
+            )
+
+    def dead_letter(self, record_id: int, reason: str) -> None:
+        with self._lock:
+            c = self._c()
+            c.execute("BEGIN")
+            try:
+                row = c.execute(
+                    "SELECT peer_id, envelope_id, envelope_json, attempts "
+                    "FROM outbox WHERE id = ?",
+                    (record_id,),
+                ).fetchone()
+                if row is None:
+                    c.execute("COMMIT")
+                    return
+                peer_id, envelope_id, env_json, attempts = row
+                # Use the envelope ts as a deterministic moved_at fallback
+                moved_at = _now_from_envelope_json(env_json)
+                c.execute(
+                    "INSERT INTO dead_letter "
+                    "(peer_id, envelope_id, envelope_json, attempts, reason, moved_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (peer_id, envelope_id, env_json, attempts, reason, moved_at),
+                )
+                c.execute("DELETE FROM outbox WHERE id = ?", (record_id,))
+                c.execute("COMMIT")
+            except Exception:
+                c.execute("ROLLBACK")
+                raise
+
+    def pending_count(self, peer_id: str) -> int:
+        with self._lock:
+            c = self._c()
+            row = c.execute(
+                "SELECT COUNT(*) FROM outbox WHERE peer_id = ?", (peer_id,)
+            ).fetchone()
+            return int(row[0])
+
+    def dead_letter_count(self, peer_id: str) -> int:
+        """Test/observability helper — count dead-lettered rows for a peer."""
+        with self._lock:
+            c = self._c()
+            row = c.execute(
+                "SELECT COUNT(*) FROM dead_letter WHERE peer_id = ?", (peer_id,)
+            ).fetchone()
+            return int(row[0])
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+
+class SqliteInbox:
+    """Default InboxLog implementation."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = _open(path)
+        self._conn.executescript(_INBOX_SCHEMA)
+
+    def _c(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise OutboxClosed("inbox is closed")
+        return self._conn
+
+    def record_seen(self, peer_id: str, envelope_id: str, ts: float) -> bool:
+        with self._lock:
+            c = self._c()
+            cur = c.execute(
+                "INSERT OR IGNORE INTO inbox_seen (peer_id, envelope_id, seen_at) "
+                "VALUES (?, ?, ?)",
+                (peer_id, envelope_id, ts),
+            )
+            return cur.rowcount > 0
+
+    def prune(self, older_than: float) -> int:
+        with self._lock:
+            c = self._c()
+            cur = c.execute(
+                "DELETE FROM inbox_seen WHERE seen_at < ?", (older_than,)
+            )
+            return cur.rowcount
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+
+def _now_from_envelope_json(env_json: str) -> float:
+    """Use the envelope's own ts to stamp the dead-letter row.
+
+    The store has no clock dependency — callers control time via
+    envelope timestamps and the ``now`` arg to :meth:`lease`. Keeping
+    a clock out of the store is what makes the lease-expiry test
+    deterministic without mocking ``time.time``.
+    """
+    try:
+        data: dict[str, Any] = json.loads(env_json)
+        return float(data.get("ts", 0.0))
+    except (ValueError, TypeError):
+        return 0.0
+
+
+__all__ = ["LEASE_TTL_SECONDS", "SqliteInbox", "SqliteOutbox"]

--- a/contrib/channels/src/agentm_channels/peer.py
+++ b/contrib/channels/src/agentm_channels/peer.py
@@ -1,0 +1,63 @@
+"""Per-peer connection state for the asyncio wire server.
+
+See ``.claude/designs/client-server-architecture.md`` §3 (Topology)
+and §4.4 (hello/welcome). Tiny module — mechanism only, no policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PeerSession:
+    """One connected peer's bookkeeping.
+
+    ``transport_writer`` is the live :class:`asyncio.StreamWriter`.
+    ``pending_count_hint`` is the last sample of ``outbox.pending_count``
+    used by the slow-consumer gate; it is a hint, not a source of truth.
+    """
+
+    peer_id: str
+    peer_kind: str
+    transport_writer: asyncio.StreamWriter
+    last_seen: float = 0.0
+    pending_count_hint: int = 0
+    # Set when the per-peer delivery worker should pause pulling new
+    # leases (slow-consumer high-water tripped). Cleared when drained
+    # below high_water / 2.
+    backpressure: bool = False
+    capabilities: dict[str, object] = field(default_factory=dict)
+
+
+class PeerRegistry:
+    """Single-loop in-memory registry of connected peers.
+
+    No locking — asyncio is single-threaded. Connection rejection on
+    duplicate ``peer_id`` is the caller's policy decision.
+    """
+
+    def __init__(self) -> None:
+        self._peers: dict[str, PeerSession] = {}
+
+    def register(self, session: PeerSession) -> None:
+        self._peers[session.peer_id] = session
+
+    def deregister(self, peer_id: str) -> None:
+        self._peers.pop(peer_id, None)
+
+    def get(self, peer_id: str) -> PeerSession | None:
+        return self._peers.get(peer_id)
+
+    def __contains__(self, peer_id: object) -> bool:
+        return isinstance(peer_id, str) and peer_id in self._peers
+
+    def __iter__(self) -> "object":
+        return iter(list(self._peers.values()))
+
+    def __len__(self) -> int:
+        return len(self._peers)
+
+
+__all__ = ["PeerRegistry", "PeerSession"]

--- a/contrib/channels/src/agentm_channels/server.py
+++ b/contrib/channels/src/agentm_channels/server.py
@@ -1,0 +1,476 @@
+"""Asyncio Unix-socket server for the channels gateway/client split.
+
+See ``.claude/designs/client-server-architecture.md`` §3, §4, §4.5.
+This is a *parallel* mechanism to the v0 in-process gateway — Phase 1.4
+will wire it up as ``agentm-gateway --bind``. Until then this module
+is consumed only by integration tests and (in subsequent phases) by
+extracted channel processes via :class:`WireClient`.
+
+Delivery semantics — at-least-once
+----------------------------------
+The per-peer delivery worker leases rows from the outbox, writes them
+to the socket, waits for ``writer.drain()``, then ``ack``s the rows.
+A peer crash *after* receiving the frame but *before* application
+processing means the row is gone — the receiver-side ``InboxLog`` is
+the deduplication boundary. The simpler interpretation (ack on
+``drain()``) is chosen deliberately:
+
+* The alternative (server waits for an explicit per-row ``ack`` over
+  the wire) doubles wire chatter and requires per-row state on the
+  receiving peer; for v1, receiver-side idempotency is enough.
+* If the application needs ack-on-process semantics it sends a fresh
+  ``inbound`` envelope back through the gateway; the inbox dedupes.
+
+Authenticator hook
+------------------
+:class:`Authenticator` is a Protocol; v1 ships :class:`AllowAllAuthenticator`
+as the default. Phase 1.4 ships :class:`UnixPeerCredAuthenticator`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, runtime_checkable
+
+from agentm_channels.outbox import (
+    InboxLog,
+    OutboxRecord,
+    OutboxStore,
+    exponential_backoff,
+)
+from agentm_channels.peer import PeerRegistry, PeerSession
+from agentm_channels.wire import (
+    HEADER_BYTES,
+    KIND_ACK,
+    KIND_ACK_BATCH,
+    KIND_BYE,
+    KIND_DELIVERY_BATCH,
+    KIND_ERROR,
+    KIND_HELLO,
+    KIND_INBOUND,
+    KIND_PING,
+    KIND_PONG,
+    KIND_WELCOME,
+    WIRE_VERSION,
+    Envelope,
+    IncompleteFrame,
+    InvalidEnvelope,
+    WireError,
+    decode_stream,
+    encode,
+)
+
+log = logging.getLogger("agentm_channels.server")
+
+SERVER_VERSION: str = "0.1.0"
+MAX_DELIVERY_ATTEMPTS: int = 5
+DELIVERY_IDLE_POLL_SECONDS: float = 0.05
+
+InboundHandler = Callable[[PeerSession, Envelope], Awaitable[None]]
+
+
+class _ConnectionLost(Exception):
+    """Internal sentinel — socket dead, exit the per-peer delivery loop."""
+
+
+@runtime_checkable
+class Authenticator(Protocol):
+    """Server-side hook for accepting/rejecting a ``hello``."""
+
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,
+        transport: asyncio.StreamWriter,
+    ) -> bool:
+        ...
+
+
+class AllowAllAuthenticator:
+    """Default — accept every hello. Suitable for tests + Unix socket
+    on trusted hosts. Phase 1.4 replaces this with a peer-cred check.
+    """
+
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,
+        transport: asyncio.StreamWriter,
+    ) -> bool:
+        return True
+
+
+class WireServer:
+    """Asyncio Unix-socket server.
+
+    Each accepted connection: handshake → register peer → spawn a
+    delivery worker that drains the outbox → read inbound frames in
+    the connection task.
+
+    Lifecycle: ``await start()``; ``await stop()`` (idempotent — removes
+    the socket file).
+    """
+
+    def __init__(
+        self,
+        socket_path: str,
+        outbox: OutboxStore,
+        inbox: InboxLog,
+        on_inbound: InboundHandler,
+        *,
+        authenticator: Authenticator | None = None,
+        delivery_batch_max: int = 32,
+        lease_ttl: float = 30.0,
+        slow_consumer_high_water: int = 1000,
+        max_delivery_attempts: int = MAX_DELIVERY_ATTEMPTS,
+    ) -> None:
+        self._socket_path = socket_path
+        self._outbox = outbox
+        self._inbox = inbox
+        self._on_inbound = on_inbound
+        self._auth: Authenticator = authenticator or AllowAllAuthenticator()
+        self._delivery_batch_max = delivery_batch_max
+        self._lease_ttl = lease_ttl
+        self._high_water = slow_consumer_high_water
+        self._low_water = max(1, slow_consumer_high_water // 2)
+        self._max_attempts = max_delivery_attempts
+        self._registry = PeerRegistry()
+        self._server: asyncio.base_events.Server | None = None
+        self._stopped = False
+        self._conn_tasks: set[asyncio.Task[None]] = set()
+        self._delivery_tasks: dict[str, asyncio.Task[None]] = {}
+
+    # -- lifecycle ----------------------------------------------------
+
+    async def start(self) -> None:
+        if self._server is not None:
+            return
+        # Clean any stale socket left by a crashed predecessor.
+        with contextlib.suppress(FileNotFoundError):
+            if os.path.exists(self._socket_path):
+                os.unlink(self._socket_path)
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection, path=self._socket_path
+        )
+
+    async def stop(self) -> None:
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+            self._server = None
+        # Cancel all delivery workers and connection tasks.
+        for task in list(self._delivery_tasks.values()):
+            task.cancel()
+        for task in list(self._conn_tasks):
+            task.cancel()
+        # Drain the cancellations.
+        all_tasks = list(self._delivery_tasks.values()) + list(self._conn_tasks)
+        for task in all_tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        self._delivery_tasks.clear()
+        self._conn_tasks.clear()
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(self._socket_path)
+
+    @property
+    def registry(self) -> PeerRegistry:
+        return self._registry
+
+    # -- connection handling -----------------------------------------
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._conn_tasks.add(task)
+        peer_id: str | None = None
+        try:
+            hello = await _read_one_frame(reader)
+            if hello is None or hello.kind != KIND_HELLO:
+                await _send(writer, _error_env("expected_hello", "expected hello as first frame"))
+                return
+            body = hello.body if isinstance(hello.body, dict) else {}
+            peer_kind = str(body.get("peer_kind", ""))
+            peer_id = str(body.get("peer_id", ""))
+            token_raw = body.get("token")
+            token = str(token_raw) if isinstance(token_raw, str) else None
+            if not peer_kind or not peer_id:
+                await _send(writer, _error_env("bad_hello", "hello body missing peer_kind/peer_id"))
+                return
+            ok = await self._auth.authenticate(peer_kind, peer_id, token, writer)
+            if not ok:
+                await _send(writer, _error_env("auth_failed", f"auth failed for peer {peer_id!r}"))
+                return
+            if peer_id in self._registry:
+                await _send(writer, _error_env("duplicate_peer", f"peer {peer_id!r} already connected"))
+                return
+
+            session = PeerSession(
+                peer_id=peer_id,
+                peer_kind=peer_kind,
+                transport_writer=writer,
+                last_seen=time.time(),
+                capabilities=dict(body.get("capabilities") or {}),
+            )
+            self._registry.register(session)
+            await _send(
+                writer,
+                _make_env(KIND_WELCOME, {"server_version": SERVER_VERSION, "peer_id_echo": peer_id}),
+            )
+
+            delivery = asyncio.create_task(
+                self._delivery_loop(session), name=f"deliver:{peer_id}"
+            )
+            self._delivery_tasks[peer_id] = delivery
+            try:
+                await self._read_loop(session, reader)
+            finally:
+                delivery.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await delivery
+                self._delivery_tasks.pop(peer_id, None)
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("connection handler crashed")
+        finally:
+            if peer_id is not None:
+                self._registry.deregister(peer_id)
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+            if task is not None:
+                self._conn_tasks.discard(task)
+
+    async def _read_loop(
+        self, session: PeerSession, reader: asyncio.StreamReader
+    ) -> None:
+        buf = b""
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                return  # peer closed
+            buf += chunk
+            try:
+                envelopes, buf = decode_stream(buf)
+            except (InvalidEnvelope, WireError) as exc:
+                await _send(
+                    session.transport_writer,
+                    _error_env("bad_frame", f"frame rejected: {exc}"),
+                )
+                return
+            for env in envelopes:
+                session.last_seen = time.time()
+                await self._dispatch_frame(session, env)
+                if env.kind == KIND_BYE:
+                    return
+
+    async def _dispatch_frame(self, session: PeerSession, env: Envelope) -> None:
+        if env.kind == KIND_INBOUND:
+            inserted = await asyncio.to_thread(
+                self._inbox.record_seen, session.peer_id, env.id, env.ts
+            )
+            if not inserted:
+                # Duplicate — skip handler, but keep transport happy.
+                return
+            try:
+                await self._on_inbound(session, env)
+            except Exception:
+                log.exception("on_inbound handler raised for env id=%s", env.id)
+            return
+        if env.kind in (KIND_ACK, KIND_ACK_BATCH):
+            return  # server-side acks are implicit; tolerate client-sent ones.
+        if env.kind == KIND_PING:
+            await _send(
+                session.transport_writer,
+                _make_env(KIND_PONG, {"echo_id": env.id}),
+            )
+            return
+        if env.kind == KIND_BYE:
+            return
+        log.debug("server: ignoring unexpected kind %s from %s", env.kind, session.peer_id)
+
+    # -- delivery worker ---------------------------------------------
+
+    async def _delivery_loop(self, session: PeerSession) -> None:
+        """Drain outbox rows for ``session.peer_id`` until cancelled.
+
+        Slow-consumer accounting is observational: we *log a diagnostic*
+        when the pending queue crosses ``slow_consumer_high_water`` and
+        clear the flag when it falls below ``high_water / 2``. We do
+        **not** stop draining — back-pressure belongs upstream of the
+        outbox (the enqueue side); the delivery worker's job is to
+        empty the queue as fast as the peer will accept. Per §0
+        simplicity, no ``slow_consumer`` wire event.
+        """
+        peer_id = session.peer_id
+        try:
+            while True:
+                pending = await asyncio.to_thread(self._outbox.pending_count, peer_id)
+                session.pending_count_hint = pending
+                if pending > self._high_water and not session.backpressure:
+                    log.warning(
+                        "slow_consumer peer=%s pending=%d high_water=%d",
+                        peer_id,
+                        pending,
+                        self._high_water,
+                    )
+                    session.backpressure = True
+                elif session.backpressure and pending <= self._low_water:
+                    session.backpressure = False
+                now = time.time()
+                records = await asyncio.to_thread(
+                    self._outbox.lease, peer_id, self._delivery_batch_max, now
+                )
+                if not records:
+                    await asyncio.sleep(DELIVERY_IDLE_POLL_SECONDS)
+                    continue
+                await self._deliver(session, records)
+        except _ConnectionLost:
+            # Socket dead — stop draining. The connection task will
+            # close the reader side and trigger reconnect logic peer-side.
+            try:
+                session.transport_writer.close()
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("delivery loop for peer=%s crashed", peer_id)
+
+    async def _deliver(
+        self, session: PeerSession, records: list[OutboxRecord]
+    ) -> None:
+        """Write one batch (or single envelope) to the peer.
+
+        On socket write/drain failure: account the records (nack or
+        dead-letter per attempts) and *re-raise* a sentinel so the
+        delivery loop exits — the connection is dead, sit out until
+        the peer reconnects. Without this the loop would re-lease the
+        same records every tick and exhaust ``max_attempts`` against
+        a closed socket.
+        """
+        writer = session.transport_writer
+        try:
+            if len(records) == 1:
+                env = records[0].envelope
+                writer.write(encode(env))
+                await writer.drain()
+            else:
+                items = [r.envelope.to_dict() for r in records]
+                batch = _make_env(KIND_DELIVERY_BATCH, {"items": items})
+                writer.write(encode(batch))
+                await writer.drain()
+        except asyncio.CancelledError:
+            await self._nack_records(records)
+            raise
+        except (ConnectionResetError, BrokenPipeError) as exc:
+            await self._handle_delivery_failure(session, records, repr(exc))
+            raise _ConnectionLost() from exc
+        except Exception as exc:
+            await self._handle_delivery_failure(session, records, repr(exc))
+            raise _ConnectionLost() from exc
+        # Success: ack the whole set.
+        await asyncio.to_thread(self._outbox.ack, [r.id for r in records])
+
+    async def _nack_records(self, records: list[OutboxRecord]) -> None:
+        now = time.time()
+        for r in records:
+            delay = exponential_backoff(r.attempts)
+            await asyncio.to_thread(self._outbox.nack, [r.id], now + delay)
+
+    async def _handle_delivery_failure(
+        self,
+        session: PeerSession,
+        records: list[OutboxRecord],
+        reason: str,
+    ) -> None:
+        now = time.time()
+        for r in records:
+            if r.attempts >= self._max_attempts:
+                await asyncio.to_thread(self._outbox.dead_letter, r.id, reason)
+                root = r.envelope.root_session_key
+                if root is not None:
+                    log.warning(
+                        "dead_letter peer=%s env_id=%s reason=%s root=%s",
+                        session.peer_id, r.envelope.id, reason, root,
+                    )
+                else:
+                    log.warning(
+                        "dead_letter peer=%s env_id=%s reason=%s",
+                        session.peer_id, r.envelope.id, reason,
+                    )
+            else:
+                delay = exponential_backoff(r.attempts)
+                await asyncio.to_thread(self._outbox.nack, [r.id], now + delay)
+
+
+# -- helpers ---------------------------------------------------------
+
+async def _read_one_frame(reader: asyncio.StreamReader) -> Envelope | None:
+    """Read exactly one framed envelope. Returns None on EOF/parse error."""
+    buf = b""
+    try:
+        header = await reader.readexactly(HEADER_BYTES)
+    except asyncio.IncompleteReadError:
+        return None
+    buf += header
+    # Peek body length from the header.
+    length = int.from_bytes(header, "big")
+    try:
+        body = await reader.readexactly(length)
+    except asyncio.IncompleteReadError:
+        return None
+    buf += body
+    try:
+        envelopes, _rest = decode_stream(buf)
+    except (InvalidEnvelope, WireError, IncompleteFrame):
+        return None
+    return envelopes[0] if envelopes else None
+
+
+def _make_env(kind: str, body: dict[str, Any]) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id=f"srv-{kind}-{os.urandom(6).hex()}",
+        kind=kind,
+        ts=time.time(),
+        body=body,
+    )
+
+
+def _error_env(code: str, message: str) -> Envelope:
+    return _make_env(KIND_ERROR, {"code": code, "message": message})
+
+
+async def _send(writer: asyncio.StreamWriter, env: Envelope) -> None:
+    writer.write(encode(env))
+    try:
+        await writer.drain()
+    except (ConnectionResetError, BrokenPipeError):
+        pass
+
+
+__all__ = [
+    "AllowAllAuthenticator",
+    "Authenticator",
+    "MAX_DELIVERY_ATTEMPTS",
+    "SERVER_VERSION",
+    "WireServer",
+]

--- a/contrib/channels/src/agentm_channels/wire/__init__.py
+++ b/contrib/channels/src/agentm_channels/wire/__init__.py
@@ -1,0 +1,51 @@
+"""Wire protocol: envelopes, kinds, length-prefixed framing.
+
+Pure-function foundation for the gateway/client process split. See
+``.claude/designs/client-server-architecture.md`` §4. Pure module —
+no I/O, no asyncio. Importable in a notebook with no harness.
+"""
+
+from __future__ import annotations
+
+from .envelope import WIRE_VERSION, Envelope
+from .errors import IncompleteFrame, InvalidEnvelope, WireError
+from .framing import HEADER_BYTES, MAX_FRAME_BYTES, decode, decode_stream, encode
+from .kinds import (
+    KIND_ACK,
+    KIND_ACK_BATCH,
+    KIND_BYE,
+    KIND_DELIVERY_BATCH,
+    KIND_ERROR,
+    KIND_HELLO,
+    KIND_INBOUND,
+    KIND_OUTBOUND,
+    KIND_PING,
+    KIND_PONG,
+    KIND_WELCOME,
+    VALID_KINDS,
+)
+
+__all__ = [
+    "HEADER_BYTES",
+    "KIND_ACK",
+    "KIND_ACK_BATCH",
+    "KIND_BYE",
+    "KIND_DELIVERY_BATCH",
+    "KIND_ERROR",
+    "KIND_HELLO",
+    "KIND_INBOUND",
+    "KIND_OUTBOUND",
+    "KIND_PING",
+    "KIND_PONG",
+    "KIND_WELCOME",
+    "MAX_FRAME_BYTES",
+    "VALID_KINDS",
+    "WIRE_VERSION",
+    "Envelope",
+    "IncompleteFrame",
+    "InvalidEnvelope",
+    "WireError",
+    "decode",
+    "decode_stream",
+    "encode",
+]

--- a/contrib/channels/src/agentm_channels/wire/envelope.py
+++ b/contrib/channels/src/agentm_channels/wire/envelope.py
@@ -1,0 +1,114 @@
+"""Wire envelope.
+
+JSON-safe dataclass implementing designs/client-server-architecture.md
+§4.2. All optional fields from §10 decision #8 land Day 1 even where
+unused — mid-cluster wire bumps are expensive.
+
+Pure module: no I/O, no logging.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .errors import InvalidEnvelope
+from .kinds import VALID_KINDS
+
+WIRE_VERSION: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    """A single wire message.
+
+    Required: ``v``, ``id``, ``kind``, ``ts``, ``body``.
+    Optional (defaulted): ``to``, ``correlation_id``, ``hops``,
+    ``root_session_key``, ``peer_kind``.
+    """
+
+    v: int
+    id: str
+    kind: str
+    ts: float
+    body: dict[str, Any] = field(default_factory=dict)
+    to: str | None = None
+    correlation_id: str | None = None
+    hops: int = 0
+    root_session_key: str | None = None
+    peer_kind: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.v != WIRE_VERSION:
+            raise InvalidEnvelope(
+                f"unsupported wire version {self.v!r}; expected {WIRE_VERSION}"
+            )
+        if not isinstance(self.id, str) or not self.id:
+            raise InvalidEnvelope("envelope id must be a non-empty string")
+        if self.kind not in VALID_KINDS:
+            raise InvalidEnvelope(f"unknown envelope kind {self.kind!r}")
+        if not isinstance(self.body, dict):
+            raise InvalidEnvelope("envelope body must be a dict")
+        if not isinstance(self.hops, int) or self.hops < 0:
+            raise InvalidEnvelope("envelope hops must be a non-negative int")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Render to a JSON-safe dict. None-valued optionals omitted."""
+        out: dict[str, Any] = {
+            "v": self.v,
+            "id": self.id,
+            "kind": self.kind,
+            "ts": self.ts,
+            "body": self.body,
+            "hops": self.hops,
+        }
+        if self.to is not None:
+            out["to"] = self.to
+        if self.correlation_id is not None:
+            out["correlation_id"] = self.correlation_id
+        if self.root_session_key is not None:
+            out["root_session_key"] = self.root_session_key
+        if self.peer_kind is not None:
+            out["peer_kind"] = self.peer_kind
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Envelope:
+        """Reconstruct from a JSON-decoded dict.
+
+        Raises :class:`InvalidEnvelope` if required fields are missing
+        or any field has the wrong type.
+        """
+        if not isinstance(data, dict):
+            raise InvalidEnvelope("envelope wire payload must be a JSON object")
+        for required in ("v", "id", "kind", "ts", "body"):
+            if required not in data:
+                raise InvalidEnvelope(f"envelope missing required field {required!r}")
+        try:
+            return cls(
+                v=int(data["v"]),
+                id=str(data["id"]),
+                kind=str(data["kind"]),
+                ts=float(data["ts"]),
+                body=data["body"],
+                to=_opt_str(data.get("to"), "to"),
+                correlation_id=_opt_str(data.get("correlation_id"), "correlation_id"),
+                hops=int(data.get("hops", 0)),
+                root_session_key=_opt_str(
+                    data.get("root_session_key"), "root_session_key"
+                ),
+                peer_kind=_opt_str(data.get("peer_kind"), "peer_kind"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise InvalidEnvelope(f"envelope field has wrong type: {exc}") from exc
+
+
+def _opt_str(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidEnvelope(f"envelope field {name!r} must be a string or null")
+    return value
+
+
+__all__ = ["Envelope", "WIRE_VERSION"]

--- a/contrib/channels/src/agentm_channels/wire/errors.py
+++ b/contrib/channels/src/agentm_channels/wire/errors.py
@@ -1,0 +1,29 @@
+"""Wire-protocol exceptions.
+
+Pure module — no I/O, no logging. Callers above the wire layer decide
+whether a :class:`WireError` is fatal to the connection or recoverable.
+"""
+
+from __future__ import annotations
+
+
+class WireError(Exception):
+    """Base class for wire-protocol failures."""
+
+
+class IncompleteFrame(WireError):
+    """Buffer does not yet contain a full length-prefixed frame.
+
+    Not a protocol error — the caller should read more bytes and retry.
+    """
+
+
+class InvalidEnvelope(WireError):
+    """Envelope structurally invalid or oversized.
+
+    Raised for malformed JSON, missing required fields, illegal field
+    values, and frames whose declared length exceeds the maximum allowed.
+    """
+
+
+__all__ = ["IncompleteFrame", "InvalidEnvelope", "WireError"]

--- a/contrib/channels/src/agentm_channels/wire/framing.py
+++ b/contrib/channels/src/agentm_channels/wire/framing.py
@@ -1,0 +1,90 @@
+"""Length-prefixed JSON framing.
+
+Per designs/client-server-architecture.md §4.1: each frame is a 4-byte
+big-endian unsigned length followed by UTF-8 JSON. Pure functions —
+no sockets, no async, no logging.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+
+from .envelope import Envelope
+from .errors import IncompleteFrame, InvalidEnvelope, WireError
+
+HEADER_BYTES: int = 4
+MAX_FRAME_BYTES: int = 16 * 1024 * 1024  # 16 MiB — §0 discipline, raise via spec only.
+
+_HEADER_STRUCT = struct.Struct(">I")
+
+
+def encode(env: Envelope) -> bytes:
+    """Serialize one envelope to a length-prefixed frame."""
+    payload = json.dumps(env.to_dict(), separators=(",", ":")).encode("utf-8")
+    if len(payload) > MAX_FRAME_BYTES:
+        raise InvalidEnvelope(
+            f"encoded envelope is {len(payload)} bytes; exceeds "
+            f"MAX_FRAME_BYTES={MAX_FRAME_BYTES}"
+        )
+    return _HEADER_STRUCT.pack(len(payload)) + payload
+
+
+def decode(buf: bytes) -> tuple[Envelope, bytes]:
+    """Decode the first complete frame from ``buf``.
+
+    Returns ``(envelope, remaining)``. Raises :class:`IncompleteFrame`
+    if ``buf`` does not yet hold a full frame. Raises
+    :class:`InvalidEnvelope` if the declared length exceeds
+    :data:`MAX_FRAME_BYTES` (checked before any allocation of the
+    body). Raises :class:`WireError` for malformed JSON.
+    """
+    if len(buf) < HEADER_BYTES:
+        raise IncompleteFrame(
+            f"need {HEADER_BYTES} header bytes, have {len(buf)}"
+        )
+    (length,) = _HEADER_STRUCT.unpack_from(buf, 0)
+    if length > MAX_FRAME_BYTES:
+        # Reject *before* trying to slice / allocate the body.
+        raise InvalidEnvelope(
+            f"declared frame length {length} exceeds MAX_FRAME_BYTES={MAX_FRAME_BYTES}"
+        )
+    end = HEADER_BYTES + length
+    if len(buf) < end:
+        raise IncompleteFrame(
+            f"need {length} body bytes, have {len(buf) - HEADER_BYTES}"
+        )
+    body_bytes = buf[HEADER_BYTES:end]
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise WireError(f"frame body is not valid UTF-8 JSON: {exc}") from exc
+    env = Envelope.from_dict(payload)
+    return env, buf[end:]
+
+
+def decode_stream(buf: bytes) -> tuple[list[Envelope], bytes]:
+    """Drain every complete frame from ``buf``.
+
+    Returns ``(envelopes, trailing)`` where ``trailing`` is the partial
+    bytes of the next not-yet-complete frame (possibly empty). Used by
+    socket readers that accumulate bytes and want to dispatch all ready
+    envelopes in one pass.
+    """
+    envelopes: list[Envelope] = []
+    rest = buf
+    while True:
+        try:
+            env, rest = decode(rest)
+        except IncompleteFrame:
+            return envelopes, rest
+        envelopes.append(env)
+
+
+__all__ = [
+    "HEADER_BYTES",
+    "MAX_FRAME_BYTES",
+    "decode",
+    "decode_stream",
+    "encode",
+]

--- a/contrib/channels/src/agentm_channels/wire/kinds.py
+++ b/contrib/channels/src/agentm_channels/wire/kinds.py
@@ -1,0 +1,50 @@
+"""Wire envelope kinds.
+
+Mirrors designs/client-server-architecture.md §4.3 exactly. Adding a
+kind requires a spec amendment — §0 design discipline.
+"""
+
+from __future__ import annotations
+
+KIND_HELLO = "hello"
+KIND_WELCOME = "welcome"
+KIND_INBOUND = "inbound"
+KIND_OUTBOUND = "outbound"
+KIND_ACK = "ack"
+KIND_ACK_BATCH = "ack_batch"
+KIND_PING = "ping"
+KIND_PONG = "pong"
+KIND_ERROR = "error"
+KIND_BYE = "bye"
+KIND_DELIVERY_BATCH = "delivery_batch"
+
+VALID_KINDS: frozenset[str] = frozenset(
+    {
+        KIND_HELLO,
+        KIND_WELCOME,
+        KIND_INBOUND,
+        KIND_OUTBOUND,
+        KIND_ACK,
+        KIND_ACK_BATCH,
+        KIND_PING,
+        KIND_PONG,
+        KIND_ERROR,
+        KIND_BYE,
+        KIND_DELIVERY_BATCH,
+    }
+)
+
+__all__ = [
+    "KIND_ACK",
+    "KIND_ACK_BATCH",
+    "KIND_BYE",
+    "KIND_DELIVERY_BATCH",
+    "KIND_ERROR",
+    "KIND_HELLO",
+    "KIND_INBOUND",
+    "KIND_OUTBOUND",
+    "KIND_PING",
+    "KIND_PONG",
+    "KIND_WELCOME",
+    "VALID_KINDS",
+]

--- a/contrib/channels/src/agentm_channels/wire_bridge.py
+++ b/contrib/channels/src/agentm_channels/wire_bridge.py
@@ -1,0 +1,180 @@
+"""Bridge between :class:`WireServer` and the in-process v0 :class:`Gateway`.
+
+The chosen extension point is **synthetic-channel registration**: each
+connected wire peer (identified by the ``channel`` field on its first
+inbound envelope) is injected into the running :class:`ChannelManager`
+as a :class:`_WireChannel`, a :class:`BaseChannel` whose ``send()``
+enqueues the outbound onto the peer's outbox. This reuses the existing
+inbound/outbound MessageBus path unchanged: gateway dispatch logic, slash
+commands, approvals, turn-complete signalling, channel allow-from — all
+of it still works, with no new conditional code in :class:`Gateway`.
+
+Rationale (vs. calling ``gateway._dispatch`` directly): going through
+``MessageBus`` keeps a single dispatch contract for v0 and wire peers,
+so observability / approval / retry semantics are identical. The cost
+is one ``BaseChannel`` instance per wire peer — cheap and short-lived.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from .base import BaseChannel
+from .bus import MessageBus, OutboundKind, OutboundMessage
+from .manager import ChannelManager
+from .outbox import OutboxStore
+from .peer import PeerSession
+from .wire import KIND_INBOUND, KIND_OUTBOUND, WIRE_VERSION, Envelope
+
+log = logging.getLogger("agentm_channels.wire_bridge")
+
+
+class _WireChannel(BaseChannel):
+    """Outbound sink for one wire peer.
+
+    Not auto-discovered; instantiated and injected directly into
+    :class:`ChannelManager.channels` by :class:`WireBridge` on hello.
+    """
+
+    name = "_wire"
+    display_name = "Wire peer"
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        bus: MessageBus,
+        *,
+        peer_id: str,
+        channel_name: str,
+        outbox: OutboxStore,
+    ) -> None:
+        super().__init__(config, bus)
+        self._peer_id = peer_id
+        self.name = channel_name  # per-instance: the manager keys on this
+        self._outbox = outbox
+        self._stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        self._running = True
+        await self._stopped.wait()
+
+    async def stop(self) -> None:
+        self._running = False
+        self._stopped.set()
+
+    async def send(self, msg: OutboundMessage) -> None:
+        # Turn-complete is internal control; chat clients want it as
+        # an envelope too, but for v1 we ship it on the wire so peers
+        # can mirror it (terminal channel uses it to print a marker).
+        env = Envelope(
+            v=WIRE_VERSION,
+            id=f"out-{self._peer_id}-{int(time.time() * 1_000_000)}",
+            kind=KIND_OUTBOUND,
+            ts=time.time(),
+            body={
+                "channel": msg.channel,
+                "chat_id": msg.chat_id,
+                "content": msg.content,
+                "kind": msg.kind.value
+                if isinstance(msg.kind, OutboundKind)
+                else str(msg.kind),
+            },
+        )
+        await asyncio.to_thread(self._outbox.enqueue, self._peer_id, env)
+
+
+class WireBridge:
+    """Glue object: turns wire inbound envelopes into v0 inbound messages.
+
+    Holds the :class:`ChannelManager` (so it can inject/remove synthetic
+    :class:`_WireChannel` instances on the fly) and the
+    :class:`OutboxStore` (so the synthetic channel can enqueue replies).
+    """
+
+    def __init__(
+        self, *, bus: MessageBus, manager: ChannelManager, outbox: OutboxStore
+    ) -> None:
+        self._bus = bus
+        self._manager = manager
+        self._outbox = outbox
+        # peer_id → channel_name registered for that peer (so we can
+        # tear it down on disconnect).
+        self._peer_channels: dict[str, str] = {}
+
+    async def handle_inbound(self, peer_session: PeerSession, env: Envelope) -> None:
+        """Invoked by :class:`WireServer` for each ``inbound`` envelope."""
+        if env.kind != KIND_INBOUND:
+            return  # ping/pong/bye are handled by the server already
+        body = env.body if isinstance(env.body, dict) else {}
+        channel_name = str(body.get("channel") or "")
+        chat_id = str(body.get("chat_id") or "")
+        sender_id = str(body.get("sender_id") or peer_session.peer_id)
+        content = str(body.get("content") or "")
+        if not channel_name or not chat_id:
+            log.warning(
+                "wire inbound rejected: missing channel/chat_id (peer=%s id=%s)",
+                peer_session.peer_id,
+                env.id,
+            )
+            return
+        await self._ensure_channel(peer_session.peer_id, channel_name)
+        from .bus import InboundMessage
+
+        await self._bus.publish_inbound(
+            InboundMessage(
+                channel=channel_name,
+                sender_id=sender_id,
+                chat_id=chat_id,
+                content=content,
+            )
+        )
+
+    async def _ensure_channel(self, peer_id: str, channel_name: str) -> None:
+        existing = self._peer_channels.get(peer_id)
+        if existing == channel_name:
+            return
+        if existing is not None:
+            # Peer renamed; drop the old synthetic channel first.
+            await self._drop_channel(existing)
+        # Inject into ChannelManager so its dispatch loop routes
+        # outbounds with this channel name through us. Bypass
+        # allow_from enforcement — the wire peer authenticated via
+        # peer-cred; per-sender ACL is deferred (§6.3).
+        ch = _WireChannel(
+            {"enabled": True, "allow_from": ["*"]},
+            self._bus,
+            peer_id=peer_id,
+            channel_name=channel_name,
+            outbox=self._outbox,
+        )
+        self._manager._channels[channel_name] = ch  # type: ignore[attr-defined]
+        # Run the channel's start() so ``stop()`` is well-formed; the
+        # task being tracked by the manager keeps lifecycle symmetric.
+        task = asyncio.create_task(ch.start(), name=f"wire-ch-{channel_name}")
+        self._manager._tasks.append(task)  # type: ignore[attr-defined]
+        self._peer_channels[peer_id] = channel_name
+        log.info(
+            "wire peer registered as channel %r (peer_id=%s)", channel_name, peer_id
+        )
+
+    async def _drop_channel(self, channel_name: str) -> None:
+        ch = self._manager._channels.pop(channel_name, None)  # type: ignore[attr-defined]
+        if ch is None:
+            return
+        try:
+            await ch.stop()
+        except Exception:  # noqa: BLE001
+            log.exception("wire channel %r stop raised", channel_name)
+
+    async def on_peer_disconnect(self, peer_id: str) -> None:
+        channel = self._peer_channels.pop(peer_id, None)
+        if channel is None:
+            return
+        await self._drop_channel(channel)
+        log.info("wire peer disconnected: channel %r dropped", channel)
+
+
+__all__ = ["WireBridge", "_WireChannel"]

--- a/contrib/channels/tests/cli/test_bind_e2e.py
+++ b/contrib/channels/tests/cli/test_bind_e2e.py
@@ -1,0 +1,185 @@
+"""Phase 1.4 fail-stop: a wire peer's ``inbound`` reaches the v0
+Gateway dispatch path, and the gateway's reply round-trips back to
+the peer via the outbox.
+
+Drives :class:`WireBridge` + :class:`WireServer` + :class:`Gateway`
+with a fake :class:`AgentSession` (echo). No subprocess, no real LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentm.core.abi import (
+    AssistantMessage,
+    EventBus,
+    TextContent,
+)
+from agentm.core.abi.events import TurnEndEvent
+
+from agentm_channels.auth import UnixPeerCredAuthenticator
+from agentm_channels.bus import MessageBus
+from agentm_channels.client import WireClient
+from agentm_channels.gateway import Gateway, GatewayConfig
+from agentm_channels.manager import ChannelManager
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.server import WireServer
+from agentm_channels.wire import KIND_OUTBOUND, Envelope
+from agentm_channels.wire_bridge import WireBridge
+
+
+class _FakeSM:
+    def get_session_id(self) -> str:
+        return f"fake-{int(time.time() * 1000)}"
+
+
+class _FakeSession:
+    def __init__(self, bus: EventBus) -> None:
+        self._bus = bus
+        self.session_manager = _FakeSM()
+
+    async def prompt(self, text: str) -> None:
+        msg = AssistantMessage(
+            role="assistant",
+            content=[TextContent(type="text", text=f"echo: {text}")],
+            timestamp=time.time(),
+        )
+        await self._bus.emit(
+            TurnEndEvent.CHANNEL,
+            TurnEndEvent(turn_index=0, message=msg, messages=()),
+        )
+
+    async def shutdown(self) -> None:
+        pass
+
+
+async def _factory(_cwd: str, bus: EventBus, _resume: str | None) -> Any:
+    return _FakeSession(bus)
+
+
+async def _wait_for(predicate: Any, *, timeout: float = 3.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("timed out")
+
+
+async def test_wire_peer_inbound_round_trips_through_gateway() -> None:
+    with tempfile.TemporaryDirectory(prefix="agentm-bind-e2e-") as d:
+        sock = os.path.join(d, "g.sock")
+        state = Path(d) / "state"
+        state.mkdir()
+
+        bus = MessageBus()
+        mgr = ChannelManager({}, bus)
+        gw = Gateway(
+            bus=bus,
+            config=GatewayConfig(cwd=d, state_dir=state),
+            session_factory=_factory,
+        )
+        await mgr.start()
+        await gw.start()
+
+        outbox = SqliteOutbox(str(state / "wire-outbox.sqlite"))
+        inbox = SqliteInbox(str(state / "wire-inbox.sqlite"))
+        bridge = WireBridge(bus=bus, manager=mgr, outbox=outbox)
+        server = WireServer(
+            socket_path=sock,
+            outbox=outbox,
+            inbox=inbox,
+            on_inbound=bridge.handle_inbound,
+            authenticator=UnixPeerCredAuthenticator(allowed_uids=None),
+        )
+        await server.start()
+
+        received: list[Envelope] = []
+
+        async def on_outbound(env: Envelope) -> None:
+            received.append(env)
+
+        client = WireClient(
+            sock, peer_id="p1", peer_kind="chat_client", on_outbound=on_outbound
+        )
+        try:
+            await client.connect()
+            await client.send_inbound(
+                {
+                    "channel": "wire-test",
+                    "chat_id": "c1",
+                    "sender_id": "u1",
+                    "content": "hello",
+                },
+                env_id="msg-1",
+            )
+
+            # The gateway emits the assistant TurnEnd reply AND a
+            # turn_complete control marker. We assert the body content
+            # round-trip on the assistant reply.
+            await _wait_for(
+                lambda: any(
+                    env.kind == KIND_OUTBOUND
+                    and isinstance(env.body, dict)
+                    and env.body.get("content") == "echo: hello"
+                    for env in received
+                )
+            )
+            assistant_env = next(
+                env
+                for env in received
+                if isinstance(env.body, dict)
+                and env.body.get("content") == "echo: hello"
+            )
+            assert assistant_env.body["channel"] == "wire-test"
+            assert assistant_env.body["chat_id"] == "c1"
+        finally:
+            await client.close()
+            await server.stop()
+            outbox.close()
+            inbox.close()
+            await gw.stop()
+            await mgr.stop()
+
+
+async def test_wire_peer_rejected_by_uid_policy() -> None:
+    """A peer-cred allow-list that excludes the test process's uid
+    refuses the connection. This is the fail-stop for ``--bind-allow-uid``.
+    """
+    pytest.importorskip("socket")
+    with tempfile.TemporaryDirectory(prefix="agentm-bind-e2e-") as d:
+        sock = os.path.join(d, "g.sock")
+        outbox = SqliteOutbox(os.path.join(d, "ob.sqlite"))
+        inbox = SqliteInbox(os.path.join(d, "ib.sqlite"))
+
+        async def _noop(_p: Any, _e: Envelope) -> None:
+            return None
+
+        server = WireServer(
+            socket_path=sock,
+            outbox=outbox,
+            inbox=inbox,
+            on_inbound=_noop,
+            authenticator=UnixPeerCredAuthenticator(
+                allowed_uids={os.geteuid() + 99999}
+            ),
+        )
+        await server.start()
+        try:
+            from agentm_channels.client import AuthError
+
+            client = WireClient(sock, peer_id="p1", peer_kind="chat_client")
+            with pytest.raises(AuthError) as exc:
+                await client.connect()
+            assert exc.value.code == "auth_failed"
+        finally:
+            await server.stop()
+            outbox.close()
+            inbox.close()

--- a/contrib/channels/tests/cli/test_bind_flag_parsing.py
+++ b/contrib/channels/tests/cli/test_bind_flag_parsing.py
@@ -1,0 +1,173 @@
+"""``--bind`` flag parsing + ``--check`` JSON output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agentm_channels.cli import _parse_args, _resolve_bind
+
+
+def _ns(**kw: object) -> argparse.Namespace:
+    """Build a minimal Namespace defaulting all bind-related fields."""
+    return argparse.Namespace(
+        bind=kw.get("bind"),
+        bind_allow_uid=kw.get("bind_allow_uid"),
+        bind_allow_any_uid=kw.get("bind_allow_any_uid", False),
+    )
+
+
+def test_resolve_bind_none_when_unset() -> None:
+    spec = _resolve_bind(_ns(), cfg={})
+    assert spec is None
+
+
+def test_resolve_bind_tcp_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(_ns(bind="tcp://127.0.0.1:7000"), cfg={})
+    assert "unix://" in str(exc.value)
+
+
+def test_resolve_bind_mutually_exclusive_flags() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            _ns(
+                bind="unix:///tmp/x.sock",
+                bind_allow_uid=[1000],
+                bind_allow_any_uid=True,
+            ),
+            cfg={},
+        )
+    assert "mutually exclusive" in str(exc.value)
+
+
+def test_resolve_bind_default_uid_is_current_process() -> None:
+    spec = _resolve_bind(_ns(bind="unix:///tmp/x.sock"), cfg={})
+    assert spec is not None
+    assert spec.allow_uids == frozenset({os.geteuid()})
+    assert spec.socket_path == "/tmp/x.sock"
+
+
+def test_resolve_bind_any_uid_means_None() -> None:
+    spec = _resolve_bind(
+        _ns(bind="unix:///tmp/x.sock", bind_allow_any_uid=True), cfg={}
+    )
+    assert spec is not None
+    assert spec.allow_uids is None
+
+
+def test_resolve_bind_explicit_uids() -> None:
+    spec = _resolve_bind(
+        _ns(bind="unix:///tmp/x.sock", bind_allow_uid=[1000, 1001]), cfg={}
+    )
+    assert spec is not None
+    assert spec.allow_uids == frozenset({1000, 1001})
+
+
+def test_resolve_bind_yaml_socket_and_allow_uids() -> None:
+    spec = _resolve_bind(
+        _ns(),
+        cfg={"bind": {"socket": "unix:///var/run/x.sock", "allow_uids": [42]}},
+    )
+    assert spec is not None
+    assert spec.socket_path == "/var/run/x.sock"
+    assert spec.allow_uids == frozenset({42})
+
+
+def test_resolve_bind_cli_overrides_yaml() -> None:
+    spec = _resolve_bind(
+        _ns(bind="unix:///cli.sock"),
+        cfg={"bind": {"socket": "unix:///yaml.sock", "allow_uids": [42]}},
+    )
+    assert spec is not None
+    assert spec.socket_path == "/cli.sock"
+    # CLI overrides the URL; uid policy not set on CLI side, so the
+    # YAML side wins (fine-grained precedence per axis).
+    assert spec.allow_uids == frozenset({42})
+
+
+def test_parse_args_appends_uids() -> None:
+    ns = _parse_args(
+        [
+            "--bind",
+            "unix:///tmp/x.sock",
+            "--bind-allow-uid",
+            "1000",
+            "--bind-allow-uid",
+            "1001",
+        ]
+    )
+    assert ns.bind == "unix:///tmp/x.sock"
+    assert ns.bind_allow_uid == [1000, 1001]
+    assert ns.bind_allow_any_uid is False
+
+
+def test_check_emits_json_to_stdout() -> None:
+    """End-to-end: ``agentm-gateway --check --bind unix://...`` prints
+    a JSON object on stdout describing the resolved config.
+    """
+    with tempfile.TemporaryDirectory(prefix="agentm-check-") as d:
+        cfg_path = Path(d) / "gw.yaml"
+        cfg_path.write_text(
+            textwrap.dedent(
+                f"""
+                cwd: {d}
+                channels:
+                  stub:
+                    enabled: true
+                    allow_from: ['*']
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        sock = Path(d) / "g.sock"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "agentm_channels.cli",
+                "--config",
+                str(cfg_path),
+                "--bind",
+                f"unix://{sock}",
+                "--bind-allow-any-uid",
+                "--check",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+        # Find the JSON payload line (logs go to stderr; stdout is one line).
+        payload = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert payload["kind"] == "check"
+        assert payload["bind"]["socket"] == f"unix://{sock}"
+        assert payload["bind"]["allow_uids"] is None
+        assert "stub" in payload["channels"]
+
+
+def test_check_rejects_tcp_bind() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agentm_channels.cli",
+            "--terminal",
+            "--bind",
+            "tcp://127.0.0.1:7000",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 2

--- a/contrib/channels/tests/cli/test_peercred_authenticator.py
+++ b/contrib/channels/tests/cli/test_peercred_authenticator.py
@@ -1,0 +1,108 @@
+"""UnixPeerCredAuthenticator over a real Unix socket pair."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+import pytest
+
+from agentm_channels.auth.peercred import UnixPeerCredAuthenticator, _peer_uid
+
+
+_PEERCRED_SUPPORTED = sys.platform.startswith("linux") or hasattr(os, "getpeereid")
+
+pytestmark = pytest.mark.skipif(
+    not _PEERCRED_SUPPORTED,
+    reason="SO_PEERCRED / getpeereid not available on this platform",
+)
+
+
+async def _open_pair() -> tuple[
+    asyncio.base_events.Server,
+    asyncio.StreamWriter,  # server-side writer (carries the accepted socket)
+    asyncio.StreamWriter,  # client-side writer
+    asyncio.Event,  # set when handler should release
+]:
+    tmp = tempfile.mkdtemp(prefix="agentm-peercred-")
+    path = os.path.join(tmp, "s.sock")
+    ready = asyncio.Event()
+    release = asyncio.Event()
+    captured: dict[str, asyncio.StreamWriter] = {}
+
+    async def handle(_r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        captured["w"] = w
+        ready.set()
+        await release.wait()
+        w.close()
+        try:
+            await w.wait_closed()
+        except Exception:
+            pass
+
+    server = await asyncio.start_unix_server(handle, path=path)
+    _r, cw = await asyncio.open_unix_connection(path=path)
+    await asyncio.wait_for(ready.wait(), timeout=2.0)
+    return server, captured["w"], cw, release
+
+
+async def _teardown(
+    server: asyncio.base_events.Server,
+    client_writer: asyncio.StreamWriter,
+    release: asyncio.Event,
+) -> None:
+    release.set()
+    client_writer.close()
+    try:
+        await client_writer.wait_closed()
+    except Exception:
+        pass
+    server.close()
+    await server.wait_closed()
+
+
+async def test_peer_uid_matches_geteuid() -> None:
+    server, sw, cw, release = await _open_pair()
+    try:
+        sock = sw.get_extra_info("socket")
+        assert _peer_uid(sock) == os.geteuid()
+    finally:
+        await _teardown(server, cw, release)
+
+
+async def test_authenticator_accepts_known_uid() -> None:
+    server, sw, cw, release = await _open_pair()
+    try:
+        auth = UnixPeerCredAuthenticator(allowed_uids={os.geteuid()})
+        assert await auth.authenticate("chat_client", "p1", None, sw) is True
+    finally:
+        await _teardown(server, cw, release)
+
+
+async def test_authenticator_rejects_unknown_uid() -> None:
+    server, sw, cw, release = await _open_pair()
+    try:
+        auth = UnixPeerCredAuthenticator(allowed_uids={os.geteuid() + 1})
+        assert await auth.authenticate("chat_client", "p1", None, sw) is False
+    finally:
+        await _teardown(server, cw, release)
+
+
+async def test_authenticator_any_uid_accepts() -> None:
+    server, sw, cw, release = await _open_pair()
+    try:
+        auth = UnixPeerCredAuthenticator(allowed_uids=None)
+        assert await auth.authenticate("chat_client", "p1", None, sw) is True
+    finally:
+        await _teardown(server, cw, release)
+
+
+async def test_authenticator_empty_allow_set_denies_all() -> None:
+    server, sw, cw, release = await _open_pair()
+    try:
+        auth = UnixPeerCredAuthenticator(allowed_uids=set())
+        assert await auth.authenticate("chat_client", "p1", None, sw) is False
+    finally:
+        await _teardown(server, cw, release)

--- a/contrib/channels/tests/outbox/conftest.py
+++ b/contrib/channels/tests/outbox/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for outbox tests."""
+
+from __future__ import annotations
+
+from agentm_channels.wire import KIND_OUTBOUND, WIRE_VERSION, Envelope
+
+
+def make_envelope(env_id: str, ts: float = 1000.0) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id=env_id,
+        kind=KIND_OUTBOUND,
+        ts=ts,
+        body={"text": f"hello {env_id}"},
+    )

--- a/contrib/channels/tests/outbox/test_batch_catchup.py
+++ b/contrib/channels/tests/outbox/test_batch_catchup.py
@@ -1,0 +1,37 @@
+"""Catch-up batch delivery: lease in chunks, in FIFO order."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import SqliteOutbox
+
+from .conftest import make_envelope
+
+
+def test_batched_lease_returns_fifo_chunks(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        for i in range(50):
+            store.enqueue("peer-A", make_envelope(f"m{i:02d}"))
+
+        first = store.lease("peer-A", batch_max=10, now=2000.0)
+        assert [r.envelope.id for r in first] == [f"m{i:02d}" for i in range(10)]
+        store.ack([r.id for r in first])
+
+        second = store.lease("peer-A", batch_max=10, now=2000.0)
+        assert [r.envelope.id for r in second] == [
+            f"m{i:02d}" for i in range(10, 20)
+        ]
+        assert store.pending_count("peer-A") == 40
+    finally:
+        store.close()
+
+
+def test_batch_max_zero_yields_empty(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        store.enqueue("peer-A", make_envelope("m1"))
+        assert store.lease("peer-A", batch_max=0, now=2000.0) == []
+    finally:
+        store.close()

--- a/contrib/channels/tests/outbox/test_dead_letter.py
+++ b/contrib/channels/tests/outbox/test_dead_letter.py
@@ -1,0 +1,46 @@
+"""Repeated nack then dead_letter — row leaves outbox, lands in dead_letter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import SqliteOutbox
+
+from .conftest import make_envelope
+
+
+def test_dead_letter_after_repeated_nack(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        store.enqueue("peer-A", make_envelope("m1"))
+
+        # Three failed attempts.
+        last_id: int | None = None
+        for attempt in range(1, 4):
+            leased = store.lease("peer-A", batch_max=10, now=1000.0 * attempt)
+            assert len(leased) == 1
+            assert leased[0].attempts == attempt
+            last_id = leased[0].id
+            store.nack([leased[0].id], next_retry_at=1000.0 * attempt)
+
+        assert last_id is not None
+        # Caller decides "enough" and dead-letters.
+        store.dead_letter(last_id, reason="max_attempts")
+
+        assert store.pending_count("peer-A") == 0
+        assert store.dead_letter_count("peer-A") == 1
+
+        # Subsequent lease yields nothing.
+        assert store.lease("peer-A", batch_max=10, now=9000.0) == []
+    finally:
+        store.close()
+
+
+def test_dead_letter_missing_row_is_noop(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        # Should not raise.
+        store.dead_letter(9999, reason="missing")
+        assert store.dead_letter_count("peer-A") == 0
+    finally:
+        store.close()

--- a/contrib/channels/tests/outbox/test_durability.py
+++ b/contrib/channels/tests/outbox/test_durability.py
@@ -1,0 +1,47 @@
+"""Enqueue, close, reopen, lease — all messages survive."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import SqliteOutbox
+
+from .conftest import make_envelope
+
+
+def test_messages_survive_close_and_reopen(tmp_path: Path) -> None:
+    db = str(tmp_path / "ob.sqlite")
+    store = SqliteOutbox(db)
+    try:
+        for i in range(8):
+            store.enqueue("peer-A", make_envelope(f"m{i}"))
+    finally:
+        store.close()
+
+    reopened = SqliteOutbox(db)
+    try:
+        assert reopened.pending_count("peer-A") == 8
+        leased = reopened.lease("peer-A", batch_max=100, now=2000.0)
+        assert [r.envelope.id for r in leased] == [f"m{i}" for i in range(8)]
+    finally:
+        reopened.close()
+
+
+def test_acks_persist_across_restart(tmp_path: Path) -> None:
+    db = str(tmp_path / "ob.sqlite")
+    store = SqliteOutbox(db)
+    try:
+        for i in range(5):
+            store.enqueue("peer-A", make_envelope(f"m{i}"))
+        leased = store.lease("peer-A", batch_max=3, now=2000.0)
+        store.ack([r.id for r in leased])
+    finally:
+        store.close()
+
+    reopened = SqliteOutbox(db)
+    try:
+        assert reopened.pending_count("peer-A") == 2
+        leased = reopened.lease("peer-A", batch_max=10, now=3000.0)
+        assert [r.envelope.id for r in leased] == ["m3", "m4"]
+    finally:
+        reopened.close()

--- a/contrib/channels/tests/outbox/test_inbox_idempotency.py
+++ b/contrib/channels/tests/outbox/test_inbox_idempotency.py
@@ -1,0 +1,33 @@
+"""InboxLog.record_seen returns False on duplicate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import SqliteInbox
+
+
+def test_record_seen_dedupes_by_peer_and_envelope_id(tmp_path: Path) -> None:
+    inbox = SqliteInbox(str(tmp_path / "ib.sqlite"))
+    try:
+        assert inbox.record_seen("peer-A", "m1", ts=100.0) is True
+        assert inbox.record_seen("peer-A", "m1", ts=101.0) is False
+        # Same envelope id but different peer is independent.
+        assert inbox.record_seen("peer-B", "m1", ts=102.0) is True
+    finally:
+        inbox.close()
+
+
+def test_prune_drops_old_entries(tmp_path: Path) -> None:
+    inbox = SqliteInbox(str(tmp_path / "ib.sqlite"))
+    try:
+        inbox.record_seen("peer-A", "m1", ts=100.0)
+        inbox.record_seen("peer-A", "m2", ts=200.0)
+        removed = inbox.prune(older_than=150.0)
+        assert removed == 1
+        # m1 was pruned, so it is "new" again.
+        assert inbox.record_seen("peer-A", "m1", ts=300.0) is True
+        # m2 remains.
+        assert inbox.record_seen("peer-A", "m2", ts=300.0) is False
+    finally:
+        inbox.close()

--- a/contrib/channels/tests/outbox/test_lease_expiry.py
+++ b/contrib/channels/tests/outbox/test_lease_expiry.py
@@ -1,0 +1,32 @@
+"""Lease without ack → after TTL, the same rows lease again."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import LEASE_TTL_SECONDS, SqliteOutbox
+
+from .conftest import make_envelope
+
+
+def test_expired_lease_is_reissued_with_incremented_attempts(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        for i in range(3):
+            store.enqueue("peer-A", make_envelope(f"m{i}"))
+
+        first = store.lease("peer-A", batch_max=10, now=1000.0)
+        assert [r.attempts for r in first] == [1, 1, 1]
+
+        # Within the lease window, lease returns nothing.
+        within = store.lease("peer-A", batch_max=10, now=1000.0 + 1.0)
+        assert within == []
+
+        # After TTL elapses, the same rows are leased again.
+        after = store.lease(
+            "peer-A", batch_max=10, now=1000.0 + LEASE_TTL_SECONDS + 1.0
+        )
+        assert [r.envelope.id for r in after] == [r.envelope.id for r in first]
+        assert [r.attempts for r in after] == [2, 2, 2]
+    finally:
+        store.close()

--- a/contrib/channels/tests/outbox/test_policy.py
+++ b/contrib/channels/tests/outbox/test_policy.py
@@ -1,0 +1,30 @@
+"""Exponential backoff math + jitter bounds."""
+
+from __future__ import annotations
+
+from agentm_channels.outbox import exponential_backoff
+
+
+def test_no_jitter_doubles_each_attempt() -> None:
+    delays = [
+        exponential_backoff(a, base=1.0, cap=60.0, jitter_ratio=0.0)
+        for a in range(1, 6)
+    ]
+    assert delays == [1.0, 2.0, 4.0, 8.0, 16.0]
+
+
+def test_cap_applies() -> None:
+    delay = exponential_backoff(10, base=1.0, cap=60.0, jitter_ratio=0.0)
+    assert delay == 60.0
+
+
+def test_jitter_stays_within_ratio() -> None:
+    for _ in range(50):
+        d = exponential_backoff(3, base=1.0, cap=60.0, jitter_ratio=0.2)
+        # raw=4.0, +/-20% → [3.2, 4.8]
+        assert 3.2 <= d <= 4.8
+
+
+def test_attempts_below_one_treated_as_one() -> None:
+    assert exponential_backoff(0, base=1.0, cap=60.0, jitter_ratio=0.0) == 1.0
+    assert exponential_backoff(-3, base=1.0, cap=60.0, jitter_ratio=0.0) == 1.0

--- a/contrib/channels/tests/outbox/test_sqlite_basic.py
+++ b/contrib/channels/tests/outbox/test_sqlite_basic.py
@@ -1,0 +1,54 @@
+"""Happy-path enqueue/lease/ack + idempotent enqueue."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentm_channels.outbox import SqliteOutbox
+
+from .conftest import make_envelope
+
+
+def test_enqueue_lease_ack(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        store.enqueue("peer-A", make_envelope("m1"))
+        store.enqueue("peer-A", make_envelope("m2"))
+
+        assert store.pending_count("peer-A") == 2
+
+        leased = store.lease("peer-A", batch_max=10, now=2000.0)
+        assert [r.envelope.id for r in leased] == ["m1", "m2"]
+        assert all(r.attempts == 1 for r in leased)
+
+        store.ack([r.id for r in leased])
+        assert store.pending_count("peer-A") == 0
+    finally:
+        store.close()
+
+
+def test_enqueue_idempotent(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        env = make_envelope("dup")
+        store.enqueue("peer-A", env)
+        store.enqueue("peer-A", env)
+        store.enqueue("peer-A", env)
+        assert store.pending_count("peer-A") == 1
+    finally:
+        store.close()
+
+
+def test_pending_count_isolated_per_peer(tmp_path: Path) -> None:
+    store = SqliteOutbox(str(tmp_path / "ob.sqlite"))
+    try:
+        store.enqueue("peer-A", make_envelope("a1"))
+        store.enqueue("peer-B", make_envelope("b1"))
+        store.enqueue("peer-B", make_envelope("b2"))
+        assert store.pending_count("peer-A") == 1
+        assert store.pending_count("peer-B") == 2
+
+        leased = store.lease("peer-A", batch_max=10, now=2000.0)
+        assert [r.peer_id for r in leased] == ["peer-A"]
+    finally:
+        store.close()

--- a/contrib/channels/tests/server/conftest.py
+++ b/contrib/channels/tests/server/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures for server integration tests.
+
+Real Unix sockets in a per-test :class:`tempfile.TemporaryDirectory`
+to keep /tmp clean and avoid cross-test path collisions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import pytest
+
+from agentm_channels.peer import PeerSession
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+InboundHandler = Callable[[PeerSession, Envelope], Awaitable[None]]
+
+
+@pytest.fixture
+def tmp_sock_dir() -> "AsyncIterator[str]":  # type: ignore[type-arg]
+    with tempfile.TemporaryDirectory(prefix="agentm-wire-") as d:
+        yield d
+
+
+@pytest.fixture
+def db_path(tmp_sock_dir: str) -> str:
+    return os.path.join(tmp_sock_dir, "outbox.sqlite")
+
+
+@pytest.fixture
+def socket_path(tmp_sock_dir: str) -> str:
+    return os.path.join(tmp_sock_dir, "gateway.sock")
+
+
+async def make_envelope(env_id: str, body: dict[str, object]) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id=env_id,
+        kind="outbound",
+        ts=time.time(),
+        body=body,
+    )
+
+
+async def wait_for(
+    predicate: Callable[[], bool], timeout: float = 3.0, interval: float = 0.02
+) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(interval)
+    return predicate()

--- a/contrib/channels/tests/server/test_auth_failure.py
+++ b/contrib/channels/tests/server/test_auth_failure.py
@@ -1,0 +1,61 @@
+"""Authenticator that rejects → client receives error and connect() raises."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentm_channels.client import AuthError, WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import Envelope
+
+
+async def _noop(_session: PeerSession, _env: Envelope) -> None:
+    return None
+
+
+class TokenAuth:
+    def __init__(self, expected_token: str, expected_peer: str) -> None:
+        self.expected_token = expected_token
+        self.expected_peer = expected_peer
+
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,
+        transport: asyncio.StreamWriter,
+    ) -> bool:
+        if peer_id == self.expected_peer and token == self.expected_token:
+            return True
+        return False
+
+
+async def test_wrong_token_rejected(socket_path: str, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        socket_path, outbox, inbox, _noop, authenticator=TokenAuth("good", "trusted")
+    )
+    await server.start()
+    try:
+        evil = WireClient(
+            socket_path, peer_id="evil", peer_kind="chat_client", token="wrong"
+        )
+        with pytest.raises(AuthError) as exc_info:
+            await evil.connect()
+        assert exc_info.value.code == "auth_failed"
+        # Confirm the *good* peer still works.
+        good = WireClient(
+            socket_path, peer_id="trusted", peer_kind="chat_client", token="good"
+        )
+        await good.connect()
+        assert good.welcome() is not None
+        await good.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_catchup_batching.py
+++ b/contrib/channels/tests/server/test_catchup_batching.py
@@ -1,0 +1,101 @@
+"""Catch-up batching: M=50 queued → batched delivery, not 50 individual frames."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from math import ceil
+
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import (
+    KIND_DELIVERY_BATCH,
+    KIND_OUTBOUND,
+    WIRE_VERSION,
+    Envelope,
+    decode_stream,
+)
+
+
+
+async def _noop(_session: PeerSession, _env: Envelope) -> None:
+    return None
+
+
+async def test_50_messages_arrive_as_batches(socket_path: str, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    for i in range(50):
+        outbox.enqueue(
+            "B",
+            Envelope(
+                v=WIRE_VERSION,
+                id=f"b{i}",
+                kind="outbound",
+                ts=time.time(),
+                body={"i": i},
+            ),
+        )
+
+    BATCH_MAX = 32
+    server = WireServer(
+        socket_path, outbox, inbox, _noop, delivery_batch_max=BATCH_MAX
+    )
+    await server.start()
+
+    # We intercept at the *wire* level by speaking the socket
+    # directly — the client lib hides batch frames behind per-item
+    # dispatch. Count raw frame kinds.
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        from agentm_channels.wire import KIND_HELLO, encode
+
+        hello = Envelope(
+            v=WIRE_VERSION,
+            id="h",
+            kind=KIND_HELLO,
+            ts=time.time(),
+            body={"peer_id": "B", "peer_kind": "chat_client"},
+        )
+        writer.write(encode(hello))
+        await writer.drain()
+
+        envs: list[Envelope] = []
+        buf = b""
+        deadline = asyncio.get_running_loop().time() + 5.0
+        item_count = 0
+        while asyncio.get_running_loop().time() < deadline and item_count < 50:
+            chunk = await asyncio.wait_for(reader.read(65536), timeout=2.0)
+            if not chunk:
+                break
+            buf += chunk
+            ready, buf = decode_stream(buf)
+            for env in ready:
+                envs.append(env)
+                if env.kind == KIND_DELIVERY_BATCH:
+                    item_count += len(env.body.get("items", []))
+                elif env.kind == KIND_OUTBOUND:
+                    item_count += 1
+        writer.close()
+
+        # Drop the welcome.
+        delivery_envs = [e for e in envs if e.kind in (KIND_OUTBOUND, KIND_DELIVERY_BATCH)]
+        delivered_total = 0
+        for e in delivery_envs:
+            if e.kind == KIND_DELIVERY_BATCH:
+                delivered_total += len(e.body["items"])
+            else:
+                delivered_total += 1
+        assert delivered_total == 50
+        # Server must use batching: at most ceil(50 / batch_max) batch envelopes
+        assert len(delivery_envs) <= ceil(50 / BATCH_MAX) + 1  # tolerate one trailing single
+        # And we should NOT have 50 single-frame outbound envelopes.
+        single_count = sum(1 for e in delivery_envs if e.kind == KIND_OUTBOUND)
+        assert single_count < 50, (
+            f"expected batched delivery, got {single_count} single outbound frames"
+        )
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_dead_letter.py
+++ b/contrib/channels/tests/server/test_dead_letter.py
@@ -1,0 +1,107 @@
+"""Dead-letter path: write keeps failing → after MAX_ATTEMPTS, row → DLQ.
+
+The server exits the delivery loop after one socket failure (the
+connection is dead), but on each peer *reconnect* the row is leased
+afresh and attempts increments. So getting a row dead-lettered needs
+``max_delivery_attempts`` reconnects. Tests run with
+``max_delivery_attempts=1`` so a single attempt suffices.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+from .conftest import wait_for
+
+
+async def _noop(_session: PeerSession, _env: Envelope) -> None:
+    return None
+
+
+class _BadWriter:
+    """Wraps a real :class:`asyncio.StreamWriter` and raises on ``write``."""
+
+    def __init__(self, real: asyncio.StreamWriter) -> None:
+        self._real = real
+        self.is_closing = real.is_closing  # type: ignore[assignment]
+
+    def write(self, data: bytes) -> None:
+        raise BrokenPipeError("simulated write failure")
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self._real.close()
+
+    async def wait_closed(self) -> None:
+        await self._real.wait_closed()
+
+
+async def test_dead_letter_after_max_attempts(socket_path: str, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    outbox.enqueue(
+        "D",
+        Envelope(
+            v=WIRE_VERSION,
+            id="dead-1",
+            kind="outbound",
+            ts=time.time(),
+            body={"k": "v"},
+        ),
+    )
+
+    # Use a very small backoff so retries happen fast. We don't expose
+    # the policy fn as config — instead, monkey-patch the policy module
+    # so attempts re-fire promptly.
+    import agentm_channels.server as server_mod
+
+    real_backoff = server_mod.exponential_backoff
+    server_mod.exponential_backoff = lambda attempts: 0.0  # type: ignore[assignment]
+
+    # max_delivery_attempts=1 → first write failure dead-letters,
+    # exercising the same code path that fires at MAX_DELIVERY_ATTEMPTS
+    # in production. Simulating 5 reconnect cycles for one test would
+    # bloat the suite without adding behavioural coverage.
+    server = WireServer(
+        socket_path,
+        outbox,
+        inbox,
+        _noop,
+        delivery_batch_max=1,
+        max_delivery_attempts=1,
+    )
+    await server.start()
+
+    # Replace the writer on register to one that always fails.
+    real_register = server._registry.register
+
+    def patched_register(session: PeerSession) -> None:  # type: ignore[no-redef]
+        session.transport_writer = _BadWriter(session.transport_writer)  # type: ignore[assignment]
+        real_register(session)
+
+    server._registry.register = patched_register  # type: ignore[assignment]
+
+    try:
+        from agentm_channels.client import WireClient
+
+        client = WireClient(socket_path, peer_id="D", peer_kind="chat_client")
+        await client.connect()
+        ok = await wait_for(
+            lambda: outbox.dead_letter_count("D") >= 1, timeout=5.0
+        )
+        assert ok
+        assert outbox.pending_count("D") == 0
+        await client.close()
+    finally:
+        server_mod.exponential_backoff = real_backoff  # type: ignore[assignment]
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_durability_restart.py
+++ b/contrib/channels/tests/server/test_durability_restart.py
@@ -1,0 +1,161 @@
+"""Durability across server restart.
+
+Demonstrates the at-least-once trade-off documented on WireServer:
+the server acks an outbox row after ``writer.drain()`` returns, so a
+client crash *after* receiving the frame but *before* processing it
+means the row is gone — the receiver-side ``InboxLog`` is the
+deduplication boundary in production.
+
+This test proves the *outbox-survives-restart* half: a write failure
+mid-burst nacks the remaining rows, the server is then taken down,
+and on restart a fresh client peer "A" receives whatever was left in
+the outbox. Items the first client already drained are not redelivered
+(per the documented trade-off); items the server failed to write are.
+
+We force the boundary deterministically by wrapping the per-peer
+writer so that after N successful frames it raises ``BrokenPipeError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from agentm_channels.client import WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+from .conftest import wait_for
+
+
+async def _noop_inbound(_session: PeerSession, _env: Envelope) -> None:
+    return None
+
+
+def _outbound(env_id: str) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id=env_id,
+        kind="outbound",
+        ts=time.time(),
+        body={"seq": env_id},
+    )
+
+
+class _GatedWriter:
+    """Wraps a real :class:`asyncio.StreamWriter`. The first
+    ``allowed_writes`` ``write()`` calls pass through; subsequent
+    calls raise :class:`BrokenPipeError`. ``drain()`` /
+    ``is_closing()`` / ``close()`` are forwarded.
+    """
+
+    def __init__(self, real: asyncio.StreamWriter, allowed_writes: int) -> None:
+        self._real = real
+        self._left = allowed_writes
+
+    def write(self, data: bytes) -> None:
+        if self._left <= 0:
+            raise BrokenPipeError("simulated boundary")
+        self._left -= 1
+        self._real.write(data)
+
+    async def drain(self) -> None:
+        await self._real.drain()
+
+    def is_closing(self) -> bool:
+        return self._real.is_closing()
+
+    def close(self) -> None:
+        self._real.close()
+
+    async def wait_closed(self) -> None:
+        await self._real.wait_closed()
+
+
+async def test_durability_across_restart(socket_path: str, db_path: str) -> None:
+    # Pre-enqueue 5 envelopes for peer A.
+    outbox = SqliteOutbox(db_path, lease_ttl=0.3)
+    inbox = SqliteInbox(db_path)
+    for i in range(5):
+        outbox.enqueue("A", _outbound(f"m{i}"))
+    outbox.close()
+    inbox.close()
+
+    seen_session1: list[str] = []
+    seen_session2: list[str] = []
+
+    # --- session 1: writer permits 2 envelopes, then fails ------------
+    # The welcome is written via the local writer variable in the
+    # connection handler, *not* via session.transport_writer, so the
+    # gate sees only delivery-loop writes.
+    outbox = SqliteOutbox(db_path, lease_ttl=0.3)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        socket_path, outbox, inbox, _noop_inbound, delivery_batch_max=1
+    )
+    # Patch register() to swap the writer before delivery starts.
+    real_register = server._registry.register
+
+    def patched_register(session: PeerSession) -> None:
+        session.transport_writer = _GatedWriter(  # type: ignore[assignment]
+            session.transport_writer, allowed_writes=2
+        )
+        real_register(session)
+
+    server._registry.register = patched_register  # type: ignore[assignment]
+    await server.start()
+
+    async def on_outbound_1(env: Envelope) -> None:
+        seen_session1.append(env.id)
+
+    try:
+        client = WireClient(
+            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_1
+        )
+        await client.connect()
+        # Welcome arrived (1 write). 2 more writes succeed → 2 envelopes.
+        # The 3rd delivery attempt raises BrokenPipeError → rows nack'd.
+        await wait_for(lambda: outbox.pending_count("A") <= 5 and len(seen_session1) >= 2, timeout=3.0)
+        # Give the server one more poll cycle to register the nack.
+        await asyncio.sleep(0.3)
+        # Now bring everything down.
+        if client._read_task is not None:  # type: ignore[attr-defined]
+            client._read_task.cancel()  # type: ignore[attr-defined]
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+    # Let leases expire.
+    await asyncio.sleep(0.5)
+
+    # --- session 2: fresh server → leftover rows redeliver ------------
+    outbox = SqliteOutbox(db_path, lease_ttl=0.3)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        socket_path, outbox, inbox, _noop_inbound, delivery_batch_max=8
+    )
+    await server.start()
+
+    async def on_outbound_2(env: Envelope) -> None:
+        seen_session2.append(env.id)
+
+    try:
+        client2 = WireClient(
+            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_2
+        )
+        await client2.connect()
+        # Expect the leftover envelopes to land.
+        leftover = 5 - len(set(seen_session1))
+        await wait_for(lambda: len(seen_session2) >= leftover, timeout=5.0)
+        all_seen = set(seen_session1) | set(seen_session2)
+        assert all_seen == {f"m{i}" for i in range(5)}, (
+            f"session1={seen_session1} session2={seen_session2}"
+        )
+        await client2.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_echo.py
+++ b/contrib/channels/tests/server/test_echo.py
@@ -1,0 +1,52 @@
+"""Inbound → server handler enqueues outbound → client receives it."""
+
+from __future__ import annotations
+
+import time
+
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+from .conftest import wait_for
+
+
+async def test_echo_inbound_to_outbound(socket_path: str, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    received: list[Envelope] = []
+
+    async def on_inbound(session: PeerSession, env: Envelope) -> None:
+        echo = Envelope(
+            v=WIRE_VERSION,
+            id=f"echo-of-{env.id}",
+            kind="outbound",
+            ts=time.time(),
+            body={"echo_of": env.body},
+        )
+        outbox.enqueue(session.peer_id, echo)
+
+    server = WireServer(socket_path, outbox, inbox, on_inbound)
+    await server.start()
+
+    async def collect(env: Envelope) -> None:
+        received.append(env)
+
+    try:
+        from agentm_channels.client import WireClient
+
+        client = WireClient(
+            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=collect
+        )
+        await client.connect()
+        await client.send_inbound({"text": "hi"}, env_id="m1")
+        ok = await wait_for(lambda: len(received) == 1)
+        assert ok
+        assert received[0].kind == "outbound"
+        assert received[0].body["echo_of"] == {"text": "hi"}
+        await client.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_handshake.py
+++ b/contrib/channels/tests/server/test_handshake.py
@@ -1,0 +1,64 @@
+"""Hello/welcome handshake + authenticator-reject path."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentm_channels.client import AuthError, WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.server import WireServer
+
+
+async def _noop_inbound(_session: object, _env: object) -> None:
+    return None
+
+
+async def test_hello_welcome_roundtrip(socket_path: str, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(socket_path, outbox, inbox, _noop_inbound)
+    await server.start()
+    try:
+        client = WireClient(socket_path, peer_id="P1", peer_kind="chat_client")
+        await client.connect()
+        welcome = client.welcome()
+        assert welcome is not None
+        assert welcome.kind == "welcome"
+        assert welcome.body["peer_id_echo"] == "P1"
+        assert "server_version" in welcome.body
+        await client.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+class RejectingAuth:
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,
+        transport: asyncio.StreamWriter,
+    ) -> bool:
+        return False
+
+
+async def test_authenticator_reject_closes_connection(
+    socket_path: str, db_path: str
+) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(socket_path, outbox, inbox, _noop_inbound, authenticator=RejectingAuth())
+    await server.start()
+    try:
+        client = WireClient(socket_path, peer_id="banned", peer_kind="chat_client")
+        with pytest.raises(AuthError) as exc_info:
+            await client.connect()
+        assert exc_info.value.code == "auth_failed"
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/server/test_slow_consumer.py
+++ b/contrib/channels/tests/server/test_slow_consumer.py
@@ -1,0 +1,73 @@
+"""Slow-consumer detection: high-water tripped → diagnostic logged, no loss."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from agentm_channels.client import WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+from .conftest import wait_for
+
+
+async def _noop(_session: PeerSession, _env: Envelope) -> None:
+    return None
+
+
+async def test_slow_consumer_logs_and_does_not_lose(
+    socket_path: str, db_path: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="agentm_channels.server")
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    for i in range(30):
+        outbox.enqueue(
+            "C",
+            Envelope(
+                v=WIRE_VERSION,
+                id=f"c{i}",
+                kind="outbound",
+                ts=time.time(),
+                body={"i": i},
+            ),
+        )
+
+    server = WireServer(
+        socket_path,
+        outbox,
+        inbox,
+        _noop,
+        delivery_batch_max=1,  # force a slow drip so high-water trips before drain
+        slow_consumer_high_water=10,
+    )
+    await server.start()
+
+    received: list[str] = []
+
+    async def slow_handler(env: Envelope) -> None:
+        received.append(env.id)
+        await asyncio.sleep(0.05)
+
+    try:
+        client = WireClient(
+            socket_path, peer_id="C", peer_kind="chat_client", on_outbound=slow_handler
+        )
+        await client.connect()
+        await wait_for(lambda: len(received) >= 30, timeout=10.0)
+        assert len(received) == 30
+        assert {r for r in received} == {f"c{i}" for i in range(30)}
+        # Diagnostic was logged.
+        slow_logs = [r for r in caplog.records if "slow_consumer" in r.getMessage()]
+        assert slow_logs, "expected slow_consumer warning log"
+        await client.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/wire/test_envelope.py
+++ b/contrib/channels/tests/wire/test_envelope.py
@@ -1,0 +1,117 @@
+"""Envelope validation and round-trip serialization."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentm_channels.wire import Envelope, InvalidEnvelope
+
+
+def _ok_kwargs() -> dict[str, object]:
+    return {
+        "v": 1,
+        "id": "msg-1",
+        "kind": "inbound",
+        "ts": 1234567890.0,
+        "body": {"text": "hi"},
+    }
+
+
+def test_construction_with_required_fields_sets_defaults() -> None:
+    env = Envelope(**_ok_kwargs())  # type: ignore[arg-type]
+    assert env.v == 1
+    assert env.id == "msg-1"
+    assert env.kind == "inbound"
+    assert env.ts == 1234567890.0
+    assert env.body == {"text": "hi"}
+    assert env.to is None
+    assert env.correlation_id is None
+    assert env.hops == 0
+    assert env.root_session_key is None
+    assert env.peer_kind is None
+
+
+def test_construction_with_all_optional_fields() -> None:
+    env = Envelope(
+        v=1,
+        id="m",
+        kind="outbound",
+        ts=0.0,
+        body={},
+        to="peer://abc",
+        correlation_id="c1",
+        hops=2,
+        root_session_key="feishu:c1",
+        peer_kind="agent_worker",
+    )
+    assert env.to == "peer://abc"
+    assert env.correlation_id == "c1"
+    assert env.hops == 2
+    assert env.root_session_key == "feishu:c1"
+    assert env.peer_kind == "agent_worker"
+
+
+def test_invalid_kind_rejected() -> None:
+    kwargs = _ok_kwargs()
+    kwargs["kind"] = "nope"
+    with pytest.raises(InvalidEnvelope):
+        Envelope(**kwargs)  # type: ignore[arg-type]
+
+
+def test_invalid_version_rejected() -> None:
+    kwargs = _ok_kwargs()
+    kwargs["v"] = 2
+    with pytest.raises(InvalidEnvelope):
+        Envelope(**kwargs)  # type: ignore[arg-type]
+
+
+def test_empty_id_rejected() -> None:
+    kwargs = _ok_kwargs()
+    kwargs["id"] = ""
+    with pytest.raises(InvalidEnvelope):
+        Envelope(**kwargs)  # type: ignore[arg-type]
+
+
+def test_to_dict_omits_none_optionals_but_keeps_required() -> None:
+    env = Envelope(**_ok_kwargs())  # type: ignore[arg-type]
+    d = env.to_dict()
+    assert d["v"] == 1
+    assert d["id"] == "msg-1"
+    assert d["kind"] == "inbound"
+    assert d["ts"] == 1234567890.0
+    assert d["body"] == {"text": "hi"}
+    assert d["hops"] == 0
+    # None-valued optionals are omitted.
+    assert "to" not in d
+    assert "correlation_id" not in d
+    assert "root_session_key" not in d
+    assert "peer_kind" not in d
+
+
+def test_round_trip_preserves_all_fields() -> None:
+    env = Envelope(
+        v=1,
+        id="m",
+        kind="hello",
+        ts=42.5,
+        body={"peer_kind": "chat_client"},
+        to="chat://feishu/oc_x",
+        correlation_id="corr-7",
+        hops=3,
+        root_session_key="feishu:c2",
+        peer_kind="chat_client",
+    )
+    again = Envelope.from_dict(env.to_dict())
+    assert again == env
+
+
+def test_from_dict_missing_required_field_rejected() -> None:
+    with pytest.raises(InvalidEnvelope):
+        Envelope.from_dict({"v": 1, "kind": "ack", "ts": 0.0, "body": {}})
+
+
+def test_from_dict_non_dict_body_rejected() -> None:
+    with pytest.raises(InvalidEnvelope):
+        Envelope.from_dict(
+            {"v": 1, "id": "x", "kind": "ack", "ts": 0.0, "body": "not-a-dict"}
+        )

--- a/contrib/channels/tests/wire/test_framing.py
+++ b/contrib/channels/tests/wire/test_framing.py
@@ -1,0 +1,125 @@
+"""Length-prefixed framing: encode, decode, streaming decode, oversize guard."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from agentm_channels.wire import (
+    Envelope,
+    IncompleteFrame,
+    InvalidEnvelope,
+    WireError,
+    decode,
+    decode_stream,
+    encode,
+)
+from agentm_channels.wire.framing import MAX_FRAME_BYTES
+
+
+def _env(kind: str = "inbound", id_: str = "m1") -> Envelope:
+    return Envelope(v=1, id=id_, kind=kind, ts=0.0, body={"k": "v"})
+
+
+def test_encode_prepends_4byte_big_endian_length() -> None:
+    env = _env()
+    buf = encode(env)
+    length = struct.unpack(">I", buf[:4])[0]
+    assert length == len(buf) - 4
+    assert length > 0
+
+
+def test_round_trip_single_envelope() -> None:
+    env = _env()
+    buf = encode(env)
+    out, rest = decode(buf)
+    assert out == env
+    assert rest == b""
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        Envelope(v=1, id="a", kind="hello", ts=0.0, body={"peer_kind": "chat_client"}),
+        Envelope(v=1, id="b", kind="ack", ts=1.5, body={}),
+        Envelope(
+            v=1,
+            id="c",
+            kind="outbound",
+            ts=2.0,
+            body={"text": "hi", "nested": {"x": [1, 2, 3]}},
+            to="peer://xyz",
+            correlation_id="cid",
+            hops=4,
+            root_session_key="feishu:c1",
+            peer_kind="agent_worker",
+        ),
+    ],
+)
+def test_round_trip_preserves_all_envelope_shapes(env: Envelope) -> None:
+    out, rest = decode(encode(env))
+    assert out == env
+    assert rest == b""
+
+
+def test_decode_partial_buffer_raises_incomplete() -> None:
+    buf = encode(_env())
+    # Header truncated.
+    with pytest.raises(IncompleteFrame):
+        decode(buf[:2])
+    # Header complete, body truncated.
+    with pytest.raises(IncompleteFrame):
+        decode(buf[:6])
+
+
+def test_decode_stream_drains_back_to_back_frames() -> None:
+    a = _env(id_="a")
+    b = _env(id_="b")
+    c = _env(id_="c")
+    buf = encode(a) + encode(b) + encode(c)
+    envs, rest = decode_stream(buf)
+    assert [e.id for e in envs] == ["a", "b", "c"]
+    assert rest == b""
+
+
+def test_decode_stream_returns_trailing_partial() -> None:
+    a = _env(id_="a")
+    b = _env(id_="b")
+    full = encode(a) + encode(b)
+    # Cut one byte off the end of b's body.
+    truncated = full[:-1]
+    envs, rest = decode_stream(truncated)
+    assert [e.id for e in envs] == ["a"]
+    # The remaining bytes are the partial b-frame: 4-byte header + body-1.
+    assert len(rest) == len(encode(b)) - 1
+
+
+def test_decode_stream_empty_input() -> None:
+    envs, rest = decode_stream(b"")
+    assert envs == []
+    assert rest == b""
+
+
+def test_oversized_length_rejected_before_allocation() -> None:
+    # Construct a header claiming > MAX_FRAME_BYTES; supply no body.
+    bad_len = MAX_FRAME_BYTES + 1
+    header = struct.pack(">I", bad_len)
+    with pytest.raises(InvalidEnvelope):
+        decode(header)
+    with pytest.raises(InvalidEnvelope):
+        decode_stream(header)
+
+
+def test_malformed_json_rejected() -> None:
+    body = b"not-json"
+    buf = struct.pack(">I", len(body)) + body
+    with pytest.raises(WireError):
+        decode(buf)
+
+
+def test_decode_rejects_envelope_with_invalid_kind() -> None:
+    body = b'{"v":1,"id":"x","kind":"bogus","ts":0,"body":{}}'
+    buf = struct.pack(">I", len(body)) + body
+    with pytest.raises(InvalidEnvelope):
+        decode(buf)

--- a/contrib/channels/tests/wire/test_kinds.py
+++ b/contrib/channels/tests/wire/test_kinds.py
@@ -1,0 +1,38 @@
+"""Kinds must match designs/client-server-architecture.md §4.3 exactly."""
+
+from __future__ import annotations
+
+from agentm_channels.wire import kinds
+
+
+def test_kind_string_values() -> None:
+    assert kinds.KIND_HELLO == "hello"
+    assert kinds.KIND_WELCOME == "welcome"
+    assert kinds.KIND_INBOUND == "inbound"
+    assert kinds.KIND_OUTBOUND == "outbound"
+    assert kinds.KIND_ACK == "ack"
+    assert kinds.KIND_ACK_BATCH == "ack_batch"
+    assert kinds.KIND_PING == "ping"
+    assert kinds.KIND_PONG == "pong"
+    assert kinds.KIND_ERROR == "error"
+    assert kinds.KIND_BYE == "bye"
+    assert kinds.KIND_DELIVERY_BATCH == "delivery_batch"
+
+
+def test_valid_kinds_frozenset_exact_membership() -> None:
+    expected = {
+        "hello",
+        "welcome",
+        "inbound",
+        "outbound",
+        "ack",
+        "ack_batch",
+        "ping",
+        "pong",
+        "error",
+        "bye",
+        "delivery_batch",
+    }
+    assert kinds.VALID_KINDS == frozenset(expected)
+    assert len(kinds.VALID_KINDS) == 11
+    assert isinstance(kinds.VALID_KINDS, frozenset)


### PR DESCRIPTION
Implements Phase 1 of `plans/2026-05-11-gateway-client-server.md` (gateway/client process split). 5 self-contained commits; full channels suite 126/126 pass, mypy + ruff clean.

## Summary

| Commit | Scope | LoC | Tests |
|---|---|---|---|
| `c3c4706` | `wire/` — Envelope, length-prefix framing, 11 kinds | 334 src | 23 |
| `2a4236c` | `outbox/` — `OutboxStore` + `InboxLog` Protocols + SQLite WAL impl + exp backoff | 447 src | 16 |
| `ff6eea2` | `server.py` + `client.py` + `peer.py` — asyncio Unix-socket server, per-peer delivery worker, single/batch delivery, dead-letter | 790 src | 8 |
| `21dd6b7` | `--bind unix://` CLI flag, `UnixPeerCredAuthenticator`, `wire_bridge` synthetic channel | 470 src | 18 |
| `d327e38` | Design-doc reconciliation: envelope `v:int`/`ts:float`, slow-consumer observational, delivery-loop disconnect | doc | — |

## Acceptance (all 7 Phase 1 fail-stop scenarios covered)

- [x] Wire encode/decode round-trip — `tests/wire/`
- [x] hello/welcome handshake — `tests/server/test_handshake.py`
- [x] Inbound→outbound echo — `tests/server/test_echo.py`
- [x] Outbox durability across gateway restart — `tests/server/test_durability_restart.py` + `tests/outbox/test_durability.py`
- [x] Catch-up batching (50 enqueued → ≤ ceil(50/32) `delivery_batch` frames) — `tests/server/test_catchup_batching.py`
- [x] Slow-consumer (observational, doesn't deadlock) — `tests/server/test_slow_consumer.py`
- [x] Dead-letter on permanent write failure — `tests/server/test_dead_letter.py`
- [x] Auth failure path — `tests/server/test_auth_failure.py` + `tests/cli/test_peercred_authenticator.py`

## Design-doc reconciliations (in `d327e38`)

Surfaced while implementing — folded back into `designs/client-server-architecture.md`:

1. Envelope `v` is `int = 1` (not `"v0"` string) — single equality check.
2. Envelope `ts` is float epoch seconds (not ISO 8601) — same reason.
3. Slow-consumer is **observational only** (log + flag); stop-pulling would deadlock the queue. Real producer-side back-pressure deferred to v2.
4. Delivery loop exits on a single write failure; outbox redelivers on reconnect.

## Non-blocking followups (from independent reviewer pass)

Caught during review, deferred to keep this PR focused:

- `delivery_batch` envelope should set `reason` + `session_key` per design §4.5.3 example; steady-state low-depth queue should pipeline single `outbound` (currently always batches when `len > 1`).
- `wire_bridge.py` reaches into `ChannelManager._channels` / `._tasks` via `type: ignore` — expose a public `inject_channel(name, ch)` on the manager.
- `test_dead_letter.py` monkey-patches module-level `exponential_backoff` and private `_registry.register` — refactor toward injectable writer factory.
- Delivery loop's 50 ms idle poll could be `asyncio.Event` wakeup from `enqueue` (optional latency win, no correctness impact).

## Out of scope (later phases)

- `agentm-terminal` extracted process (Phase 2)
- `agentm-feishu` extracted process (Phase 3)
- v0 in-process channel deprecation (Phase 4)
- Distributed `agent_worker` peer kind (Phase 5)
- a2a tool calls (Phase 6)
- TCP bind, mTLS, bearer tokens (deferred per §6 decisions)

## Test plan

- [x] `uv run pytest contrib/channels/` — 126 passed
- [x] `uv run mypy contrib/channels/src/` — clean
- [x] `uv run ruff check contrib/channels/src/ contrib/channels/tests/` — clean
- [x] §11 atom contract: 0 `core._internal` imports in new code
- [x] `--check` emits structured JSON to stdout; `--bind tcp://` exits 2 (config error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)