### PR TITLE
feat(channels): Phase 2 — agentm-terminal as a separate process

### DIFF
--- a/contrib/channels-clients/terminal/README.md
+++ b/contrib/channels-clients/terminal/README.md
@@ -1,0 +1,30 @@
+# agentm-terminal
+
+Terminal (stdin/stdout) client process for the AgentM channels gateway.
+
+Connects to an `agentm-gateway --bind unix://…` over the v1 wire
+protocol and renders outbound messages on stdout. Replaces the legacy
+in-process `TerminalChannel` driver.
+
+```sh
+agentm-gateway --bind unix:///tmp/gw.sock &
+agentm-terminal --connect unix:///tmp/gw.sock
+```
+
+Output formats:
+
+* `--format text` (default if stdout is a TTY) — human-friendly, ANSI
+  colors, `agent ▸` prefix, numbered button rendering.
+* `--format json` (default when piped) — one JSON object per line on
+  stdout, suitable for scripts and other agents.
+
+Exit codes (per `cli-design` rule group 3):
+
+| Code | Meaning |
+|------|---------|
+| 0 | Clean shutdown (stdin EOF or `--no-input`) |
+| 1 | Generic unexpected error |
+| 2 | Argument / syntax error |
+| 4 | Auth / handshake rejected by gateway |
+| 6 | User interrupt (SIGINT) |
+| 7 | Cannot connect (socket missing / refused) |

--- a/contrib/channels-clients/terminal/pyproject.toml
+++ b/contrib/channels-clients/terminal/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "agentm-terminal"
+version = "0.1.0"
+description = "Terminal (stdin/stdout) client process for the AgentM channels gateway."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "AgentM contributors" }]
+# Depends on the in-tree `agentm-channels` for the wire protocol +
+# WireClient. The dependency is wired via the workspace `[tool.uv.sources]`
+# entry in the repo root pyproject.toml; nothing extra is needed at
+# install time beyond `uv sync`.
+dependencies = [
+    "agentm-channels",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.6",
+    "mypy>=1.11",
+]
+
+[project.scripts]
+agentm-terminal = "agentm_terminal.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentm_terminal"]
+
+[tool.uv.sources]
+agentm-channels = { workspace = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/contrib/channels-clients/terminal/src/agentm_terminal/__init__.py
+++ b/contrib/channels-clients/terminal/src/agentm_terminal/__init__.py
@@ -1,0 +1,7 @@
+"""Terminal client process for the AgentM channels gateway."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
+++ b/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
@@ -1,0 +1,405 @@
+"""``agentm-terminal`` — stdin/stdout client for the channels gateway.
+
+Connects to an ``agentm-gateway --bind unix://…`` over the v1 wire
+protocol, reads user input from stdin, and renders gateway outbound
+messages on stdout.
+
+CLI design follows ``autoharness:cli-design``:
+
+* All logs go to stderr. Stdout carries business data only.
+* Exit codes are stable and standardized (see ``EXIT_*`` constants).
+* Errors are reported as
+  ``agentm-terminal: error: <type>: <root cause>. <suggested fix>.``
+* Format auto-detection: ``--format`` defaults to ``text`` when stdout
+  is a TTY, ``json`` otherwise. Document explicitly in --help so the
+  contract is discoverable.
+
+Example::
+
+    # Interactive:
+    agentm-terminal --connect unix:///tmp/gw.sock
+
+    # Piped (auto json mode):
+    printf '/help\\n' | agentm-terminal --connect unix:///tmp/gw.sock
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import signal
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.parse import urlparse
+
+from agentm_channels.client import AuthError, WireClient
+from agentm_channels.wire import (
+    KIND_BYE,
+    KIND_DELIVERY_BATCH,
+    KIND_ERROR,
+    KIND_OUTBOUND,
+    KIND_PING,
+    KIND_PONG,
+    Envelope,
+)
+
+from . import __version__
+from .renderer import Renderer
+
+# -- Exit codes (cli-design rule group 3) ------------------------------
+
+EXIT_OK = 0
+EXIT_GENERIC = 1
+EXIT_USAGE = 2
+EXIT_AUTH = 4
+EXIT_SIGINT = 6
+EXIT_CONNECT = 7
+
+PROG = "agentm-terminal"
+
+log = logging.getLogger("agentm_terminal")
+
+
+def _err(kind: str, root: str, fix: str) -> None:
+    """Print a structured error line to stderr.
+
+    Format: ``agentm-terminal: error: <type>: <root cause>. <fix>.``
+    """
+    sys.stderr.write(f"{PROG}: error: {kind}: {root}. {fix}.\n")
+    sys.stderr.flush()
+
+
+# -- argv --------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    epilog = (
+        "Examples:\n"
+        "  Interactive (TTY auto-selects text format):\n"
+        f"    {PROG} --connect unix:///tmp/gw.sock\n"
+        "\n"
+        "  Piped (auto-selects JSON format):\n"
+        f"    printf '/help\\n' | {PROG} --connect unix:///tmp/gw.sock\n"
+    )
+    p = argparse.ArgumentParser(
+        prog=PROG,
+        description=(
+            "Terminal client for the AgentM channels gateway. Connects "
+            "over the v1 wire protocol (Unix socket) and renders outbound "
+            "messages on stdout."
+        ),
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--connect",
+        required=True,
+        metavar="URL",
+        help=(
+            "Gateway socket URL. v1 supports only unix:///abs/path/to/sock; "
+            "other schemes are rejected with exit 2."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default=None,
+        help=(
+            "Output format. Default: 'text' when stdout is a TTY, else 'json'. "
+            "Use 'json' explicitly when a script or another agent is driving."
+        ),
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help=(
+            "Disable ANSI color in text mode. Also honoured via the "
+            "NO_COLOR environment variable (https://no-color.org)."
+        ),
+    )
+    p.add_argument(
+        "--sender-id",
+        default="local",
+        help="Inbound sender id (default: 'local').",
+    )
+    p.add_argument(
+        "--chat-id",
+        default="terminal",
+        help="Chat / session id (default: 'terminal').",
+    )
+    p.add_argument(
+        "--no-input",
+        action="store_true",
+        help=(
+            "Exit immediately after the gateway handshake. Useful for "
+            "liveness probes; not the default — the client normally reads "
+            "stdin."
+        ),
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Raise log level on stderr to INFO (default: WARNING).",
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"{PROG} {__version__}",
+    )
+    return p
+
+
+def _resolve_format(arg: str | None) -> str:
+    if arg is not None:
+        return arg
+    return "text" if sys.stdout.isatty() else "json"
+
+
+def _resolve_color(no_color_flag: bool, fmt: str) -> bool:
+    if fmt == "json":
+        return False
+    if no_color_flag:
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return sys.stdout.isatty()
+
+
+def _parse_connect_url(url: str) -> str:
+    """Return the absolute socket path. Raises ``SystemExit(2)`` on
+    invalid input (scheme, missing path)."""
+    parsed = urlparse(url)
+    if parsed.scheme != "unix":
+        _err(
+            "bad-argument",
+            f"--connect scheme {parsed.scheme!r} is not supported",
+            "use unix:///abs/path/to/sock (only unix:// is available in v1)",
+        )
+        raise SystemExit(EXIT_USAGE)
+    # urlparse on ``unix:///abs/path`` → netloc="", path="/abs/path".
+    socket_path = parsed.path or parsed.netloc
+    if not socket_path or not socket_path.startswith("/"):
+        _err(
+            "bad-argument",
+            f"--connect URL {url!r} has no absolute socket path",
+            "use unix:///abs/path/to/sock",
+        )
+        raise SystemExit(EXIT_USAGE)
+    return socket_path
+
+
+# -- async run loop ----------------------------------------------------
+
+
+async def _arun(args: argparse.Namespace) -> int:
+    fmt = _resolve_format(args.format)
+    color = _resolve_color(args.no_color, fmt)
+    renderer = Renderer(fmt=fmt, color=color)
+
+    socket_path = _parse_connect_url(args.connect)
+
+    # Peer id: stable-ish within a single run. The gateway uses this as
+    # the synthetic channel name registered on the bus; pairing it with
+    # a uuid prevents collisions between concurrent terminal sessions.
+    peer_id = f"terminal-{uuid.uuid4().hex[:8]}"
+
+    stop_event = asyncio.Event()
+    exit_code = EXIT_OK
+
+    async def on_outbound(env: Envelope) -> None:
+        # WireClient already unpacks delivery_batch items and dispatches
+        # each as its own ``KIND_OUTBOUND`` envelope, so we only need to
+        # handle the single-item case here.
+        if env.kind == KIND_OUTBOUND:
+            body = env.body if isinstance(env.body, dict) else {}
+            try:
+                renderer.render_outbound(body)
+            except Exception:  # noqa: BLE001
+                log.exception("renderer failed on envelope id=%s", env.id)
+            return
+        # WireClient's _dispatch handles delivery_batch → outbound itself,
+        # but defensive branches keep the contract explicit.
+        if env.kind == KIND_DELIVERY_BATCH:  # pragma: no cover — handled upstream
+            return
+        if env.kind == KIND_PING:
+            return  # WireClient replies pong itself
+        if env.kind == KIND_PONG:
+            return
+        if env.kind == KIND_BYE:
+            log.info("gateway sent BYE; shutting down")
+            stop_event.set()
+            return
+        if env.kind == KIND_ERROR:
+            nonlocal exit_code
+            body = env.body if isinstance(env.body, dict) else {}
+            code = body.get("code", "unknown")
+            message = body.get("message", "")
+            _err(
+                "gateway-error",
+                f"gateway emitted error code={code!r} message={message!r}",
+                "check the gateway logs (stderr on its side)",
+            )
+            exit_code = EXIT_GENERIC
+            stop_event.set()
+            return
+
+    client = WireClient(
+        socket_path=socket_path,
+        peer_id=peer_id,
+        peer_kind="chat_client",
+        on_outbound=on_outbound,
+    )
+
+    try:
+        await client.connect()
+    except AuthError as exc:
+        _err(
+            "auth-failed",
+            f"gateway rejected handshake (code={exc.code!r})",
+            "verify --bind-allow-uid on the gateway covers this client's uid",
+        )
+        return EXIT_AUTH
+    except (FileNotFoundError, ConnectionRefusedError) as exc:
+        _err(
+            "connect-failed",
+            f"cannot connect to {args.connect!r} ({exc.__class__.__name__})",
+            "is the gateway running with --bind on that path",
+        )
+        return EXIT_CONNECT
+    except OSError as exc:
+        # ENOENT / ECONNREFUSED / EACCES on the socket path.
+        _err(
+            "connect-failed",
+            f"cannot connect to {args.connect!r}: {exc.strerror or exc}",
+            "check the socket path and gateway state",
+        )
+        return EXIT_CONNECT
+
+    # Handshake succeeded. Announce ready.
+    renderer.ready()
+
+    if args.no_input:
+        await client.close()
+        return EXIT_OK
+
+    # Install a SIGINT handler that flips to the EXIT_SIGINT code so a
+    # piped user (Ctrl-C while reading stdin) gets a stable exit code.
+    sigint_seen = False
+
+    def _on_sigint() -> None:
+        nonlocal sigint_seen
+        sigint_seen = True
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _on_sigint if sig == signal.SIGINT else stop_event.set)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover — Windows
+            pass
+
+    reader_task = asyncio.create_task(
+        _stdin_reader(client, args.sender_id, args.chat_id, stop_event),
+        name="terminal-stdin",
+    )
+    stop_task = asyncio.create_task(stop_event.wait(), name="terminal-stop")
+
+    try:
+        done, pending = await asyncio.wait(
+            [reader_task, stop_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for t in pending:
+            t.cancel()
+    finally:
+        renderer.stopped()
+        await client.close()
+
+    if sigint_seen:
+        return EXIT_SIGINT
+    return exit_code
+
+
+async def _stdin_reader(
+    client: WireClient,
+    sender_id: str,
+    chat_id: str,
+    stop_event: asyncio.Event,
+) -> None:
+    """Read stdin line by line, wrap into ``inbound`` envelopes."""
+    loop = asyncio.get_running_loop()
+    while not stop_event.is_set():
+        try:
+            line = await loop.run_in_executor(None, sys.stdin.readline)
+        except Exception:  # pragma: no cover — defensive
+            log.exception("stdin read failed")
+            stop_event.set()
+            return
+        if not line:
+            # EOF (Ctrl-D / piped input exhausted). Clean shutdown.
+            stop_event.set()
+            return
+        content = line.rstrip("\n")
+        if not content:
+            continue
+        button_value: str | None = None
+        if content.startswith("="):
+            # Round-trip escape for approval-button clicks. Matches the
+            # legacy TerminalChannel format byte-for-byte.
+            button_value = content[1:].strip() or None
+            display = f"[button click: {button_value or ''}]"
+        else:
+            display = content
+        body: dict[str, Any] = {
+            "channel": "terminal",
+            "sender_id": sender_id,
+            "chat_id": chat_id,
+            "content": display,
+        }
+        if button_value is not None:
+            body["button_value"] = button_value
+        try:
+            await client.send_inbound(
+                body, env_id=f"in-{int(time.time() * 1_000_000)}"
+            )
+        except Exception:  # noqa: BLE001
+            log.exception("failed to send inbound; closing")
+            stop_event.set()
+            return
+
+
+# -- entrypoint --------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else sys.argv[1:])
+    except SystemExit as exc:
+        # argparse already printed to stderr. Map to canonical usage code.
+        if isinstance(exc.code, int):
+            return EXIT_USAGE if exc.code == 2 else int(exc.code)
+        return EXIT_USAGE
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        return asyncio.run(_arun(args))
+    except KeyboardInterrupt:
+        return EXIT_SIGINT
+    except SystemExit as exc:
+        if isinstance(exc.code, int):
+            return exc.code
+        return EXIT_GENERIC
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/contrib/channels-clients/terminal/src/agentm_terminal/renderer.py
+++ b/contrib/channels-clients/terminal/src/agentm_terminal/renderer.py
@@ -1,0 +1,166 @@
+"""Rendering helpers ported byte-for-byte from the legacy
+``agentm_channels.channels.terminal.TerminalChannel``.
+
+The wire protocol carries outbound payloads as plain dicts (the
+gateway-side ``WireBridge`` serialises an ``OutboundMessage`` into the
+envelope body). The renderer therefore consumes a ``dict`` shape, not
+the in-process ``OutboundMessage`` dataclass — that's the only
+difference from the legacy code. All output formats are identical:
+
+* text mode: ``agent ▸`` prefix, ANSI-coloured ``[N] label   value=…``
+  button block, ``(type =<value> to round-trip a button click)`` hint,
+  ``[terminal channel ready …]`` greeting, ``… (turn complete)`` after
+  each turn.
+* json mode: ``{"kind":"ready"}`` after handshake, then one
+  ``{"kind":"message",…}`` per outbound (carrying ``content``,
+  optional ``buttons``, optional ``metadata``),
+  ``{"kind":"turn_complete"}`` at end-of-turn, ``{"kind":"stopped"}``
+  on shutdown.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+_RESET = "\033[0m"
+_DIM = "\033[2m"
+_BLUE = "\033[94m"
+_YELLOW = "\033[93m"
+_GREEN = "\033[92m"
+
+
+# Outbound "kind" values used by the gateway-side bus. Matches
+# ``agentm_channels.bus.OutboundKind`` without importing it (the client
+# process must not depend on bus internals).
+_KIND_TURN_COMPLETE = "turn_complete"
+
+
+class Renderer:
+    """Stateless-ish renderer wrapping stdout writes.
+
+    ``color`` is honoured in text mode only; JSON mode is always
+    plain ASCII / UTF-8 so a downstream parser sees clean lines.
+    """
+
+    def __init__(self, *, fmt: str, color: bool) -> None:
+        if fmt not in ("text", "json"):
+            raise ValueError(
+                f"renderer format must be 'text' or 'json' (got {fmt!r})"
+            )
+        self._format = fmt
+        # JSON mode forces ANSI off (the legacy channel did the same).
+        self._color = False if fmt == "json" else color
+
+    # --- lifecycle markers ---------------------------------------------
+
+    def ready(self) -> None:
+        if self._format == "json":
+            self._emit({"kind": "ready"})
+        else:
+            self._print(
+                self._style(
+                    "[terminal channel ready — type /help for commands, "
+                    "Ctrl-D to exit]",
+                    _DIM,
+                )
+            )
+
+    def stopped(self) -> None:
+        if self._format == "json":
+            self._emit({"kind": "stopped"})
+
+    # --- per-outbound --------------------------------------------------
+
+    def render_outbound(self, body: dict[str, Any]) -> None:
+        """Render one outbound envelope body.
+
+        ``body`` is the dict shape that the gateway puts in
+        ``Envelope.body`` for ``kind="outbound"``. Fields read:
+
+        * ``kind`` — optional, defaults to ``"message"``. ``"turn_complete"``
+          renders the per-turn marker only.
+        * ``content`` — assistant text (may be empty).
+        * ``buttons`` — optional list of ``{"label","value","style"}``.
+        * ``metadata`` — optional dict, forwarded as-is in JSON mode.
+        """
+        kind = body.get("kind") or "message"
+        if self._format == "json":
+            self._render_json(kind, body)
+        else:
+            self._render_text(kind, body)
+
+    # --- text ----------------------------------------------------------
+
+    def _render_text(self, kind: str, body: dict[str, Any]) -> None:
+        if kind == _KIND_TURN_COMPLETE:
+            self._print(self._style("… (turn complete)", _DIM))
+            return
+        content = str(body.get("content") or "")
+        text = content.rstrip()
+        if text:
+            prefix = self._style("agent ▸ ", _BLUE)
+            self._print(prefix + text)
+        buttons = body.get("buttons") or []
+        if buttons:
+            for idx, btn in enumerate(buttons, start=1):
+                style = str(btn.get("style") or "primary")
+                label = str(btn.get("label") or "")
+                value = str(btn.get("value") or "")
+                color = _YELLOW if style == "danger" else _GREEN
+                self._print(
+                    self._style(f"  [{idx}] {label}", color)
+                    + self._style(f"   value={value}", _DIM)
+                )
+            self._print(
+                self._style(
+                    "  (type =<value> to round-trip a button click)", _DIM
+                )
+            )
+
+    # --- json ----------------------------------------------------------
+
+    def _render_json(self, kind: str, body: dict[str, Any]) -> None:
+        if kind == _KIND_TURN_COMPLETE:
+            self._emit({"kind": "turn_complete"})
+            return
+        payload: dict[str, Any] = {
+            "kind": "message",
+            "content": str(body.get("content") or ""),
+        }
+        buttons = body.get("buttons")
+        if buttons:
+            payload["buttons"] = [
+                {
+                    "label": str(b.get("label") or ""),
+                    "value": str(b.get("value") or ""),
+                    "style": str(b.get("style") or "primary"),
+                }
+                for b in buttons
+            ]
+        metadata = body.get("metadata")
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        self._emit(payload)
+
+    # --- low-level -----------------------------------------------------
+
+    def _style(self, text: str, code: str) -> str:
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    @staticmethod
+    def _print(text: str) -> None:
+        print(text, flush=True)
+
+    @staticmethod
+    def _emit(obj: dict[str, Any]) -> None:
+        """One JSON object per line on stdout. ``ensure_ascii=False``
+        keeps non-ASCII (e.g. Chinese) human-readable."""
+        sys.stdout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+        sys.stdout.flush()
+
+
+__all__ = ["Renderer"]

--- a/contrib/channels-clients/terminal/tests/test_cli_smoke.py
+++ b/contrib/channels-clients/terminal/tests/test_cli_smoke.py
@@ -1,0 +1,73 @@
+"""argparse-level smoke tests — no subprocess, no real socket."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from agentm_terminal import cli as terminal_cli
+
+
+def test_help_exits_zero(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        terminal_cli._build_parser().parse_args(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "agentm-terminal" in out
+    assert "--connect" in out
+    # Examples section is mandated by the brief — keeps the contract
+    # discoverable from --help alone.
+    assert "Examples" in out
+
+
+def test_version_prints_and_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        terminal_cli._build_parser().parse_args(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "0.1.0" in out
+
+
+def test_bad_connect_scheme_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = terminal_cli.main(["--connect", "tcp://127.0.0.1:7000"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "agentm-terminal: error" in err
+    assert "unix://" in err
+
+
+def test_missing_connect_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = terminal_cli.main([])
+    assert rc == 2
+
+
+def test_resolve_format_defaults_text_for_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdout", _FakeStream(isatty=True))
+    assert terminal_cli._resolve_format(None) == "text"
+
+
+def test_resolve_format_defaults_json_for_pipe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdout", _FakeStream(isatty=False))
+    assert terminal_cli._resolve_format(None) == "json"
+
+
+class _FakeStream(io.StringIO):
+    def __init__(self, *, isatty: bool) -> None:
+        super().__init__()
+        self._isatty = isatty
+
+    def isatty(self) -> bool:  # type: ignore[override]
+        return self._isatty

--- a/contrib/channels-clients/terminal/tests/test_subprocess_e2e.py
+++ b/contrib/channels-clients/terminal/tests/test_subprocess_e2e.py
@@ -1,0 +1,240 @@
+"""Subprocess E2E for ``agentm-terminal``.
+
+We don't spin up the full ``agentm-gateway`` CLI here — it pulls the
+LLM session factory, which is heavy and not what we're testing.
+Instead, we run a minimal ``WireServer`` in-process inside the test
+loop (the same pattern Phase 1 used in ``tests/server/test_echo.py``)
+and connect the terminal CLI as a real subprocess via its installed
+console script.
+
+Each test uses ``tmp_path`` for the Unix socket so we never collide
+in /tmp.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from agentm_channels.auth import UnixPeerCredAuthenticator
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+
+# ----- helpers --------------------------------------------------------
+
+
+async def _start_echo_server(
+    socket_path: str, db_path: str, *, allow_uids: set[int] | None = None
+) -> tuple[WireServer, SqliteOutbox, SqliteInbox]:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+
+    async def on_inbound(session: PeerSession, env: Envelope) -> None:
+        # Echo the inbound back as a plain outbound message. The
+        # renderer expects ``content`` / optional ``buttons`` /
+        # optional ``metadata``; we mirror the inbound body's
+        # ``content`` so the test can assert round-trip.
+        body = env.body if isinstance(env.body, dict) else {}
+        echo = Envelope(
+            v=WIRE_VERSION,
+            id=f"echo-{env.id}",
+            kind="outbound",
+            ts=time.time(),
+            body={"content": str(body.get("content") or ""), "kind": "message"},
+        )
+        outbox.enqueue(session.peer_id, echo)
+
+    authenticator = (
+        UnixPeerCredAuthenticator(allowed_uids=allow_uids)
+        if allow_uids is not None
+        else None
+    )
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=on_inbound,
+        authenticator=authenticator,
+    )
+    await server.start()
+    return server, outbox, inbox
+
+
+def _spawn_terminal(
+    *,
+    socket_path: str,
+    extra: list[str] | None = None,
+    stdin: int | None = subprocess.PIPE,
+) -> subprocess.Popen[str]:
+    # Invoke through ``python -m agentm_terminal.cli`` to avoid relying
+    # on the console-script entry being on PATH inside the workspace.
+    cmd = [
+        sys.executable,
+        "-m",
+        "agentm_terminal.cli",
+        "--connect",
+        f"unix://{socket_path}",
+        "--format",
+        "json",
+        *(extra or []),
+    ]
+    return subprocess.Popen(
+        cmd,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _wait_proc(proc: subprocess.Popen[str], timeout: float) -> int:
+    try:
+        return proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2.0)
+        raise
+
+
+def _read_until_kind(
+    proc: subprocess.Popen[str], kind: str, timeout: float
+) -> dict[str, Any]:
+    """Read stdout JSON lines until we see one with ``kind == kind``."""
+    assert proc.stdout is not None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            time.sleep(0.05)
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("kind") == kind:
+            return obj
+    raise AssertionError(f"timed out waiting for kind={kind!r}")
+
+
+# ----- tests ----------------------------------------------------------
+
+
+async def test_echo_round_trip(tmp_path: Path) -> None:
+    sock = str(tmp_path / "gw.sock")
+    db = str(tmp_path / "outbox.sqlite")
+    server, outbox, inbox = await _start_echo_server(
+        sock, db, allow_uids={os.geteuid()}
+    )
+    proc = _spawn_terminal(socket_path=sock)
+    try:
+        # Wait for the ``ready`` line (announced after WELCOME).
+        ready = await asyncio.to_thread(_read_until_kind, proc, "ready", 5.0)
+        assert ready == {"kind": "ready"}
+        # Send a line on stdin; expect an echo back as a ``message``.
+        assert proc.stdin is not None
+        proc.stdin.write("hello\n")
+        proc.stdin.flush()
+        msg = await asyncio.to_thread(_read_until_kind, proc, "message", 5.0)
+        assert msg["content"] == "hello"
+    finally:
+        if proc.poll() is None:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+            try:
+                proc.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2.0)
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+async def test_clean_eof_shutdown(tmp_path: Path) -> None:
+    sock = str(tmp_path / "gw.sock")
+    db = str(tmp_path / "outbox.sqlite")
+    server, outbox, inbox = await _start_echo_server(
+        sock, db, allow_uids={os.geteuid()}
+    )
+    proc = _spawn_terminal(socket_path=sock)
+    try:
+        await asyncio.to_thread(_read_until_kind, proc, "ready", 5.0)
+        # Close stdin → client should EOF its read loop and exit 0.
+        assert proc.stdin is not None
+        proc.stdin.close()
+        rc = await asyncio.to_thread(_wait_proc, proc, 5.0)
+        assert rc == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2.0)
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+async def test_handshake_rejection(tmp_path: Path) -> None:
+    sock = str(tmp_path / "gw.sock")
+    db = str(tmp_path / "outbox.sqlite")
+    # Allow only an impossible uid → peer-cred auth rejects every
+    # local connection with ``auth_failed``.
+    server, outbox, inbox = await _start_echo_server(
+        sock, db, allow_uids={99999}
+    )
+    proc = _spawn_terminal(socket_path=sock)
+    try:
+        rc = await asyncio.to_thread(_wait_proc, proc, 5.0)
+        assert rc == 4, f"expected EXIT_AUTH=4, got {rc}; stderr={proc.stderr.read() if proc.stderr else ''}"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2.0)
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+def test_bad_connect_url_subprocess() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "agentm_terminal.cli", "--connect", "http://x"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 2
+    assert "agentm-terminal: error" in proc.stderr
+
+
+def test_missing_socket_subprocess(tmp_path: Path) -> None:
+    missing = tmp_path / "definitely-not-there.sock"
+    assert not missing.exists()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agentm_terminal.cli",
+            "--connect",
+            f"unix://{missing}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 7, proc.stderr
+    assert "connect-failed" in proc.stderr

--- a/contrib/channels/README.md
+++ b/contrib/channels/README.md
@@ -40,20 +40,26 @@ src/agentm_channels/
 ## Local validation (terminal mode)
 
 The fastest way to try this end-to-end without configuring a chat
-platform:
+platform — gateway + terminal client as two processes:
 
 ```bash
-uv run agentm-gateway --terminal --cwd ./workspace --scenario feishu_chat
+# Terminal A:
+uv run agentm-gateway --bind unix:///tmp/gw.sock \
+    --cwd ./workspace --scenario feishu_chat
+
+# Terminal B:
+uv run agentm-terminal --connect unix:///tmp/gw.sock
 ```
 
 You get a stdin/stdout REPL backed by the same gateway + commands +
 approvals as production. Useful for testing `/help`, `/skill:foo`,
 `/new`, custom markdown commands, and approval flows before pointing
-Feishu at the daemon. `Ctrl-D` ends the session.
+Feishu at the daemon. `Ctrl-D` on the terminal client ends the
+session.
 
-Approval-button round-trips in terminal mode: when the agent posts an
-approval card you'll see numbered `[1] Approve` / `[2] Deny` options
-and the literal `value=…` next to each. Type `=<value>` (e.g.
+Approval-button round-trips in the terminal client: when the agent
+posts an approval card you'll see numbered `[1] Approve` / `[2] Deny`
+options and the literal `value=…` next to each. Type `=<value>` (e.g.
 `=approval-deadbeef:approve`) to click. Less ergonomic than a Feishu
 button, but exercises the exact same code path.
 

--- a/contrib/channels/src/agentm_channels/channels/terminal.py
+++ b/contrib/channels/src/agentm_channels/channels/terminal.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import warnings
 from typing import Any, Literal
 
 from ..base import BaseChannel
@@ -105,6 +106,13 @@ class TerminalChannel(BaseChannel):
     async def start(self) -> None:
         if self._running:
             return
+        warnings.warn(
+            "TerminalChannel (in-process) is deprecated and will be removed in "
+            "a future release. Run the gateway with --bind unix:///path and "
+            "connect with `agentm-terminal --connect unix:///path` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._running = True
         self._reader_task = asyncio.create_task(
             self._read_loop(), name="terminal-read"

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -2,13 +2,17 @@
 
 Reads a YAML config (or env vars), builds a :class:`MessageBus`,
 spins up a :class:`ChannelManager` and a :class:`Gateway`, and runs
-until the process is signalled to stop (SIGINT / SIGTERM) — *or*, in
-``--terminal`` mode, until stdin closes (Ctrl-D / piped input
-exhausted). The terminal-EOF path is what lets shell pipelines drive
-the gateway without timeouts:
+until the process is signalled to stop (SIGINT / SIGTERM).
 
-    printf '/help\\n/atom:list\\n' | \\
-      agentm-gateway --terminal --terminal-format json --config gw.yaml
+The legacy in-process ``--terminal`` driver has been removed; run the
+gateway with ``--bind unix:///path`` and connect a separate
+``agentm-terminal --connect unix:///path`` process instead.
+
+    # Terminal A:
+    agentm-gateway --bind unix:///tmp/gw.sock --config gw.yaml
+
+    # Terminal B:
+    agentm-terminal --connect unix:///tmp/gw.sock
 
 Minimal config (``gateway.yaml``)::
 
@@ -41,16 +45,6 @@ Exit codes (see also ``cli-design`` rule group 3):
 * ``0`` — clean shutdown
 * ``2`` — argument / config error (missing channels, bad YAML, empty allow_from)
 * ``130`` — SIGINT (Ctrl-C)
-
-JSON output contract (``--terminal --terminal-format json``):
-
-* stdout is one JSON object per line; stderr carries logs only.
-* ``{"kind":"ready"}`` — channel started, safe to start sending.
-* ``{"kind":"message","content":"…","buttons":[…],"metadata":{…}}``
-* ``{"kind":"turn_complete"}`` — emitted at the end of a real agent
-  turn. Control commands (``/help`` / ``/status`` / …) do **not** emit
-  ``turn_complete``; they emit one ``message`` object and that's it.
-* ``{"kind":"stopped"}`` — final line; no further output is coming.
 """
 
 from __future__ import annotations
@@ -319,11 +313,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
             "one command router, one approval bridge."
         ),
         epilog=(
-            "Shell-driving recipe (no driver/wrapper needed):\n"
-            "  printf '/help\\n/atom:list\\n' | \\\n"
-            "    agentm-gateway --terminal --terminal-format json \\\n"
-            "                   --config gw.yaml 2>/tmp/gw.err\n"
-            "Stdout = one JSON object per line; stderr = logs."
+            "Run as a wire-protocol daemon and connect clients separately:\n"
+            "  agentm-gateway --bind unix:///tmp/gw.sock --config gw.yaml\n"
+            "  agentm-terminal --connect unix:///tmp/gw.sock\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -351,35 +343,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--log-level", default=os.environ.get("AGENTM_GATEWAY_LOG_LEVEL", "INFO")
     )
     p.add_argument(
-        "--terminal",
-        action="store_true",
-        help=(
-            "Run the gateway with only the terminal channel (stdin/stdout). "
-            "Useful for local validation of slash commands and skill "
-            "activation without configuring a chat platform."
-        ),
-    )
-    p.add_argument(
-        "--terminal-format",
-        choices=("text", "json"),
-        default=os.environ.get("AGENTM_GATEWAY_TERMINAL_FORMAT", "text"),
-        help=(
-            "Output format when --terminal is set. 'text' is human-"
-            "friendly (ANSI colors, agent prefix). 'json' emits one "
-            "JSON object per line — use this when a script or another "
-            "agent is driving the gateway. See module docstring for the "
-            "JSON contract."
-        ),
-    )
-    p.add_argument(
         "--bind",
         default=None,
         help=(
             "Run the wire-protocol server on the given URL (v1 supports "
             "only ``unix:///abs/path/to/sock``; TCP is deferred). Coexists "
-            "with --terminal and the v0 channels: section. Authentication "
-            "is Unix peer-cred; by default only the current process's uid "
-            "may connect — override with --bind-allow-uid or "
+            "with the v0 channels: section. Authentication is Unix "
+            "peer-cred; by default only the current process's uid may "
+            "connect — override with --bind-allow-uid or "
             "--bind-allow-any-uid."
         ),
     )
@@ -457,30 +428,17 @@ async def _arun(args: argparse.Namespace) -> int:
 
     bind_spec = _resolve_bind(args, cfg)
 
-    if args.terminal:
-        # Terminal mode overrides any YAML/env channels — explicit flag
-        # is unambiguous about intent (local validation, single user).
-        channels_cfg: dict[str, Any] = {
-            "terminal": {
-                "enabled": True,
-                "allow_from": ["*"],
-                "format": args.terminal_format,
-            }
-        }
-        # JSON mode is consumed by parsers; even WARNING-level logging
-        # on stderr is the right home (operator can still see it via
-        # ``2>``). Suppress INFO chatter unless the operator opted in.
-        if args.log_level.upper() == "INFO":
-            args.log_level = "WARNING"
-    else:
-        channels_cfg = cfg.get("channels") or _channels_from_env(dict(os.environ))
-        if not channels_cfg and bind_spec is None:
-            raise SystemExit(
-                "no channels configured. Pass --config <yaml> with a "
-                "`channels:` section, set LARK_APP_ID / LARK_APP_SECRET for "
-                "the one-liner Feishu mode, run with --terminal for local "
-                "validation, or run with --bind unix:///… to accept wire peers."
-            )
+    channels_cfg: dict[str, Any] = (
+        cfg.get("channels") or _channels_from_env(dict(os.environ))
+    )
+    if not channels_cfg and bind_spec is None:
+        raise SystemExit(
+            "no channels configured and no --bind given. Either pass "
+            "--bind unix:///abs/path/to/sock (and connect a client like "
+            "`agentm-terminal --connect unix://…`), or pass --config "
+            "<yaml> with a `channels:` section, or set LARK_APP_ID / "
+            "LARK_APP_SECRET for the one-liner Feishu mode."
+        )
 
     provider = args.provider or cfg.get("provider") or _default_provider()
     model = (
@@ -595,40 +553,6 @@ async def _arun(args: argparse.Namespace) -> int:
     logger.info(
         "gateway running with channels: %s", sorted(manager.channels) or "(none)"
     )
-
-    # In ``--terminal`` mode, stdin EOF must teardown the daemon — that
-    # is what makes ``printf '…' | agentm-gateway --terminal`` exit
-    # cleanly without an external ``timeout``. The terminal channel
-    # already sets its ``_stopped`` event on EOF; the manager's
-    # per-channel start tasks complete when it does. So in terminal
-    # mode we race ``stop_event`` (SIGINT/SIGTERM) against "any
-    # channel task finished naturally". Other modes only honour
-    # signals — Feishu's channel.start() blocks forever and an EOF
-    # condition isn't meaningful.
-    if args.terminal:
-        channel_tasks = list(manager._tasks)  # type: ignore[attr-defined]
-        signal_wait = asyncio.create_task(stop_event.wait(), name="gw-signal")
-        try:
-            done, _pending = await asyncio.wait(
-                [signal_wait, *channel_tasks],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if signal_wait in done:
-                logger.info("gateway shutting down (signal)")
-            else:
-                logger.info("gateway shutting down (stdin EOF)")
-        finally:
-            if not signal_wait.done():
-                signal_wait.cancel()
-            if wire_server is not None:
-                await wire_server.stop()
-            if wire_outbox is not None:
-                wire_outbox.close()
-            if wire_inbox is not None:
-                wire_inbox.close()
-            await gateway.stop()
-            await manager.stop()
-        return EXIT_OK
 
     try:
         await stop_event.wait()

--- a/contrib/channels/tests/cli/test_bind_flag_parsing.py
+++ b/contrib/channels/tests/cli/test_bind_flag_parsing.py
@@ -161,7 +161,6 @@ def test_check_rejects_tcp_bind() -> None:
             sys.executable,
             "-m",
             "agentm_channels.cli",
-            "--terminal",
             "--bind",
             "tcp://127.0.0.1:7000",
             "--check",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ members = [
     "contrib/extensions/llmharness",
     "contrib/scenarios/rca",
     "contrib/channels",
+    "contrib/channels-clients/terminal",
 ]
 
 [tool.pytest.ini_options]
@@ -60,7 +61,7 @@ markers = [
 # Nested workspace projects own their own tests/ trees and pyproject. The
 # top-level pytest must not recurse into them — both define a ``tests``
 # package and the import paths collide.
-addopts = "-m 'not ui' --ignore=contrib/extensions/llmharness --ignore=contrib/scenarios/rca --ignore=contrib/channels"
+addopts = "-m 'not ui' --ignore=contrib/extensions/llmharness --ignore=contrib/scenarios/rca --ignore=contrib/channels --ignore=contrib/channels-clients"
 
 [tool.mypy]
 python_version = "3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "agentm",
     "agentm-channels",
     "agentm-rca",
+    "agentm-terminal",
     "llmharness",
 ]
 
@@ -131,6 +132,32 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
 ]
+
+[[package]]
+name = "agentm-terminal"
+version = "0.1.0"
+source = { editable = "contrib/channels-clients/terminal" }
+dependencies = [
+    { name = "agentm-channels" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentm-channels", editable = "contrib/channels" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "annotated-doc"


### PR DESCRIPTION
## Summary

Phase 2 of the channels gateway/client process split (continues from #140). The terminal channel now lives in its own package and process; the gateway no longer hosts it.

Users invoke two native CLIs — no driver / wrapper / subprocess-spawn convenience flag:

```bash
# terminal 1
agentm-gateway --bind unix:///tmp/gw.sock

# terminal 2
agentm-terminal --connect unix:///tmp/gw.sock
```

## Commits

| sha | scope |
|-----|-------|
| `2328a74` | new package `contrib/channels-clients/terminal/` + 11 tests |
| `16ddb1c` | drop `--terminal` / `--terminal-format` from `agentm-gateway`; deprecate in-process `TerminalChannel` |

## CLI contract (`agentm-terminal`)

Follows `autoharness:cli-design` rule groups 2–4:

- `--connect URL` required; only `unix://` scheme in v1 (others → exit 2).
- `--format {text,json}` auto-detects from `sys.stdout.isatty()`; documented in `--help`.
- `--no-color` flag + `NO_COLOR` env var honored.
- `--sender-id`, `--chat-id`, `--no-input`, `--verbose`, `--version`.
- Logs to **stderr only**; stdout carries rendered messages.
- Structured error format: `agentm-terminal: error: <type>: <root cause>. <fix>.`
- Standardized exit codes: `0` ok, `1` generic, `2` usage, `4` auth/handshake, `6` SIGINT, `7` connect refused.
- Rendering parity (text + json) with the legacy `TerminalChannel` is preserved byte-for-byte.

## Acceptance — Phase 2 (per `plans/2026-05-11-gateway-client-server.md`)

- [x] New package `contrib/channels-clients/terminal/` with own pyproject; workspace member.
- [x] `agentm-terminal` connects via `WireClient`, handshakes, renders outbound, ack semantics handled by `WireClient`.
- [x] Subprocess-driven integration test mirroring `test_gateway_e2e.py` over the wire (echo round-trip, EOF shutdown, handshake rejection, bad URL, missing socket).
- [x] Legacy `TerminalChannel` emits `DeprecationWarning` on start (functionality intact; Phase 4 removes).
- [x] `agentm-gateway` no longer offers `--terminal` driver — drops the flag entirely rather than keeping a deprecated alias (cleaner, simpler-and-pluggable per project preference).

## Test results

```
contrib/channels/tests/                            126 passed, 2 deprecation warnings
contrib/channels-clients/terminal/tests/            11 passed
ruff check                                         clean
mypy                                               clean (4 source files)
```

Tests must be run from each subproject directory (same pattern Phase 1 used; root `pyproject.toml` ignores both subtrees).

## Design notes

- **No new wire kinds.** Everything reuses `KIND_HELLO/WELCOME/INBOUND/OUTBOUND/DELIVERY_BATCH/PING/PONG/ERROR/BYE` from Phase 1.
- **Peer id = `terminal-<uuid8>`** so concurrent terminal clients don't collide on the gateway's peer registry.
- **SIGINT** sets a flag so we return `EXIT_SIGINT=6` deterministically rather than relying on `KeyboardInterrupt` under `asyncio.run`.
- **Inbound body includes `channel: "terminal"`** so `WireBridge` routes correctly (matches the legacy channel name).

## Deferred (non-blocking, recorded for later phases)

1. `WireBridge` does not yet propagate `button_value` from inbound or `buttons`/`metadata` on outbound. The renderer handles them defensively when present, but full button-click round-trip E2E requires a bridge enhancement. Pre-existing Phase 1 gap; out of scope here.
2. Combined `pytest contrib/channels/tests/ contrib/channels-clients/terminal/tests/` from the repo root fails due to duplicate `tests` package names + per-subproject `asyncio_mode` config. Each subproject runs cleanly on its own (same as Phase 1).

## Out of scope (forever / later phases)

- Phases 3 (Feishu extraction), 4 (deprecate v0 channels), 5 (agent-worker peer kind), 6 (A2A) per the plan.
- TCP / TLS / mTLS transports (operator concern; v2+).
- `agentm-gateway --terminal` subprocess driver — explicitly dropped per user direction ("不要写 driver，直接用原生命令行").

🤖 Generated with [Claude Code](https://claude.com/claude-code)