### PR TITLE
feat(channels): Phase 3 — agentm-feishu as a separate process

### DIFF
--- a/contrib/channels-clients/feishu/README.md
+++ b/contrib/channels-clients/feishu/README.md
@@ -1,0 +1,31 @@
+# agentm-feishu
+
+Feishu / Lark client process for the AgentM channels gateway.
+
+Connects to an `agentm-gateway --bind unix://…` over the v1 wire
+protocol and bridges inbound Feishu messages / card-button clicks into
+the gateway, then renders gateway outbounds as Feishu interactive
+cards. Replaces the legacy in-process `FeishuChannel` driver.
+
+```sh
+agentm-gateway --bind unix:///tmp/gw.sock &
+agentm-feishu \
+  --connect unix:///tmp/gw.sock \
+  --app-id cli_xxxx \
+  --app-secret /run/secrets/feishu_app_secret
+```
+
+The app secret is read from a file (or `LARK_APP_SECRET` env). It is
+never accepted as a CLI argument — secrets must not appear in argv
+(per `autoharness:cli-design` rule group 5).
+
+Exit codes (per `cli-design` rule group 3):
+
+| Code | Meaning |
+|------|---------|
+| 0 | Clean shutdown |
+| 1 | Generic unexpected error |
+| 2 | Argument / usage error |
+| 4 | Auth rejected by gateway or Feishu credentials invalid |
+| 6 | User interrupt (SIGINT) |
+| 7 | Cannot connect to socket |

--- a/contrib/channels-clients/feishu/pyproject.toml
+++ b/contrib/channels-clients/feishu/pyproject.toml
@@ -1,0 +1,41 @@
+[project]
+name = "agentm-feishu"
+version = "0.1.0"
+description = "Feishu / Lark client process for the AgentM channels gateway."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "AgentM contributors" }]
+# Depends on the in-tree `agentm-channels` for the wire protocol +
+# WireClient. The lark_oapi runtime dep moved here from `agentm-channels`
+# as part of the Phase 3 gateway/client split — only the Feishu client
+# process needs the vendor SDK now.
+dependencies = [
+    "agentm-channels",
+    "lark-oapi>=1.6",
+    "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.6",
+    "mypy>=1.11",
+]
+
+[project.scripts]
+agentm-feishu = "agentm_feishu.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentm_feishu"]
+
+[tool.uv.sources]
+agentm-channels = { workspace = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/contrib/channels-clients/feishu/src/agentm_feishu/__init__.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/__init__.py
@@ -1,0 +1,7 @@
+"""agentm-feishu — Feishu / Lark client process for the channels gateway."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/contrib/channels-clients/feishu/src/agentm_feishu/adapter.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/adapter.py
@@ -1,0 +1,393 @@
+"""Feishu / Lark adapter for the ``agentm-feishu`` client process.
+
+Lifted from the legacy in-process ``FeishuChannel`` driver in
+``agentm_channels.channels.feishu``. Interface differences:
+
+* No ``BaseChannel`` parent. The adapter is a plain class that owns a
+  :class:`WireClient` and pushes inbound traffic out over the wire
+  instead of an in-process :class:`MessageBus`.
+* Outbound delivery is no longer dispatched by a manager; the CLI's
+  wire read loop calls :meth:`handle_outbound` for every
+  ``KIND_OUTBOUND`` envelope from the gateway.
+
+Card schema 2.0, approval buttons, the ACK-emoji reaction handling,
+``cardAction`` → ``button_value`` round-trip, and ``thread_id`` →
+``session_key`` mapping are preserved byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentm_channels.client import WireClient
+from agentm_channels.wire import KIND_INBOUND, WIRE_VERSION, Envelope
+
+log = logging.getLogger("agentm_feishu.adapter")
+
+
+# Mirrors ``agentm_channels.bus.ButtonStyle`` without depending on the
+# enum module — the adapter sees raw outbound bodies off the wire.
+_BUTTON_STYLE_MAP: dict[str, str] = {
+    "primary": "primary",
+    "danger": "danger",
+    "default": "default",
+}
+
+
+@dataclass(slots=True)
+class FeishuConfig:
+    """Adapter config — derived from CLI flags / env in ``cli.py``."""
+
+    app_id: str
+    app_secret: str
+    allow_from: list[str] = field(default_factory=lambda: ["*"])
+    chat_id_prefix: str = "feishu"
+    ack_emoji: str = "OK"
+    channel_name: str = "feishu"
+    """Channel name announced on inbound envelopes. The gateway uses it
+    as the synthetic-channel key registered through ``inject_channel``.
+    """
+
+
+class FeishuAdapter:
+    """Bridges a ``lark_oapi`` Feishu channel to a :class:`WireClient`."""
+
+    def __init__(self, client: WireClient, config: FeishuConfig) -> None:
+        self._client = client
+        self._config = config
+        self._channel: Any = None
+        self._connect_task: asyncio.Task[Any] | None = None
+        # Pending ACK reactions keyed by chat_id — same lifetime contract
+        # as the legacy implementation. Cleared on turn_complete.
+        self._pending_acks: dict[str, list[asyncio.Task[Any]]] = {}
+        self._running = False
+
+    # -- lifecycle -----------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to Feishu and stay alive until :meth:`stop`."""
+        if self._running:
+            return
+        try:
+            from lark_oapi.channel import FeishuChannel as _Lark
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "lark_oapi is not installed. Reinstall agentm-feishu with "
+                "its declared dependencies (`uv sync`)."
+            ) from exc
+
+        cfg = self._config
+        if not cfg.app_id or not cfg.app_secret:
+            raise RuntimeError(
+                "feishu adapter: app_id / app_secret missing"
+            )
+
+        channel = _Lark(app_id=cfg.app_id, app_secret=cfg.app_secret)
+        self._channel = channel
+        # ``FeishuChannel.on`` in lark-oapi 1.6.x requires the
+        # ``(name, handler)`` call form — the decorator form raises.
+        channel.on("message", self._on_message)
+        channel.on("cardAction", self._on_card_action)
+        self._connect_task = asyncio.create_task(
+            channel.connect(), name="feishu-channel"
+        )
+        try:
+            await channel.connect_until_ready(timeout=20.0)
+        except Exception:
+            log.exception("feishu connect_until_ready failed")
+            raise
+        self._running = True
+        # Stay alive until stop() is invoked from outside.
+        await self._connect_task
+
+    async def stop(self) -> None:
+        if not self._running and self._channel is None:
+            return
+        self._running = False
+        if self._channel is not None:
+            try:
+                await self._channel.disconnect()
+            except Exception:
+                log.exception("FeishuAdapter.disconnect raised")
+            try:
+                await self._channel.stop_background()
+            except Exception:
+                log.exception("FeishuAdapter.stop_background raised")
+        if self._connect_task is not None and not self._connect_task.done():
+            self._connect_task.cancel()
+            try:
+                await self._connect_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    # -- inbound (Feishu → gateway) -----------------------------------
+
+    async def _on_message(self, msg: Any) -> None:
+        sender = getattr(msg, "sender_id", "") or ""
+        message_id = getattr(msg, "message_id", None)
+        chat_id = getattr(msg, "chat_id", "") or ""
+        content = getattr(msg, "content_text", "") or ""
+        log.info(
+            "[feishu] rx chat=%s sender=%s msg_id=%s text=%r",
+            chat_id,
+            sender,
+            message_id,
+            content[:120],
+        )
+        if self._is_self(sender):
+            return
+        if not self._is_allowed(sender):
+            return
+        # Quick visual ACK so the user knows the bot got it before the
+        # LLM has had a chance to reply. Best-effort, fire-and-forget —
+        # we MUST NOT await it here: if the SDK's reaction RPC hangs or
+        # holds a lock, awaiting blocks the inbound handler and the
+        # message never reaches the agent.
+        if message_id and self._config.ack_emoji:
+            task = asyncio.create_task(
+                self._safe_reaction(message_id, self._config.ack_emoji),
+                name="feishu-ack",
+            )
+            self._pending_acks.setdefault(chat_id, []).append(task)
+        await self._forward_inbound(
+            sender_id=str(sender),
+            chat_id=str(chat_id),
+            content=content,
+            button_value=None,
+        )
+
+    async def _on_card_action(self, event: Any) -> None:
+        value = getattr(event.action, "value", None) or {}
+        button_value: str | None = None
+        if isinstance(value, dict):
+            raw = value.get("button_value")
+            if raw is not None:
+                button_value = str(raw)
+        if not button_value:
+            return
+        operator = getattr(event, "operator", None)
+        sender = (
+            getattr(operator, "open_id", None)
+            or getattr(operator, "user_id", None)
+            or ""
+        )
+        chat_id = getattr(event, "chat_id", "") or ""
+        if not self._is_allowed(str(sender)):
+            return
+        await self._forward_inbound(
+            sender_id=str(sender),
+            chat_id=str(chat_id),
+            # The gateway routes on ``button_value``; ``content`` is
+            # informational only (shows up in observability traces).
+            content=f"[card click: {button_value}]",
+            button_value=button_value,
+        )
+
+    async def _forward_inbound(
+        self,
+        *,
+        sender_id: str,
+        chat_id: str,
+        content: str,
+        button_value: str | None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "channel": self._config.channel_name,
+            "sender_id": sender_id,
+            "chat_id": chat_id,
+            "content": content,
+        }
+        if button_value is not None:
+            body["button_value"] = button_value
+        env = Envelope(
+            v=WIRE_VERSION,
+            id=f"in-feishu-{int(time.time() * 1_000_000)}",
+            kind=KIND_INBOUND,
+            ts=time.time(),
+            body=body,
+        )
+        try:
+            await self._client.send(env)
+        except Exception:  # noqa: BLE001
+            log.exception("forward_inbound failed; dropping envelope")
+
+    # -- outbound (gateway → Feishu) ----------------------------------
+
+    async def handle_outbound(self, env: Envelope) -> None:
+        """Render and deliver one outbound envelope to Feishu."""
+        if self._channel is None:
+            raise RuntimeError("FeishuAdapter.start() has not completed")
+        body = env.body if isinstance(env.body, dict) else {}
+        out_kind = str(body.get("kind") or "message")
+        chat_id = str(body.get("chat_id") or "")
+        if not chat_id:
+            log.warning("outbound dropped: empty chat_id (env id=%s)", env.id)
+            return
+        if out_kind == "turn_complete":
+            # Control signal — clear ACK reactions, nothing on the wire.
+            await self._clear_pending_acks(chat_id)
+            return
+        # Buttons travel in the body under "buttons" — list of dicts
+        # ``{"label": str, "value": str, "style": str}`` mirroring the
+        # in-process Button dataclass. The wire bridge does not yet
+        # serialize buttons (Phase 1 outbound body has no field for
+        # them); when it gains one, this code path is already prepared.
+        buttons_raw = body.get("buttons") or []
+        buttons: list[_ButtonLike] = []
+        if isinstance(buttons_raw, list):
+            for b in buttons_raw:
+                if not isinstance(b, dict):
+                    continue
+                label = str(b.get("label", ""))
+                value = str(b.get("value", ""))
+                style = str(b.get("style", "default"))
+                if label and value:
+                    buttons.append(_ButtonLike(label=label, value=value, style=style))
+        content = str(body.get("content") or "")
+        await self._send_card(chat_id, content, buttons)
+
+    async def _send_card(
+        self, chat_id: str, content: str, buttons: list[_ButtonLike]
+    ) -> None:
+        # Render every chat message as a schema-2.0 interactive card so
+        # Chinese, markdown (code fences, lists, headings) and action
+        # buttons all use the same path. Lark's plain ``text`` message
+        # type does not render markdown.
+        assert self._channel is not None
+        await self._channel.send(
+            chat_id,
+            {"card": _markdown_card(content, buttons=buttons)},
+        )
+
+    # -- ACK reactions ------------------------------------------------
+
+    async def _safe_reaction(
+        self, message_id: str, emoji: str
+    ) -> tuple[str, str] | None:
+        """Add an ACK reaction; return ``(message_id, reaction_id)`` on
+        success so the turn-complete cleanup can remove it.
+        """
+        assert self._channel is not None
+        try:
+            result = await self._channel.add_reaction(message_id, emoji)
+        except Exception:
+            log.exception("[feishu] add_reaction failed for %s", message_id)
+            return None
+        raw = getattr(result, "raw", None) or {}
+        data = raw.get("data") if isinstance(raw, dict) else None
+        reaction_id: str | None = None
+        if isinstance(data, dict):
+            inner = data.get("reaction_id")
+            if isinstance(inner, str):
+                reaction_id = inner
+            else:
+                reaction = data.get("reaction")
+                if isinstance(reaction, dict):
+                    rid = reaction.get("reaction_id")
+                    if isinstance(rid, str):
+                        reaction_id = rid
+        if not reaction_id:
+            log.warning(
+                "[feishu] add_reaction succeeded but reaction_id missing in %r",
+                raw,
+            )
+            return None
+        return message_id, reaction_id
+
+    async def _clear_pending_acks(self, chat_id: str) -> None:
+        """Remove every ACK reaction we attached for ``chat_id``."""
+        tasks = self._pending_acks.pop(chat_id, None)
+        if not tasks:
+            return
+        assert self._channel is not None
+        for task in tasks:
+            try:
+                pair = await task
+            except Exception:
+                log.exception("[feishu] ack-add task raised")
+                continue
+            if not pair:
+                continue
+            message_id, reaction_id = pair
+            try:
+                await self._channel.remove_reaction(message_id, reaction_id)
+            except Exception:
+                log.exception(
+                    "[feishu] remove_reaction failed (msg=%s reaction=%s)",
+                    message_id,
+                    reaction_id,
+                )
+
+    # -- helpers -------------------------------------------------------
+
+    def _is_self(self, sender_id: str) -> bool:
+        bot = getattr(self._channel, "_bot", None) if self._channel else None
+        bot_oid = getattr(bot, "open_id", None) if bot else None
+        return bool(bot_oid and sender_id == bot_oid)
+
+    def _is_allowed(self, sender_id: str) -> bool:
+        allow = self._config.allow_from
+        if not allow:
+            log.warning(
+                "[feishu] allow_from is empty — denying %s; "
+                "pass --allow-from '*' to permit everyone",
+                sender_id,
+            )
+            return False
+        if "*" in allow:
+            return True
+        return str(sender_id) in {str(x) for x in allow}
+
+
+@dataclass(slots=True)
+class _ButtonLike:
+    """Local mirror of ``agentm_channels.bus.Button``.
+
+    Kept local so the adapter doesn't need to import bus types — the
+    wire transports buttons as plain dicts (when the bridge gains
+    button serialization).
+    """
+
+    label: str
+    value: str
+    style: str = "default"
+
+
+def _markdown_card(text: str, *, buttons: list[_ButtonLike]) -> dict[str, Any]:
+    """Construct a Lark schema-2.0 interactive card.
+
+    Body is one ``markdown`` element so Chinese, code fences, lists,
+    and inline formatting all render. When ``buttons`` is non-empty an
+    ``action`` block is appended; each button's ``value`` round-trips
+    through Lark's ``cardAction`` callback as the typed inbound
+    ``button_value``. Style mapping is mechanical — no label-string
+    heuristics — so the caller controls visual emphasis via
+    ``Button.style``.
+    """
+    elements: list[dict[str, Any]] = [
+        {"tag": "markdown", "content": text or "*(empty)*"}
+    ]
+    if buttons:
+        elements.append(
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": btn.label},
+                        "type": _BUTTON_STYLE_MAP.get(btn.style, "default"),
+                        "name": btn.label.lower(),
+                        "value": {"button_value": btn.value},
+                    }
+                    for btn in buttons
+                ],
+            }
+        )
+    return {"schema": "2.0", "body": {"elements": elements}}
+
+
+__all__ = ["FeishuAdapter", "FeishuConfig"]

--- a/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
@@ -1,0 +1,408 @@
+"""``agentm-feishu`` — Feishu / Lark client process for the channels gateway.
+
+Connects to an ``agentm-gateway --bind unix://…`` over the v1 wire
+protocol, brings up the Feishu adapter, and proxies inbound messages /
+card-button clicks into the gateway and outbound messages back to
+Feishu as schema-2.0 interactive cards.
+
+CLI design follows ``autoharness:cli-design``:
+
+* All logs go to stderr. Stdout is unused (daemon).
+* Exit codes are stable and standardized (see ``EXIT_*`` constants).
+* Errors: ``agentm-feishu: error: <type>: <root cause>. <suggested fix>.``
+* Secrets never appear in argv (rule group 5). The app secret comes
+  from a file (``--app-secret PATH``) or the ``LARK_APP_SECRET`` env
+  variable — never as a literal flag value.
+
+Examples::
+
+    # File-based secret (recommended):
+    agentm-feishu \\
+      --connect unix:///tmp/gw.sock \\
+      --app-id cli_xxxx \\
+      --app-secret /run/secrets/feishu_app_secret
+
+    # Env-based secret:
+    LARK_APP_ID=cli_xxxx LARK_APP_SECRET=... \\
+      agentm-feishu --connect unix:///tmp/gw.sock
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import signal
+import sys
+import uuid
+from urllib.parse import urlparse
+
+from agentm_channels.client import AuthError, WireClient
+from agentm_channels.wire import (
+    KIND_BYE,
+    KIND_DELIVERY_BATCH,
+    KIND_ERROR,
+    KIND_OUTBOUND,
+    KIND_PING,
+    KIND_PONG,
+    Envelope,
+)
+
+from . import __version__
+from .adapter import FeishuAdapter, FeishuConfig
+from .ws_patch import apply_ws_patch
+
+# -- Exit codes (cli-design rule group 3) ------------------------------
+
+EXIT_OK = 0
+EXIT_GENERIC = 1
+EXIT_USAGE = 2
+EXIT_AUTH = 4
+EXIT_SIGINT = 6
+EXIT_CONNECT = 7
+
+PROG = "agentm-feishu"
+
+log = logging.getLogger("agentm_feishu")
+
+
+def _err(kind: str, root: str, fix: str) -> None:
+    """Print a structured error line to stderr."""
+    sys.stderr.write(f"{PROG}: error: {kind}: {root}. {fix}.\n")
+    sys.stderr.flush()
+
+
+# -- argv --------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    epilog = (
+        "Examples:\n"
+        "  File-based secret (recommended):\n"
+        f"    {PROG} --connect unix:///tmp/gw.sock \\\n"
+        "      --app-id cli_xxxx \\\n"
+        "      --app-secret /run/secrets/feishu_app_secret\n"
+        "\n"
+        "  Env-based credentials:\n"
+        "    LARK_APP_ID=cli_xxxx LARK_APP_SECRET=... \\\n"
+        f"      {PROG} --connect unix:///tmp/gw.sock\n"
+    )
+    p = argparse.ArgumentParser(
+        prog=PROG,
+        description=(
+            "Feishu / Lark client for the AgentM channels gateway. "
+            "Connects over the v1 wire protocol (Unix socket) and "
+            "bridges Feishu events ↔ gateway envelopes."
+        ),
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--connect",
+        required=True,
+        metavar="URL",
+        help=(
+            "Gateway socket URL. v1 supports only unix:///abs/path/to/sock; "
+            "other schemes are rejected with exit 2."
+        ),
+    )
+    p.add_argument(
+        "--app-id",
+        metavar="ID",
+        default=None,
+        help=(
+            "Feishu app id. Falls back to the LARK_APP_ID env variable; "
+            "missing → exit 2."
+        ),
+    )
+    p.add_argument(
+        "--app-secret",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to a file containing the Feishu app secret. Required "
+            "unless LARK_APP_SECRET is set in the environment. The file "
+            "wins if both are present. Secrets are never accepted as "
+            "literal CLI values."
+        ),
+    )
+    p.add_argument(
+        "--allow-from",
+        action="append",
+        metavar="PATTERN",
+        default=None,
+        help=(
+            "Sender id allow-list for inbound (repeatable). Defaults to "
+            "['*'] (allow everyone) — set explicit ids to harden."
+        ),
+    )
+    p.add_argument(
+        "--chat-id-prefix",
+        default="feishu",
+        metavar="STR",
+        help="Channel name reported on inbound envelopes (default: feishu).",
+    )
+    p.add_argument(
+        "--check-config",
+        action="store_true",
+        help=(
+            "Validate flags / env and exit 0 without contacting the "
+            "gateway or Feishu. Useful for systemd unit smoke tests."
+        ),
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Raise log level on stderr to INFO (default: WARNING).",
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"{PROG} {__version__}",
+    )
+    return p
+
+
+def _parse_connect_url(url: str) -> str:
+    """Return the absolute socket path. Raises ``SystemExit(2)`` on
+    invalid input (scheme, missing path)."""
+    parsed = urlparse(url)
+    if parsed.scheme != "unix":
+        _err(
+            "bad-argument",
+            f"--connect scheme {parsed.scheme!r} is not supported",
+            "use unix:///abs/path/to/sock (only unix:// is available in v1)",
+        )
+        raise SystemExit(EXIT_USAGE)
+    socket_path = parsed.path or parsed.netloc
+    if not socket_path or not socket_path.startswith("/"):
+        _err(
+            "bad-argument",
+            f"--connect URL {url!r} has no absolute socket path",
+            "use unix:///abs/path/to/sock",
+        )
+        raise SystemExit(EXIT_USAGE)
+    return socket_path
+
+
+def _load_app_secret(path: str | None) -> str | None:
+    """Load the Feishu app secret. File wins over env."""
+    if path:
+        try:
+            with open(path, encoding="utf-8") as f:
+                secret = f.read().strip()
+        except OSError as exc:
+            _err(
+                "bad-argument",
+                f"cannot read --app-secret file {path!r}: {exc.strerror or exc}",
+                "check the path and read permission",
+            )
+            raise SystemExit(EXIT_USAGE) from exc
+        if not secret:
+            _err(
+                "bad-argument",
+                f"--app-secret file {path!r} is empty",
+                "write the secret into the file (no trailing newline required)",
+            )
+            raise SystemExit(EXIT_USAGE)
+        return secret
+    env_secret = os.environ.get("LARK_APP_SECRET", "").strip()
+    return env_secret or None
+
+
+def _resolve_config(args: argparse.Namespace) -> FeishuConfig:
+    """Materialize the adapter config or exit 2."""
+    app_id = args.app_id or os.environ.get("LARK_APP_ID", "").strip()
+    if not app_id:
+        _err(
+            "bad-argument",
+            "missing --app-id (and no LARK_APP_ID in env)",
+            "pass --app-id cli_xxxx or set LARK_APP_ID",
+        )
+        raise SystemExit(EXIT_USAGE)
+    app_secret = _load_app_secret(args.app_secret)
+    if not app_secret:
+        _err(
+            "bad-argument",
+            "missing app secret (no --app-secret file and LARK_APP_SECRET empty)",
+            "pass --app-secret PATH or set LARK_APP_SECRET",
+        )
+        raise SystemExit(EXIT_USAGE)
+    allow_from = list(args.allow_from) if args.allow_from else ["*"]
+    return FeishuConfig(
+        app_id=app_id,
+        app_secret=app_secret,
+        allow_from=allow_from,
+        chat_id_prefix=args.chat_id_prefix,
+        channel_name=args.chat_id_prefix,
+    )
+
+
+# -- async run loop ----------------------------------------------------
+
+
+async def _arun(args: argparse.Namespace) -> int:
+    socket_path = _parse_connect_url(args.connect)
+    cfg = _resolve_config(args)
+
+    if args.check_config:
+        return EXIT_OK
+
+    peer_id = f"feishu-{uuid.uuid4().hex[:8]}"
+    stop_event = asyncio.Event()
+    exit_code = EXIT_OK
+    adapter: FeishuAdapter | None = None
+
+    async def on_outbound(env: Envelope) -> None:
+        nonlocal exit_code
+        if env.kind == KIND_OUTBOUND:
+            if adapter is None:
+                return
+            try:
+                await adapter.handle_outbound(env)
+            except Exception:  # noqa: BLE001
+                log.exception("adapter.handle_outbound failed id=%s", env.id)
+            return
+        if env.kind == KIND_DELIVERY_BATCH:  # pragma: no cover — unwrapped upstream
+            return
+        if env.kind in (KIND_PING, KIND_PONG):
+            return
+        if env.kind == KIND_BYE:
+            log.info("gateway sent BYE; shutting down")
+            stop_event.set()
+            return
+        if env.kind == KIND_ERROR:
+            body = env.body if isinstance(env.body, dict) else {}
+            code = body.get("code", "unknown")
+            message = body.get("message", "")
+            _err(
+                "gateway-error",
+                f"gateway emitted error code={code!r} message={message!r}",
+                "check the gateway logs (stderr on its side)",
+            )
+            exit_code = EXIT_GENERIC
+            stop_event.set()
+            return
+
+    client = WireClient(
+        socket_path=socket_path,
+        peer_id=peer_id,
+        peer_kind="chat_client",
+        on_outbound=on_outbound,
+    )
+
+    try:
+        await client.connect()
+    except AuthError as exc:
+        _err(
+            "auth-failed",
+            f"gateway rejected handshake (code={exc.code!r})",
+            "verify --bind-allow-uid on the gateway covers this client's uid",
+        )
+        return EXIT_AUTH
+    except (FileNotFoundError, ConnectionRefusedError) as exc:
+        _err(
+            "connect-failed",
+            f"cannot connect to {args.connect!r} ({exc.__class__.__name__})",
+            "is the gateway running with --bind on that path",
+        )
+        return EXIT_CONNECT
+    except OSError as exc:
+        _err(
+            "connect-failed",
+            f"cannot connect to {args.connect!r}: {exc.strerror or exc}",
+            "check the socket path and gateway state",
+        )
+        return EXIT_CONNECT
+
+    # Apply WS patch *before* constructing the adapter — the patch
+    # rebinds ``lark_oapi.ws.client.loop`` and the adapter's
+    # ``FeishuChannel`` constructor latches onto that module global.
+    apply_ws_patch()
+    adapter = FeishuAdapter(client=client, config=cfg)
+
+    # Install signal handlers for clean shutdown.
+    sigint_seen = False
+
+    def _on_sigint() -> None:
+        nonlocal sigint_seen
+        sigint_seen = True
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(
+                sig, _on_sigint if sig == signal.SIGINT else stop_event.set
+            )
+        except (NotImplementedError, RuntimeError):  # pragma: no cover — Windows
+            pass
+
+    adapter_task = asyncio.create_task(adapter.start(), name="feishu-adapter")
+    stop_task = asyncio.create_task(stop_event.wait(), name="feishu-stop")
+
+    try:
+        done, pending = await asyncio.wait(
+            [adapter_task, stop_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        # If the adapter task crashed (e.g. invalid Feishu credentials)
+        # surface the exception class as an auth failure.
+        if adapter_task in done and adapter_task.exception() is not None:
+            adapter_exc = adapter_task.exception()
+            assert adapter_exc is not None  # for mypy
+            _err(
+                "feishu-error",
+                f"adapter failed: {adapter_exc.__class__.__name__}: {adapter_exc}",
+                "check --app-id / --app-secret and Feishu app status",
+            )
+            # Distinguish credential / handshake failures from generic
+            # crashes by class name — lark_oapi raises connect errors
+            # without a dedicated type, so this is the best we can do.
+            return EXIT_AUTH
+        for t in pending:
+            t.cancel()
+    finally:
+        try:
+            await adapter.stop()
+        except Exception:  # noqa: BLE001
+            log.exception("adapter.stop raised")
+        await client.close()
+
+    if sigint_seen:
+        return EXIT_SIGINT
+    return exit_code
+
+
+# -- entrypoint --------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else sys.argv[1:])
+    except SystemExit as exc:
+        if isinstance(exc.code, int):
+            return EXIT_USAGE if exc.code == 2 else int(exc.code)
+        return EXIT_USAGE
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        return asyncio.run(_arun(args))
+    except KeyboardInterrupt:
+        return EXIT_SIGINT
+    except SystemExit as exc:
+        if isinstance(exc.code, int):
+            return exc.code
+        return EXIT_GENERIC
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/contrib/channels-clients/feishu/src/agentm_feishu/ws_patch.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/ws_patch.py
@@ -1,0 +1,37 @@
+"""Workaround for the upstream lark-oapi WS event-loop bug.
+
+``lark_oapi.ws.client`` captures ``asyncio.get_event_loop()`` at
+module-import time. When the module is imported from inside an
+already-running event loop (our case — ``agentm-feishu`` runs the
+adapter under ``asyncio.run``), that captured reference *is* the main
+loop; ``WSClient.start`` then calls ``loop.run_until_complete(...)``
+from a background thread against the still-running main loop and
+raises ``RuntimeError: This event loop is already running``. Replacing
+the module-level reference with a fresh dedicated loop makes
+``run_until_complete`` legal again — the WS client is the only
+consumer of that module global.
+
+TODO: drop this once an upstream fix lands. File the issue on
+https://github.com/larksuite/oapi-sdk-python with a reproducer and
+delete this module plus its caller in ``cli._arun``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def apply_ws_patch() -> None:
+    """Replace ``lark_oapi.ws.client.loop`` with a fresh event loop.
+
+    Idempotent only in the sense that calling it twice in the same
+    process just installs a second fresh loop; the WS client picks up
+    whatever is current at ``WSClient.start`` time. Call once at CLI
+    startup, before constructing the lark ``Client``.
+    """
+    import lark_oapi.ws.client as _ws_client  # noqa: PLC0415 — import-on-demand
+
+    _ws_client.loop = asyncio.new_event_loop()
+
+
+__all__ = ["apply_ws_patch"]

--- a/contrib/channels-clients/feishu/tests/test_adapter_unit.py
+++ b/contrib/channels-clients/feishu/tests/test_adapter_unit.py
@@ -1,0 +1,290 @@
+"""Unit tests for ``FeishuAdapter`` without contacting Feishu.
+
+We bypass :meth:`FeishuAdapter.start` (which would import lark_oapi
+and open a WebSocket) and instead inject a fake ``_channel`` attribute
+plus drive the event handlers directly. The wire side is a stub that
+records ``send`` calls so we can assert exactly what would have hit
+the gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from agentm_channels.wire import (
+    KIND_INBOUND,
+    KIND_OUTBOUND,
+    WIRE_VERSION,
+    Envelope,
+)
+from agentm_feishu.adapter import FeishuAdapter, FeishuConfig, _markdown_card
+
+
+class _StubClient:
+    """Records :meth:`send` calls so tests can inspect the envelopes."""
+
+    def __init__(self) -> None:
+        self.sent: list[Envelope] = []
+
+    async def send(self, env: Envelope) -> None:  # noqa: D401
+        self.sent.append(env)
+
+
+class _FakeLarkChannel:
+    """Minimal stand-in for ``lark_oapi.channel.FeishuChannel``."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict[str, Any]]] = []
+        self.reactions_added: list[tuple[str, str]] = []
+        self.reactions_removed: list[tuple[str, str]] = []
+        self._bot = None  # so adapter._is_self() is always False
+
+    async def send(self, chat_id: str, payload: dict[str, Any]) -> None:
+        self.sent.append((chat_id, payload))
+
+    async def add_reaction(self, message_id: str, emoji: str) -> Any:
+        self.reactions_added.append((message_id, emoji))
+        # Shape mirrors what lark-oapi returns: ``result.raw["data"]["reaction_id"]``.
+
+        class _R:
+            raw = {"data": {"reaction_id": f"rx-{message_id}"}}
+
+        return _R()
+
+    async def remove_reaction(self, message_id: str, reaction_id: str) -> None:
+        self.reactions_removed.append((message_id, reaction_id))
+
+
+def _make_adapter(allow: list[str] | None = None) -> tuple[FeishuAdapter, _StubClient, _FakeLarkChannel]:
+    client = _StubClient()
+    cfg = FeishuConfig(
+        app_id="cli_xxxx",
+        app_secret="secret",
+        allow_from=allow if allow is not None else ["*"],
+        chat_id_prefix="feishu",
+        channel_name="feishu",
+        ack_emoji="OK",
+    )
+    adapter = FeishuAdapter(client=client, config=cfg)  # type: ignore[arg-type]
+    fake_channel = _FakeLarkChannel()
+    adapter._channel = fake_channel  # type: ignore[assignment]
+    return adapter, client, fake_channel
+
+
+# -- inbound: messageReceiveEvent → wire ------------------------------
+
+
+class _FakeMessage:
+    def __init__(
+        self,
+        sender_id: str,
+        chat_id: str,
+        content_text: str,
+        message_id: str | None = "msg_1",
+    ) -> None:
+        self.sender_id = sender_id
+        self.chat_id = chat_id
+        self.content_text = content_text
+        self.message_id = message_id
+
+
+async def test_message_event_forwards_inbound_envelope() -> None:
+    adapter, client, fake = _make_adapter()
+    msg = _FakeMessage(
+        sender_id="ou_alice",
+        chat_id="oc_chat",
+        content_text="hello world",
+    )
+
+    await adapter._on_message(msg)
+
+    # ACK-reaction task is fire-and-forget; let it complete.
+    await asyncio.sleep(0)
+    for tasks in list(adapter._pending_acks.values()):
+        for t in tasks:
+            await t
+
+    # Exactly one inbound envelope on the wire.
+    assert len(client.sent) == 1
+    env = client.sent[0]
+    assert env.kind == KIND_INBOUND
+    assert env.v == WIRE_VERSION
+    assert env.body == {
+        "channel": "feishu",
+        "sender_id": "ou_alice",
+        "chat_id": "oc_chat",
+        "content": "hello world",
+    }
+    # ACK reaction was attempted.
+    assert fake.reactions_added == [("msg_1", "OK")]
+
+
+async def test_message_event_disallowed_sender_is_dropped() -> None:
+    adapter, client, _fake = _make_adapter(allow=["ou_bob"])
+    msg = _FakeMessage(
+        sender_id="ou_alice", chat_id="oc_chat", content_text="hi"
+    )
+    await adapter._on_message(msg)
+    assert client.sent == []
+
+
+async def test_message_event_empty_allow_list_denies_all() -> None:
+    adapter, client, _fake = _make_adapter(allow=[])
+    msg = _FakeMessage(
+        sender_id="ou_alice", chat_id="oc_chat", content_text="hi"
+    )
+    await adapter._on_message(msg)
+    assert client.sent == []
+
+
+# -- inbound: cardAction → wire ---------------------------------------
+
+
+class _FakeOperator:
+    def __init__(self, open_id: str) -> None:
+        self.open_id = open_id
+        self.user_id = None
+
+
+class _FakeAction:
+    def __init__(self, value: dict[str, Any]) -> None:
+        self.value = value
+
+
+class _FakeCardEvent:
+    def __init__(self, button_value: str, sender: str, chat_id: str) -> None:
+        self.action = _FakeAction({"button_value": button_value})
+        self.operator = _FakeOperator(sender)
+        self.chat_id = chat_id
+        self.message_id = "card_msg_1"
+
+
+async def test_card_action_forwards_button_value() -> None:
+    adapter, client, _fake = _make_adapter()
+    ev = _FakeCardEvent("approve_abc123", "ou_alice", "oc_chat")
+    await adapter._on_card_action(ev)
+    assert len(client.sent) == 1
+    body = client.sent[0].body
+    assert body["channel"] == "feishu"
+    assert body["sender_id"] == "ou_alice"
+    assert body["chat_id"] == "oc_chat"
+    assert body["button_value"] == "approve_abc123"
+    assert "[card click: approve_abc123]" in body["content"]
+
+
+async def test_card_action_without_button_value_is_ignored() -> None:
+    adapter, client, _fake = _make_adapter()
+
+    class _Empty:
+        action = _FakeAction({})  # no button_value key
+        operator = _FakeOperator("ou_alice")
+        chat_id = "oc_chat"
+        message_id = "x"
+
+    await adapter._on_card_action(_Empty())
+    assert client.sent == []
+
+
+# -- outbound: gateway envelope → Feishu card --------------------------
+
+
+def _outbound_env(body: dict[str, Any]) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id="out-1",
+        kind=KIND_OUTBOUND,
+        ts=time.time(),
+        body=body,
+    )
+
+
+async def test_handle_outbound_renders_markdown_card() -> None:
+    adapter, _client, fake = _make_adapter()
+    env = _outbound_env(
+        {
+            "channel": "feishu",
+            "chat_id": "oc_chat",
+            "content": "## Hello\n你好",
+            "kind": "message",
+        }
+    )
+    await adapter.handle_outbound(env)
+    assert len(fake.sent) == 1
+    chat_id, payload = fake.sent[0]
+    assert chat_id == "oc_chat"
+    card = payload["card"]
+    assert card["schema"] == "2.0"
+    assert card["body"]["elements"][0] == {
+        "tag": "markdown",
+        "content": "## Hello\n你好",
+    }
+
+
+async def test_handle_outbound_with_buttons_appends_action_block() -> None:
+    adapter, _client, fake = _make_adapter()
+    env = _outbound_env(
+        {
+            "channel": "feishu",
+            "chat_id": "oc_chat",
+            "content": "Approve?",
+            "kind": "message",
+            "buttons": [
+                {"label": "Approve", "value": "ok", "style": "primary"},
+                {"label": "Deny", "value": "no", "style": "danger"},
+            ],
+        }
+    )
+    await adapter.handle_outbound(env)
+    card = fake.sent[0][1]["card"]
+    elements = card["body"]["elements"]
+    assert len(elements) == 2
+    action = elements[1]
+    assert action["tag"] == "action"
+    actions = action["actions"]
+    assert actions[0]["type"] == "primary"
+    assert actions[0]["value"] == {"button_value": "ok"}
+    assert actions[1]["type"] == "danger"
+    assert actions[1]["value"] == {"button_value": "no"}
+
+
+async def test_handle_outbound_turn_complete_clears_acks() -> None:
+    adapter, _client, fake = _make_adapter()
+    # Prime an ACK by running an inbound first.
+    await adapter._on_message(
+        _FakeMessage("ou_alice", "oc_chat", "hi", message_id="msg_1")
+    )
+    # Let the ACK-add task finish.
+    for tasks in adapter._pending_acks.values():
+        for t in tasks:
+            await t
+    env = _outbound_env(
+        {"channel": "feishu", "chat_id": "oc_chat", "kind": "turn_complete"}
+    )
+    await adapter.handle_outbound(env)
+    assert fake.reactions_removed == [("msg_1", "rx-msg_1")]
+    # No card was sent for turn_complete.
+    assert fake.sent == []
+
+
+async def test_handle_outbound_empty_chat_id_drops() -> None:
+    adapter, _client, fake = _make_adapter()
+    env = _outbound_env(
+        {"channel": "feishu", "chat_id": "", "content": "x", "kind": "message"}
+    )
+    await adapter.handle_outbound(env)
+    assert fake.sent == []
+
+
+# -- card construction helper -----------------------------------------
+
+
+def test_markdown_card_empty_text_is_placeholder() -> None:
+    card = _markdown_card("", buttons=[])
+    assert card["body"]["elements"][0]["content"] == "*(empty)*"
+
+
+def test_markdown_card_no_buttons_has_one_element() -> None:
+    card = _markdown_card("hi", buttons=[])
+    assert len(card["body"]["elements"]) == 1

--- a/contrib/channels-clients/feishu/tests/test_cli_smoke.py
+++ b/contrib/channels-clients/feishu/tests/test_cli_smoke.py
@@ -1,0 +1,245 @@
+"""argparse-level smoke tests for ``agentm-feishu``.
+
+No subprocess, no real Feishu, no real socket. ``--check-config`` is
+used to drive the happy path through argument parsing and config
+resolution without contacting the gateway or Feishu.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agentm_feishu import cli as feishu_cli
+
+
+@pytest.fixture(autouse=True)
+def _scrub_lark_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every test start from a clean LARK_* environment."""
+    monkeypatch.delenv("LARK_APP_ID", raising=False)
+    monkeypatch.delenv("LARK_APP_SECRET", raising=False)
+
+
+def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        feishu_cli._build_parser().parse_args(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "agentm-feishu" in out
+    assert "--connect" in out
+    assert "--app-id" in out
+    assert "--app-secret" in out
+    # Examples section is mandated by the brief.
+    assert "Examples" in out
+
+
+def test_version_prints_and_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        feishu_cli._build_parser().parse_args(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "0.1.0" in out
+
+
+def test_missing_connect_exits_two(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = feishu_cli.main([])
+    assert rc == 2
+
+
+def test_bad_connect_scheme_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = feishu_cli.main(
+        [
+            "--connect",
+            "tcp://127.0.0.1:7000",
+            "--app-id",
+            "cli_xxxx",
+            "--check-config",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "agentm-feishu: error" in err
+    assert "unix://" in err
+
+
+def test_missing_app_id_exits_two(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = feishu_cli.main(
+        ["--connect", "unix:///tmp/gw.sock", "--check-config"]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing --app-id" in err
+
+
+def test_missing_app_secret_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = feishu_cli.main(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--check-config",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing app secret" in err
+
+
+def test_empty_secret_file_exits_two(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("")
+    rc = feishu_cli.main(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--app-secret",
+            str(secret_file),
+            "--check-config",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "empty" in err
+
+
+def test_check_config_success_with_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LARK_APP_ID", "cli_xxxx")
+    monkeypatch.setenv("LARK_APP_SECRET", "secret_value")
+    rc = feishu_cli.main(
+        ["--connect", "unix:///tmp/gw.sock", "--check-config"]
+    )
+    assert rc == 0
+
+
+def test_check_config_success_with_file(tmp_path: Path) -> None:
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("secret_value\n")
+    rc = feishu_cli.main(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--app-secret",
+            str(secret_file),
+            "--check-config",
+        ]
+    )
+    assert rc == 0
+
+
+def test_secret_file_wins_over_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When both are set the file wins, per CLI contract."""
+    monkeypatch.setenv("LARK_APP_SECRET", "from_env")
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("from_file")
+    cfg = feishu_cli._resolve_config(
+        feishu_cli._build_parser().parse_args(
+            [
+                "--connect",
+                "unix:///tmp/gw.sock",
+                "--app-id",
+                "cli_xxxx",
+                "--app-secret",
+                str(secret_file),
+            ]
+        )
+    )
+    assert cfg.app_secret == "from_file"
+
+
+def test_bad_secret_file_path_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = feishu_cli.main(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--app-secret",
+            "/nonexistent/path/that/does/not/exist",
+            "--check-config",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "cannot read --app-secret file" in err
+
+
+def test_default_allow_from_is_star(tmp_path: Path) -> None:
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("x")
+    args = feishu_cli._build_parser().parse_args(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--app-secret",
+            str(secret_file),
+        ]
+    )
+    cfg = feishu_cli._resolve_config(args)
+    assert cfg.allow_from == ["*"]
+
+
+def test_repeated_allow_from(tmp_path: Path) -> None:
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("x")
+    args = feishu_cli._build_parser().parse_args(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "cli_xxxx",
+            "--app-secret",
+            str(secret_file),
+            "--allow-from",
+            "ou_alice",
+            "--allow-from",
+            "ou_bob",
+        ]
+    )
+    cfg = feishu_cli._resolve_config(args)
+    assert cfg.allow_from == ["ou_alice", "ou_bob"]
+
+
+def test_env_path_does_not_leak_when_arg_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sanity: LARK_APP_ID from env is overridden by --app-id flag."""
+    monkeypatch.setenv("LARK_APP_ID", "from_env")
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("x")
+    args = feishu_cli._build_parser().parse_args(
+        [
+            "--connect",
+            "unix:///tmp/gw.sock",
+            "--app-id",
+            "explicit_arg",
+            "--app-secret",
+            str(secret_file),
+        ]
+    )
+    cfg = feishu_cli._resolve_config(args)
+    assert cfg.app_id == "explicit_arg"
+    # Belt-and-braces: env is gone for the rest of the test.
+    assert os.environ["LARK_APP_ID"] == "from_env"

--- a/contrib/channels/pyproject.toml
+++ b/contrib/channels/pyproject.toml
@@ -7,13 +7,15 @@ requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "AgentM contributors" }]
 # `agentm` is supplied by the parent workspace (path install) and intentionally
-# omitted here. lark-oapi is required for the bundled Feishu channel; future
-# channel modules pull their own per-vendor SDKs as direct deps too — keeping
-# them here means `agentm-gateway` works out of the box after `uv sync`.
+# omitted here. Per-vendor SDKs (lark-oapi, slack-sdk, …) used to live here
+# when channels ran in-process; as of Phase 3 they belong to the extracted
+# client packages (`agentm-feishu`, …) so the gateway image stays vendor-
+# agnostic. The legacy in-process `FeishuChannel` is kept for backwards
+# compatibility but emits a DeprecationWarning and imports lark_oapi lazily,
+# so it no longer needs to appear here.
 dependencies = [
     "pyyaml>=6",
     "python-dotenv>=1.0",
-    "lark-oapi>=1.6",
 ]
 
 [project.optional-dependencies]

--- a/contrib/channels/src/agentm_channels/channels/feishu.py
+++ b/contrib/channels/src/agentm_channels/channels/feishu.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warnings
 from typing import Any
 
 from ..base import BaseChannel
@@ -93,6 +94,16 @@ class FeishuChannel(BaseChannel):
     async def start(self) -> None:
         if self._running:
             return
+        warnings.warn(
+            "agentm_channels.channels.feishu.FeishuChannel is deprecated as "
+            "of Phase 3 of the gateway/client split. Run the Feishu adapter "
+            "as a separate process: "
+            "`agentm-feishu --connect unix:///path/to/gateway.sock --app-id ... "
+            "--app-secret /path/to/secret-file`. The in-process driver "
+            "remains functional but will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             from lark_oapi.channel import FeishuChannel as _Lark
         except ImportError as exc:  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ members = [
     "contrib/scenarios/rca",
     "contrib/channels",
     "contrib/channels-clients/terminal",
+    "contrib/channels-clients/feishu",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ resolution-markers = [
 members = [
     "agentm",
     "agentm-channels",
+    "agentm-feishu",
     "agentm-rca",
     "agentm-terminal",
     "llmharness",
@@ -73,7 +74,6 @@ name = "agentm-channels"
 version = "0.1.0"
 source = { editable = "contrib/channels" }
 dependencies = [
-    { name = "lark-oapi" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
@@ -88,12 +88,41 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lark-oapi", specifier = ">=1.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "agentm-feishu"
+version = "0.1.0"
+source = { editable = "contrib/channels-clients/feishu" }
+dependencies = [
+    { name = "agentm-channels" },
+    { name = "lark-oapi" },
+    { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentm-channels", editable = "contrib/channels" },
+    { name = "lark-oapi", specifier = ">=1.6" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

Phase 3 of the gateway/client process split. The Feishu chat client now lives in its own package and process; `lark_oapi` moves out of the gateway pyproject so operators not using Feishu get a smaller venv.

\`\`\`bash
# terminal 1 — daemon
agentm-gateway --bind unix:///tmp/agentm/gw.sock

# terminal 2 — feishu client
LARK_APP_ID=cli_xxx agentm-feishu \
    --connect unix:///tmp/agentm/gw.sock \
    --app-secret /etc/agentm/feishu.secret
\`\`\`

## CLI contract

Same shape as `agentm-terminal` per `autoharness:cli-design`:

- `--connect unix:///path` required.
- `--app-id` or `LARK_APP_ID` env.
- `--app-secret <file>` or `LARK_APP_SECRET` env — **never argv** (rule group 5).
- `--allow-from`, `--chat-id-prefix`, `--verbose`, `--version`, `--help`, `--check-config`.
- Exit codes 0/1/2/4/6/7 standardized.

## What moved

Card schema 2.0, approval buttons, ACK emoji reactions, both event handlers, the `lark_oapi.ws.client` monkey-patch. Inbound body shape unchanged.

## Tests

- channels: 129
- terminal: 11
- feishu: **25** (new — 15 CLI smoke + 10 adapter unit, no live creds)
- ruff + mypy clean

## Known gap — separate PR

Wire bridge doesn't yet serialize `OutboundMessage.buttons` or forward `button_value` on inbound. Adapter prepared on both sides; bridge fix unblocks approval end-to-end over wire-mode Feishu. Same gap affects wire-mode terminal too.

## Deprecates

- `FeishuChannel.start()` → `DeprecationWarning` pointing to the new CLI.
- `lark-oapi>=1.6` removed from `contrib/channels/pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)