### PR TITLE
refactor(channels): session-as-routing-primary; persistent host bindings

### DIFF
--- a/contrib/channels-clients/worker/src/agentm_worker/runner.py
+++ b/contrib/channels-clients/worker/src/agentm_worker/runner.py
@@ -189,6 +189,18 @@ class WorkerRunner:
         self._inflight_root_session_key[session_key] = (
             env.root_session_key or session_key
         )
+        # Session-as-routing-primary: the gateway hands us the
+        # ``resume_id`` for this session_key when the binding store has
+        # one (typically because a previous host crashed). Stash it in
+        # the local chat_session_map so the Gateway's session_factory
+        # picks it up on the very next ``session_factory(cwd, bus,
+        # resume_id)`` call. First-bind inbounds carry no resume_id —
+        # the Gateway then writes its freshly-created session_id back
+        # into chat_session_map, which we surface to the gateway-side
+        # binding store on the next outbound via ``_session_id_hint``.
+        resume_id_raw = body.get("resume_id")
+        if isinstance(resume_id_raw, str) and resume_id_raw:
+            self._gateway._chat_map.set(session_key, resume_id_raw)  # type: ignore[attr-defined]
         async with self._semaphore:
             await self._bus.publish_inbound(
                 InboundMessage(
@@ -233,10 +245,19 @@ class WorkerRunner:
         try:
             while not self._stopped.is_set():
                 msg: OutboundMessage = await self._bus.consume_outbound()
-                root = self._inflight_root_session_key.get(
-                    f"{msg.channel}:{msg.chat_id}"
+                session_key = f"{msg.channel}:{msg.chat_id}"
+                root = self._inflight_root_session_key.get(session_key)
+                # Surface the locally-known AgentSession id back to the
+                # gateway so the binding store records it. Gateway uses
+                # the hint to populate ``resume_id`` on the binding;
+                # next time this session_key rebinds to a fresh host,
+                # the new host receives the hint and resumes.
+                session_id_hint = self._gateway._chat_map.get(session_key)  # type: ignore[attr-defined]
+                env = _outbound_to_envelope(
+                    msg,
+                    root_session_key=root,
+                    session_id_hint=session_id_hint,
                 )
-                env = _outbound_to_envelope(msg, root_session_key=root)
                 try:
                     await self._client.send(env)
                 except Exception:
@@ -329,6 +350,7 @@ def _outbound_to_envelope(
     msg: OutboundMessage,
     *,
     root_session_key: str | None = None,
+    session_id_hint: str | None = None,
 ) -> Envelope:
     body: dict[str, Any] = {
         "channel": msg.channel,
@@ -345,6 +367,12 @@ def _outbound_to_envelope(
         ]
     if msg.metadata:
         body["metadata"] = dict(msg.metadata)
+    if session_id_hint:
+        # Side-channel: the gateway's WireBridge strips this before
+        # forwarding to the chat client and writes it onto the
+        # binding store. See the WireBridge.handle_worker_outbound
+        # comment for the rationale.
+        body["_session_id_hint"] = session_id_hint
     return Envelope(
         v=WIRE_VERSION,
         id=f"wkr-out-{int(time.time() * 1_000_000)}",

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -72,6 +72,7 @@ from .gateway import Gateway, GatewayConfig
 from .manager import ChannelManager
 from .outbox import SqliteInbox, SqliteOutbox
 from .server import WireServer
+from .session_bindings import SessionBindingStore
 from .wire_bridge import DEFAULT_MAX_A2A_HOPS, WireBridge
 
 
@@ -583,10 +584,17 @@ async def _arun(args: argparse.Namespace) -> int:
         state_dir.mkdir(parents=True, exist_ok=True)
         wire_outbox = SqliteOutbox(str(state_dir / "wire-outbox.sqlite"))
         wire_inbox = SqliteInbox(str(state_dir / "wire-inbox.sqlite"))
+        # Routing table: session_key → host_id + resume_id. Lives next
+        # to the outbox so the whole gateway state directory is one
+        # consistent unit on disk. Survives gateway restart by design.
+        session_bindings = SessionBindingStore(
+            state_dir / "session-bindings.sqlite"
+        )
         bridge = WireBridge(
             bus=bus,
             manager=manager,
             outbox=wire_outbox,
+            bindings=session_bindings,
             scenario=args.scenario or cfg.get("scenario") or "",
             allow_inproc=bool(getattr(args, "inproc_worker", True)),
             max_a2a_hops=int(

--- a/contrib/channels/src/agentm_channels/session_bindings.py
+++ b/contrib/channels/src/agentm_channels/session_bindings.py
@@ -1,0 +1,182 @@
+"""Persistent ``session_key → host`` binding store.
+
+This is the gateway's routing table. A *session* is the first-class
+routable thing; *workers* are just hosts that happen to be holding it.
+A binding survives:
+
+* worker / host disconnect — next inbound for the same ``session_key``
+  picks any online host, and the new host resumes the AgentSession
+  via the persisted ``resume_id`` so the conversation continues.
+* gateway restart — the table lives in SQLite next to the outbox, so
+  reconnecting peers find the same routing they had before.
+
+The store is intentionally schema-thin (one table, four columns).
+Anything richer (load-tracking, host capability fingerprints, last-
+heard time series) belongs to a presence / load subsystem, not the
+binding table.
+
+Atomic writes only — concurrent ``upsert`` and ``get`` from multiple
+asyncio tasks are safe because every write goes through a single
+threading lock and SQLite's per-statement atomicity. Callers offload
+to ``asyncio.to_thread`` if they care about not blocking the loop.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["SessionBinding", "SessionBindingStore"]
+
+
+@dataclass(frozen=True)
+class SessionBinding:
+    session_key: str
+    host_id: str
+    resume_id: str | None
+    last_seen_at: float
+
+
+class SessionBindingStore:
+    """SQLite-backed persistent map. One table, columns:
+
+    ``session_key`` (PK), ``host_id``, ``resume_id``, ``last_seen_at``.
+    """
+
+    _DDL = """
+    CREATE TABLE IF NOT EXISTS session_bindings (
+        session_key   TEXT PRIMARY KEY,
+        host_id       TEXT NOT NULL,
+        resume_id     TEXT,
+        last_seen_at  REAL NOT NULL
+    )
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        # ``":memory:"`` is honored as a special sqlite path so tests
+        # can spin up a store without touching the filesystem. The
+        # in-memory connection is opened eagerly and held — the data
+        # disappears when ``close()`` is called.
+        if isinstance(db_path, str) and db_path == ":memory:":
+            self._path: Path | str = ":memory:"
+            self._in_memory = True
+        else:
+            p = Path(db_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            self._path = p
+            self._in_memory = False
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = None
+        self._ensure_schema()
+
+    # -- lifecycle ---------------------------------------------------
+
+    def _c(self) -> sqlite3.Connection:
+        if self._conn is None:
+            path_arg: str = ":memory:" if self._in_memory else str(self._path)
+            self._conn = sqlite3.connect(
+                path_arg, isolation_level=None, check_same_thread=False
+            )
+            if not self._in_memory:
+                # WAL only makes sense on disk-backed files.
+                self._conn.execute("PRAGMA journal_mode = WAL")
+                self._conn.execute("PRAGMA synchronous = NORMAL")
+        return self._conn
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            self._c().execute(self._DDL)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+    # -- reads -------------------------------------------------------
+
+    def get(self, session_key: str) -> SessionBinding | None:
+        with self._lock:
+            row = self._c().execute(
+                "SELECT session_key, host_id, resume_id, last_seen_at "
+                "FROM session_bindings WHERE session_key = ?",
+                (session_key,),
+            ).fetchone()
+        if row is None:
+            return None
+        return SessionBinding(
+            session_key=row[0],
+            host_id=row[1],
+            resume_id=row[2],
+            last_seen_at=float(row[3]),
+        )
+
+    def all_for_host(self, host_id: str) -> list[SessionBinding]:
+        with self._lock:
+            rows = self._c().execute(
+                "SELECT session_key, host_id, resume_id, last_seen_at "
+                "FROM session_bindings WHERE host_id = ?",
+                (host_id,),
+            ).fetchall()
+        return [
+            SessionBinding(
+                session_key=r[0], host_id=r[1], resume_id=r[2], last_seen_at=float(r[3])
+            )
+            for r in rows
+        ]
+
+    # -- writes ------------------------------------------------------
+
+    def upsert(
+        self,
+        session_key: str,
+        host_id: str,
+        resume_id: str | None = None,
+    ) -> None:
+        """Bind ``session_key`` to ``host_id``. If ``resume_id`` is
+        ``None`` the existing one (if any) is preserved — letting the
+        bridge record host changes without losing the resumption
+        anchor that the worker reports separately."""
+        now = time.time()
+        with self._lock:
+            c = self._c()
+            if resume_id is None:
+                c.execute(
+                    "INSERT INTO session_bindings "
+                    "(session_key, host_id, resume_id, last_seen_at) "
+                    "VALUES (?, ?, NULL, ?) "
+                    "ON CONFLICT(session_key) DO UPDATE SET "
+                    "host_id = excluded.host_id, "
+                    "last_seen_at = excluded.last_seen_at",
+                    (session_key, host_id, now),
+                )
+            else:
+                c.execute(
+                    "INSERT INTO session_bindings "
+                    "(session_key, host_id, resume_id, last_seen_at) "
+                    "VALUES (?, ?, ?, ?) "
+                    "ON CONFLICT(session_key) DO UPDATE SET "
+                    "host_id = excluded.host_id, "
+                    "resume_id = excluded.resume_id, "
+                    "last_seen_at = excluded.last_seen_at",
+                    (session_key, host_id, resume_id, now),
+                )
+
+    def set_resume_id(self, session_key: str, resume_id: str) -> None:
+        """Update only the resume_id (called when a host reports its
+        AgentSession id after first inbound)."""
+        with self._lock:
+            self._c().execute(
+                "UPDATE session_bindings SET resume_id = ?, last_seen_at = ? "
+                "WHERE session_key = ?",
+                (resume_id, time.time(), session_key),
+            )
+
+    def delete(self, session_key: str) -> None:
+        with self._lock:
+            self._c().execute(
+                "DELETE FROM session_bindings WHERE session_key = ?", (session_key,)
+            )

--- a/contrib/channels/src/agentm_channels/wire_bridge.py
+++ b/contrib/channels/src/agentm_channels/wire_bridge.py
@@ -64,6 +64,7 @@ from .wire import (
     WIRE_VERSION,
     Envelope,
 )
+from .session_bindings import SessionBindingStore
 from .worker_registry import WorkerRegistry
 
 log = logging.getLogger("agentm_channels.wire_bridge")
@@ -174,6 +175,7 @@ class WireBridge:
         bus: MessageBus,
         manager: ChannelManager,
         outbox: OutboxStore,
+        bindings: SessionBindingStore | None = None,
         worker_registry: WorkerRegistry | None = None,
         scenario: str | None = None,
         allow_inproc: bool = True,
@@ -182,7 +184,13 @@ class WireBridge:
         self._bus = bus
         self._manager = manager
         self._outbox = outbox
-        self._workers = worker_registry or WorkerRegistry()
+        # The binding store is the routing source of truth. Tests omit
+        # the kwarg and we fall back to an in-memory sqlite — fine
+        # because tests construct one bridge per case. Production paths
+        # in ``cli.py`` supply an on-disk store next to ``outbox.sqlite``
+        # so the routing table survives gateway restart.
+        self._bindings = bindings or SessionBindingStore(":memory:")
+        self._workers = worker_registry or WorkerRegistry(self._bindings)
         self._scenario = scenario or ""
         self._allow_inproc = allow_inproc
         self._max_a2a_hops = max(1, int(max_a2a_hops))
@@ -216,14 +224,19 @@ class WireBridge:
     async def handle_peer_disconnect(self, session: PeerSession) -> None:
         """Tear down per-peer state on disconnect.
 
-        For workers: release sticky session bindings and warn every
-        affected chat client that its in-flight turn is lost.
+        For workers: drop the online-set entry but **leave the
+        persistent session bindings untouched**. The next inbound for
+        a stranded session_key will rebind to any other online host
+        advertising the same scenario, and the host receives the
+        binding's ``resume_id`` so the conversation continues. If no
+        replacement is available, the chat client gets the standard
+        "no host" outbound (same surface as a never-bound session)
+        instead of a separate "worker disconnected" error.
+
         For chat clients: drop the synthetic channel.
         """
         if session.peer_kind == "agent_worker":
-            lost = self._workers.unregister(session.peer_id)
-            for session_key in lost:
-                await self._emit_worker_lost(session_key)
+            self._workers.unregister(session.peer_id)
             return
         # chat_client (or unknown): drop the synthetic channel.
         await self.on_peer_disconnect(session.peer_id)
@@ -275,7 +288,9 @@ class WireBridge:
         # identifier of the user-facing conversation.
         root_session_key = env.root_session_key or session_key
 
-        worker_peer = self._workers.find_worker(self._scenario, session_key)
+        worker_peer, resume_id = self._workers.find_host(
+            self._scenario, session_key
+        )
         if worker_peer is not None:
             forwarded_hops = env.hops + 1
             if forwarded_hops > self._max_a2a_hops:
@@ -289,12 +304,19 @@ class WireBridge:
                     },
                 )
                 return
+            # Propagate the persisted resume_id (if any) so a host that
+            # took over from a crashed predecessor resumes the prior
+            # AgentSession instead of starting a fresh one — the whole
+            # point of session-as-routing-primary.
+            forwarded_body = dict(body)
+            if resume_id is not None:
+                forwarded_body["resume_id"] = resume_id
             forwarded = Envelope(
                 v=WIRE_VERSION,
                 id=f"fwd-{worker_peer}-{int(time.time() * 1_000_000)}",
                 kind=KIND_INBOUND,
                 ts=time.time(),
-                body=dict(body),
+                body=forwarded_body,
                 root_session_key=root_session_key,
                 correlation_id=env.correlation_id,
                 hops=forwarded_hops,
@@ -428,6 +450,21 @@ class WireBridge:
         """
         body = env.body if isinstance(env.body, dict) else {}
 
+        # Side-channel: workers report their AgentSession id back via
+        # ``body["_session_id_hint"]`` on outbound envelopes (the worker
+        # runner adds it after create/resume). We persist it onto the
+        # binding so a future rebind hands the next host the right
+        # resume anchor. Strip the hint before forwarding — chat
+        # clients don't need to see this plumbing.
+        hint = body.pop("_session_id_hint", None) if isinstance(body, dict) else None
+        if isinstance(hint, str) and hint:
+            ch = str(body.get("channel") or "")
+            cid = str(body.get("chat_id") or "")
+            if ch and cid:
+                await asyncio.to_thread(
+                    self._workers.record_resume_id, f"{ch}:{cid}", hint
+                )
+
         # Case 1: approval routing override. Must come before the
         # default path because approval-request bodies still carry a
         # channel field that points at the worker's synthetic channel.
@@ -540,34 +577,6 @@ class WireBridge:
             body={"reason": reason, **extra},
         )
         await asyncio.to_thread(self._outbox.enqueue, peer_id, env)
-
-    async def _emit_worker_lost(self, session_key: str) -> None:
-        """Notify the chat side that the worker holding ``session_key``
-        is gone. Strict policy: the in-flight turn is lost."""
-        channel_name, _, chat_id = session_key.partition(":")
-        if not channel_name or not chat_id:
-            return
-        chat_peer_id = self._channel_to_peer.get(channel_name)
-        if chat_peer_id is None:
-            # Chat already disconnected too — nothing to deliver.
-            return
-        msg = OutboundMessage(
-            channel=channel_name,
-            chat_id=chat_id,
-            content=(
-                "agent worker disconnected; the in-flight turn is lost. "
-                "send your next message to restart."
-            ),
-        )
-        env = _outbound_to_envelope(msg, peer_id=chat_peer_id)
-        await asyncio.to_thread(self._outbox.enqueue, chat_peer_id, env)
-        turn = OutboundMessage(
-            channel=channel_name,
-            chat_id=chat_id,
-            kind=OutboundKind.TURN_COMPLETE,
-        )
-        env2 = _outbound_to_envelope(turn, peer_id=chat_peer_id)
-        await asyncio.to_thread(self._outbox.enqueue, chat_peer_id, env2)
 
     async def _ensure_channel(self, peer_id: str, channel_name: str) -> None:
         existing = self._peer_channels.get(peer_id)

--- a/contrib/channels/src/agentm_channels/worker_registry.py
+++ b/contrib/channels/src/agentm_channels/worker_registry.py
@@ -1,25 +1,30 @@
-"""Gateway-side registry for ``agent_worker`` wire peers.
+"""Gateway-side host pool + persistent session→host binding.
 
-Phase 5a routing surface — see
-``.claude/designs/client-server-architecture.md`` for the topology and
-the brief in ``.claude/plans/2026-05-11-phase5-agent-worker.md`` for
-the policy this module implements (or absence thereof).
+This used to be a "worker registry with an in-memory sticky map".
+The refactor flips the abstraction order:
 
-Policy (minimum-viable):
+* **Session is the primary routable thing.** The persistent binding
+  (``SessionBindingStore``) is what answers "where does this
+  conversation live?".
+* **Hosts are just session storage.** A worker, an inproc gateway
+  loop, or any future ``agent_worker`` peer is interchangeable as
+  long as it can host an ``AgentSession``.
 
-* A worker advertises ``capabilities.scenarios: [<name>, ...]`` at
-  hello. A worker matches an inbound message if its advertised list
-  contains the gateway's currently-configured ``scenario`` string.
-  Equality only — no glob, no version, no LB weight.
-* A ``session_key`` is bound to the first matching worker on first
-  inbound and stays sticky for the rest of that worker's lifetime.
-  When the worker disconnects the binding is released; the next
-  inbound for that session_key picks again from the live pool.
+Routing logic on inbound:
 
-Anything fancier (multi-worker LB, presence-tracked load, scenario
-glob match, sticky persistence across worker restarts) belongs to a
-later phase — keep this surface small per
-``feedback_simple_and_pluggable`` (memory).
+1. Look up the binding for the inbound's ``session_key``.
+2. If bound and host is still online → forward there.
+3. If bound but host is offline → pick any online host advertising
+   the requested scenario, rebind, and forward; the new host receives
+   the binding's ``resume_id`` (if any) and resumes the session so
+   the conversation continues instead of restarting cold.
+4. If no binding exists → pick any online host, write the binding,
+   forward.
+
+Host disconnect does **not** release the binding — that is what lets
+a fresh worker take over the same session on the next inbound. The
+"worker disconnected, in-flight turn lost" surface only fires when
+there is no replacement host *and* the chat is mid-turn.
 """
 
 from __future__ import annotations
@@ -28,12 +33,14 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from .session_bindings import SessionBinding, SessionBindingStore
+
 log = logging.getLogger("agentm_channels.worker_registry")
 
 
 @dataclass
 class WorkerInfo:
-    """One connected ``agent_worker`` peer's capabilities."""
+    """One connected ``agent_worker`` peer's advertised capabilities."""
 
     peer_id: str
     scenarios: frozenset[str]
@@ -42,18 +49,22 @@ class WorkerInfo:
 
 
 class WorkerRegistry:
-    """In-memory registry of connected workers + sticky session bindings.
+    """Online-host set + persistent session bindings.
 
-    Single asyncio loop → no locking. The gateway owns the only
-    instance; ``WireBridge`` reaches into it on hello / disconnect /
-    inbound.
+    Single asyncio loop owns the only instance; ``WireBridge`` calls
+    in on hello / disconnect / inbound dispatch. SQLite work happens
+    on the asyncio thread — callers offload to ``asyncio.to_thread``
+    if they care about not blocking the loop.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, bindings: SessionBindingStore | None = None) -> None:
         self._workers: dict[str, WorkerInfo] = {}
-        self._sticky: dict[str, str] = {}
+        # Default to an in-memory store so tests / quick scripts can
+        # construct a registry without filesystem state. Production
+        # (cli.py) supplies a disk-backed store.
+        self._bindings = bindings or SessionBindingStore(":memory:")
 
-    # -- worker lifecycle --------------------------------------------
+    # -- host lifecycle ----------------------------------------------
 
     def register(self, peer_id: str, capabilities: dict[str, Any]) -> None:
         raw = capabilities or {}
@@ -71,65 +82,93 @@ class WorkerRegistry:
             raw_capabilities=dict(raw),
         )
         log.info(
-            "worker registered peer_id=%s scenarios=%s cwd=%s",
+            "host online peer_id=%s scenarios=%s cwd=%s",
             peer_id,
             sorted(scenarios),
             cwd,
         )
 
     def unregister(self, peer_id: str) -> set[str]:
-        """Drop the worker. Return the set of ``session_key`` that were
-        bound to it — the caller is responsible for notifying chat
-        clients that their in-flight turns are lost."""
+        """Drop the host from the online set. Returns the set of
+        ``session_key`` that *had been* bound to it — useful for
+        diagnostics. The binding rows themselves stay in the store
+        so a new host can pick the session up on the next inbound.
+        """
         self._workers.pop(peer_id, None)
-        lost = {
-            key for key, owner in self._sticky.items() if owner == peer_id
-        }
-        for key in lost:
-            self._sticky.pop(key, None)
-        if lost:
+        stranded = {b.session_key for b in self._bindings.all_for_host(peer_id)}
+        if stranded:
             log.info(
-                "worker unregistered peer_id=%s lost_sessions=%s",
+                "host offline peer_id=%s stranded_sessions=%s (bindings retained)",
                 peer_id,
-                sorted(lost),
+                sorted(stranded),
             )
-        return lost
+        return stranded
 
     # -- routing -----------------------------------------------------
 
-    def find_worker(self, scenario: str, session_key: str) -> str | None:
-        """Look up the worker to receive an inbound for ``session_key``.
+    def find_host(
+        self, scenario: str, session_key: str
+    ) -> tuple[str | None, str | None]:
+        """Resolve the host that should receive an inbound for
+        ``session_key``. Returns ``(host_peer_id, resume_id)``:
 
-        Returns ``None`` when no live worker advertises ``scenario``.
-        Side effect: on a cold session_key the first match is *bound*
-        sticky so subsequent calls within the same turn-stream stay on
-        the same worker.
+        * ``host_peer_id is None`` — no online host advertises
+          ``scenario`` (and no fallback). The bridge should emit a
+          "no host available" outbound.
+        * ``host_peer_id`` set, ``resume_id`` set — the session was
+          previously bound; the host (this one, or another) should
+          resume the prior AgentSession from ``resume_id``.
+        * ``host_peer_id`` set, ``resume_id`` None — first-time
+          binding for this session_key (or the prior host never
+          reported a session_id).
+
+        Side effect: writes the binding when a rebind or first-bind
+        happens, so subsequent inbound traffic stays sticky.
         """
-        sticky_owner = self._sticky.get(session_key)
-        if sticky_owner is not None and sticky_owner in self._workers:
-            return sticky_owner
-        # Stale sticky entry (worker disconnected without unregister
-        # being called yet) → drop and re-pick.
-        if sticky_owner is not None and sticky_owner not in self._workers:
-            self._sticky.pop(session_key, None)
-        # First-match-wins. ``dict`` iteration is insertion-ordered,
-        # so the earliest-connected matching worker is chosen.
+        binding = self._bindings.get(session_key)
+        if binding is not None and binding.host_id in self._workers:
+            # Happy path: bound + online.
+            return binding.host_id, binding.resume_id
+
+        # Need to (re)bind. Pick any online host advertising the scenario.
         for peer_id, info in self._workers.items():
             if scenario in info.scenarios:
-                self._sticky[session_key] = peer_id
-                return peer_id
-        return None
+                # Preserve the existing resume_id if any — that is the
+                # whole point of persistent bindings. Pass resume_id=None
+                # to `upsert` so it doesn't clobber.
+                self._bindings.upsert(session_key, peer_id, resume_id=None)
+                return peer_id, binding.resume_id if binding is not None else None
+        return None, None
 
-    def release_session(self, session_key: str) -> None:
-        self._sticky.pop(session_key, None)
+    def find_worker(self, scenario: str, session_key: str) -> str | None:
+        """Backward-compatible accessor — returns just the host peer_id
+        (drops the resume_id half of ``find_host``). New code should
+        prefer ``find_host`` so it can pass the resume_id through to
+        the destination."""
+        host_id, _ = self.find_host(scenario, session_key)
+        return host_id
+
+    def record_resume_id(self, session_key: str, resume_id: str) -> None:
+        """Workers report their AgentSession id back via outbound
+        metadata; the bridge funnels it here so future rebinds know
+        what to resume."""
+        self._bindings.set_resume_id(session_key, resume_id)
 
     # -- introspection (tests, logging) ------------------------------
 
     def workers(self) -> list[WorkerInfo]:
         return list(self._workers.values())
 
+    def binding(self, session_key: str) -> SessionBinding | None:
+        return self._bindings.get(session_key)
+
     def sticky_owner(self, session_key: str) -> str | None:
-        return self._sticky.get(session_key)
+        """Diagnostic accessor: which host is currently bound to
+        ``session_key``? Returns ``None`` if no binding exists. The
+        host might be offline — callers that need "currently routable"
+        should use ``find_host`` instead, which transparently rebinds."""
+        b = self._bindings.get(session_key)
+        return b.host_id if b is not None else None
 
     def has(self, peer_id: str) -> bool:
         return peer_id in self._workers

--- a/contrib/channels/tests/test_session_bindings.py
+++ b/contrib/channels/tests/test_session_bindings.py
@@ -1,0 +1,109 @@
+"""Tests for the SessionBindingStore — the persistent session → host map.
+
+Fail-stop positions:
+- Round-trip after process restart (the whole point — survive gateway restart).
+- ``upsert`` with ``resume_id=None`` preserves an existing resume_id.
+- ``set_resume_id`` updates only that field.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from agentm_channels.session_bindings import SessionBindingStore
+
+
+def test_get_returns_none_for_missing() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            assert store.get("terminal:t1") is None
+        finally:
+            store.close()
+
+
+def test_upsert_then_get_round_trip() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            store.upsert("terminal:t1", host_id="worker-A", resume_id="sess-001")
+            b = store.get("terminal:t1")
+            assert b is not None
+            assert b.host_id == "worker-A"
+            assert b.resume_id == "sess-001"
+            assert b.last_seen_at > 0
+        finally:
+            store.close()
+
+
+def test_upsert_survives_close_and_reopen() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "b.sqlite"
+        s1 = SessionBindingStore(path)
+        s1.upsert("terminal:t1", host_id="worker-A", resume_id="sess-001")
+        s1.close()
+        # New process, new connection — what gateway restart looks like.
+        s2 = SessionBindingStore(path)
+        try:
+            b = s2.get("terminal:t1")
+            assert b is not None
+            assert b.host_id == "worker-A"
+            assert b.resume_id == "sess-001"
+        finally:
+            s2.close()
+
+
+def test_upsert_none_resume_preserves_existing() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            store.upsert("k", host_id="A", resume_id="sess-1")
+            # Re-bind to a different host without supplying resume_id —
+            # the previously recorded one must NOT be erased.
+            store.upsert("k", host_id="B", resume_id=None)
+            b = store.get("k")
+            assert b is not None
+            assert b.host_id == "B"
+            assert b.resume_id == "sess-1"
+        finally:
+            store.close()
+
+
+def test_set_resume_id_only_updates_that_field() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            store.upsert("k", host_id="A", resume_id=None)
+            store.set_resume_id("k", "sess-42")
+            b = store.get("k")
+            assert b is not None
+            assert b.host_id == "A"
+            assert b.resume_id == "sess-42"
+        finally:
+            store.close()
+
+
+def test_all_for_host_returns_only_matching() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            store.upsert("k1", host_id="A", resume_id="s1")
+            store.upsert("k2", host_id="A", resume_id="s2")
+            store.upsert("k3", host_id="B", resume_id="s3")
+            assert {b.session_key for b in store.all_for_host("A")} == {"k1", "k2"}
+            assert {b.session_key for b in store.all_for_host("B")} == {"k3"}
+            assert store.all_for_host("nope") == []
+        finally:
+            store.close()
+
+
+def test_delete_removes_binding() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = SessionBindingStore(Path(d) / "b.sqlite")
+        try:
+            store.upsert("k", host_id="A", resume_id="s")
+            store.delete("k")
+            assert store.get("k") is None
+        finally:
+            store.close()

--- a/contrib/channels/tests/test_worker_routing.py
+++ b/contrib/channels/tests/test_worker_routing.py
@@ -321,9 +321,107 @@ async def test_sticky_session_key(
         inbox.close()
 
 
-async def test_worker_disconnect_releases_sticky_and_emits_error(
+async def test_resume_id_flows_to_replacement_host_after_disconnect(
     socket_path: str, db_path: str
 ) -> None:
+    """End-to-end resume propagation. Worker-A handles a turn and ships
+    back a ``_session_id_hint`` via outbound; the bridge persists it
+    onto the binding. Worker-A disconnects, worker-B comes online; the
+    next inbound for the same session_key arrives at worker-B with
+    ``body["resume_id"]`` set to whatever A reported. This is the
+    invariant that lets a fresh host pick up a dead host's session."""
+    server, bridge, _bus, outbox, inbox = await _start_server(
+        socket_path, db_path, scenario="x", allow_inproc=False
+    )
+    received_a: list[Envelope] = []
+    received_b: list[Envelope] = []
+
+    async def collect_a(env: Envelope) -> None:
+        received_a.append(env)
+
+    async def collect_b(env: Envelope) -> None:
+        received_b.append(env)
+
+    try:
+        worker_a = WireClient(
+            socket_path=socket_path,
+            peer_id="worker-A",
+            peer_kind="agent_worker",
+            capabilities={"scenarios": ["x"]},
+            on_outbound=collect_a,
+        )
+        await worker_a.connect()
+        assert await _wait(lambda: bridge.worker_registry.has("worker-A"))
+
+        chat = WireClient(
+            socket_path=socket_path, peer_id="chat-A", peer_kind="chat_client"
+        )
+        await chat.connect()
+        await chat.send(_make_inbound(peer_id="chat-A", env_id="m1"))
+        assert await _wait(lambda: len(received_a) >= 1, timeout=2.0)
+
+        # Worker-A reports its AgentSession id back via outbound side-
+        # channel. The bridge writes it onto the binding.
+        await worker_a.send(
+            Envelope(
+                v=WIRE_VERSION,
+                id="out-A-1",
+                kind=KIND_OUTBOUND,
+                ts=time.time(),
+                body={
+                    "channel": "terminal",
+                    "chat_id": "c1",
+                    "content": "ack",
+                    "kind": "message",
+                    "_session_id_hint": "sess-xyz-001",
+                },
+            )
+        )
+        assert await _wait(
+            lambda: (
+                bridge.worker_registry.binding("terminal:c1") is not None
+                and bridge.worker_registry.binding("terminal:c1").resume_id  # type: ignore[union-attr]
+                == "sess-xyz-001"
+            ),
+            timeout=2.0,
+        )
+
+        # Worker-A goes away. Worker-B takes over.
+        await worker_a.close()
+        worker_b = WireClient(
+            socket_path=socket_path,
+            peer_id="worker-B",
+            peer_kind="agent_worker",
+            capabilities={"scenarios": ["x"]},
+            on_outbound=collect_b,
+        )
+        await worker_b.connect()
+        assert await _wait(lambda: bridge.worker_registry.has("worker-B"))
+
+        await chat.send(_make_inbound(peer_id="chat-A", env_id="m2"))
+        assert await _wait(lambda: len(received_b) >= 1, timeout=2.0)
+        # The forwarded envelope to worker-B MUST carry the resume_id
+        # we persisted earlier — otherwise worker-B would start a fresh
+        # AgentSession and the conversation loses context.
+        assert isinstance(received_b[0].body, dict)
+        assert received_b[0].body.get("resume_id") == "sess-xyz-001"
+
+        await chat.close()
+        await worker_b.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+async def test_worker_disconnect_rebinds_silently_on_next_inbound(
+    socket_path: str, db_path: str
+) -> None:
+    """Session-as-routing-primary semantics: when the worker holding a
+    session_key disconnects, the binding STAYS in the persistent store.
+    No "worker disconnected" message is sent to chat. The next inbound
+    for that session_key transparently rebinds to any other online host
+    advertising the same scenario."""
     server, bridge, _bus, outbox, inbox = await _start_server(
         socket_path, db_path, scenario="x", allow_inproc=False
     )
@@ -363,23 +461,20 @@ async def test_worker_disconnect_releases_sticky_and_emits_error(
         assert await _wait(lambda: len(received_a) >= 1, timeout=2.0)
         assert bridge.worker_registry.sticky_owner("terminal:c1") == "worker-A"
 
-        # Worker disconnects mid-turn.
+        # Worker A disconnects. The binding row stays — no message to
+        # chat. Confirm no "worker disconnected" outbound is emitted
+        # (would have arrived within a poll cycle or two if it were
+        # going to).
         await worker_a.close()
-        # Wait for the bridge to observe the disconnect and emit the
-        # strict-policy error outbound to the chat client.
-        ok = await _wait(
-            lambda: any(
-                env.kind == KIND_OUTBOUND
-                and "worker disconnected" in str(env.body.get("content", ""))
-                for env in chat_replies
-            ),
-            timeout=3.0,
-        )
-        assert ok, f"chat replies: {[(e.kind, e.body) for e in chat_replies]}"
-        # Sticky binding must be cleared.
-        assert bridge.worker_registry.sticky_owner("terminal:c1") is None
+        await asyncio.sleep(0.3)
+        assert not any(
+            "worker disconnected" in str(e.body.get("content", ""))
+            for e in chat_replies
+        ), f"unexpected worker-lost message: {chat_replies}"
+        assert bridge.worker_registry.sticky_owner("terminal:c1") == "worker-A"
 
-        # Bring up worker-B and a fresh inbound binds to it.
+        # Bring up worker-B. The next inbound for the same session_key
+        # rebinds to worker-B because worker-A is offline.
         worker_b = WireClient(
             socket_path=socket_path,
             peer_id="worker-B",


### PR DESCRIPTION
## Summary

Flips the abstraction order Phase 5a got backwards: **session is the routable thing; hosts are just session storage.** Replaces the in-memory sticky map (lost on gateway restart, lost on worker disconnect) with a SQLite-backed `SessionBindingStore`. Worker disconnects no longer emit a "worker disconnected" error — the binding stays, the next inbound rebinds, and the new host receives the binding's \`resume_id\` so the conversation continues.

This is the conceptual fix that subsumes Phase 5b candidates #4 (worker restart resumption) and #5 (sticky binding persistence) into a single, cleaner story.

## Conceptual diff (before → after)

| | Before | After |
|---|---|---|
| Primary | worker peer_id | session_key |
| Sticky storage | in-memory dict (`WorkerRegistry._sticky`) | SQLite (`SessionBindingStore`) |
| Gateway restart | loses bindings; chats restart cold | bindings persist; routing resumes |
| Worker disconnect | "worker disconnected; in-flight turn lost" to chat | silent; next inbound transparently rebinds |
| Replacement host | starts a fresh AgentSession (context lost) | receives \`resume_id\`, resumes prior session |
| Phase 5b #4/#5 | open follow-ups | delivered |

## What changed

- New \`SessionBindingStore\` — one SQLite table (\`session_key PK, host_id, resume_id, last_seen_at\`). Lives next to \`wire-outbox.sqlite\`. Supports \`:memory:\` for tests.
- \`WorkerRegistry\` keeps the online-host set, delegates routing to the binding store. New \`find_host\` returns \`(host_id, resume_id)\`. Legacy \`find_worker\` shim preserves the peer-only signature.
- \`WireBridge\` forwards inbound to workers with \`body["resume_id"]\` when the binding has one. Worker outbound carries \`body["_session_id_hint"]\` (side-channel); bridge strips it and writes to the binding.
- Worker runner: reads inbound \`resume_id\` and stamps the local \`chat_session_map\` so the embedded Gateway resumes the AgentSession. Surfaces its local AgentSession id back via \`_session_id_hint\` on every outbound.
- \`cli.py\` wires \`SessionBindingStore(state_dir/"session-bindings.sqlite")\`.

## Tests

| package | passed | new |
|---|---|---|
| channels | **149** | +7 \`test_session_bindings\` + 1 resume-propagation in \`test_worker_routing\` |
| terminal | 11 | — |
| feishu | 25 | — |
| worker | 11 | — |
| **total** | **196** | |

ruff + mypy clean.

### Notable rewrites

- \`test_worker_disconnect_releases_sticky_and_emits_error\` → \`test_worker_disconnect_rebinds_silently_on_next_inbound\`. Old name described old behavior; new test asserts the new contract (no error message; binding survives; next inbound rebinds).

### Key end-to-end invariant test

\`test_resume_id_flows_to_replacement_host_after_disconnect\` — drives worker_A to handle a turn + report its session_id via the hint side-channel, disconnects worker_A, brings worker_B online, sends another inbound for the same session_key, asserts worker_B receives the envelope with \`body["resume_id"]\` set to what A reported. This is the load-bearing correctness check for the whole refactor.

## What was deferred (deliberately not in this PR)

- Collapsing \`ChatSessionMap\` (JSON, inproc-only) into \`SessionBindingStore\` — two stores doing similar jobs. Worth a follow-up but the inproc path is correct as-is.
- Dropping \`--no-inproc-worker\` flag distinction (treat inproc as just another host). Mechanical change but doesn't affect correctness.
- Real multi-worker LB across multiple matching hosts — first-match-wins remains. The conceptual model now supports LB cleanly (the host pick is one localized function); plug in round-robin or least-loaded when there's a deployment that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)