### PR TITLE
feat(channels): WebSocket transport for gateway + clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Precedence per option: **CLI flag > env var > `.env` file > built-in default.**
 | `AGENTM_SCENARIO` | gateway, worker | `--scenario` |
 | `AGENTM_CWD` | gateway, worker | `--cwd` |
 | `AGENTM_SOCKET` | gateway, terminal, worker, feishu | `--bind` / `--connect` |
+| `AGENTM_TOKEN` | worker, terminal, feishu | `--token` |
 | `AGENTM_CONFIG` | gateway | `--config` |
 | `AGENTM_STATE_DIR` | gateway | `--state-dir` |
 | `AGENTM_LOG_LEVEL` | gateway | `--log-level` |

--- a/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
@@ -42,7 +42,7 @@ import typer
 
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
-from agentm_channels.client_cli import ConnectError, resolve_connect
+from agentm_channels.client_cli import ConnectError, ConnectOptions, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_DELIVERY_BATCH,
@@ -332,9 +332,9 @@ def cli(
     try:
         rc = asyncio.run(
             _arun(
-                connect=connect,
-                token=token,
-                tls_ca=tls_ca,
+                connect_opts=ConnectOptions(
+                    connect=connect, token=token, tls_ca=tls_ca
+                ),
                 app_id=app_id,
                 app_secret_path=app_secret,
                 allow_from=allow_from,
@@ -352,16 +352,16 @@ def cli(
 
 async def _arun(
     *,
-    connect: str,
-    token: str | None,
-    tls_ca: str | None,
+    connect_opts: ConnectOptions,
     app_id: str | None,
     app_secret_path: str | None,
     allow_from: list[str] | None,
     chat_id_prefix: str,
     check_config: bool,
 ) -> int:
-    _spec, transport = _resolve_connect(connect, tls_ca)
+    connect = connect_opts.connect
+    token = connect_opts.token
+    _spec, transport = _resolve_connect(connect, connect_opts.tls_ca)
     cfg = _resolve_config(
         app_id=app_id,
         app_secret_path=app_secret_path,

--- a/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
+++ b/contrib/channels-clients/feishu/src/agentm_feishu/cli.py
@@ -37,12 +37,12 @@ import sys
 import uuid
 import warnings
 from typing import Annotated
-from urllib.parse import urlparse
 
 import typer
 
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
+from agentm_channels.client_cli import ConnectError, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_DELIVERY_BATCH,
@@ -86,26 +86,12 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit(code=EXIT_OK)
 
 
-def _parse_connect_url(url: str) -> str:
-    """Return the absolute socket path. Raises ``typer.Exit(2)`` on
-    invalid input (scheme, missing path)."""
-    parsed = urlparse(url)
-    if parsed.scheme != "unix":
-        _err(
-            "bad-argument",
-            f"--connect scheme {parsed.scheme!r} is not supported",
-            "use unix:///abs/path/to/sock (only unix:// is available in v1)",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    socket_path = parsed.path or parsed.netloc
-    if not socket_path or not socket_path.startswith("/"):
-        _err(
-            "bad-argument",
-            f"--connect URL {url!r} has no absolute socket path",
-            "use unix:///abs/path/to/sock",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    return socket_path
+def _resolve_connect(url: str, tls_ca: str | None):
+    try:
+        return resolve_connect(url, tls_ca=tls_ca)
+    except ConnectError as exc:
+        _err("bad-argument", str(exc), "see --help for the supported schemes")
+        raise typer.Exit(code=EXIT_USAGE) from exc
 
 
 def _load_app_secret(path: str | None) -> str | None:
@@ -220,12 +206,34 @@ def cli(
             envvar="AGENTM_SOCKET",
             metavar="URL",
             help=(
-                "Gateway socket URL. v1 supports only unix:///abs/path/to/sock; "
-                "other schemes are rejected with exit 2. Default: shared with "
-                "`agentm-gateway`. Env: AGENTM_SOCKET."
+                "Gateway URL. Supported schemes: unix:///abs/path/to/sock, "
+                "ws://host:port/path, wss://host:port/path. Default: shared "
+                "with `agentm-gateway`. Env: AGENTM_SOCKET."
             ),
         ),
     ] = DEFAULT_SOCKET_URL,
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            envvar="AGENTM_TOKEN",
+            help=(
+                "Bearer token sent in the hello envelope. Required for "
+                "ws/wss gateways with token auth. Env: AGENTM_TOKEN."
+            ),
+        ),
+    ] = None,
+    tls_ca: Annotated[
+        str | None,
+        typer.Option(
+            "--tls-ca",
+            metavar="PATH",
+            help=(
+                "CA bundle (PEM) to verify the gateway certificate. Only "
+                "meaningful with wss://."
+            ),
+        ),
+    ] = None,
     app_id: Annotated[
         str | None,
         typer.Option(
@@ -325,6 +333,8 @@ def cli(
         rc = asyncio.run(
             _arun(
                 connect=connect,
+                token=token,
+                tls_ca=tls_ca,
                 app_id=app_id,
                 app_secret_path=app_secret,
                 allow_from=allow_from,
@@ -343,13 +353,15 @@ def cli(
 async def _arun(
     *,
     connect: str,
+    token: str | None,
+    tls_ca: str | None,
     app_id: str | None,
     app_secret_path: str | None,
     allow_from: list[str] | None,
     chat_id_prefix: str,
     check_config: bool,
 ) -> int:
-    socket_path = _parse_connect_url(connect)
+    _spec, transport = _resolve_connect(connect, tls_ca)
     cfg = _resolve_config(
         app_id=app_id,
         app_secret_path=app_secret_path,
@@ -397,9 +409,10 @@ async def _arun(
             return
 
     client = WireClient(
-        socket_path=socket_path,
+        transport=transport,
         peer_id=peer_id,
         peer_kind="chat_client",
+        token=token,
         on_outbound=on_outbound,
     )
 

--- a/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
+++ b/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
@@ -37,7 +37,7 @@ import typer
 
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
-from agentm_channels.client_cli import ConnectError, resolve_connect
+from agentm_channels.client_cli import ConnectError, ConnectOptions, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_DELIVERY_BATCH,
@@ -245,9 +245,9 @@ def cli(
     try:
         rc = asyncio.run(
             _arun(
-                connect=connect,
-                token=token,
-                tls_ca=tls_ca,
+                connect_opts=ConnectOptions(
+                    connect=connect, token=token, tls_ca=tls_ca
+                ),
                 output_format=output_format,
                 no_color=no_color,
                 sender_id=sender_id,
@@ -265,15 +265,16 @@ def cli(
 
 async def _arun(
     *,
-    connect: str,
-    token: str | None,
-    tls_ca: str | None,
+    connect_opts: ConnectOptions,
     output_format: str | None,
     no_color: bool,
     sender_id: str,
     chat_id: str,
     no_input: bool,
 ) -> int:
+    connect = connect_opts.connect
+    token = connect_opts.token
+    tls_ca = connect_opts.tls_ca
     fmt = _resolve_format(output_format)
     color = _resolve_color(no_color, fmt)
     renderer = (

--- a/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
+++ b/contrib/channels-clients/terminal/src/agentm_terminal/cli.py
@@ -32,12 +32,12 @@ import sys
 import time
 import uuid
 from typing import Annotated, Any
-from urllib.parse import urlparse
 
 import typer
 
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
+from agentm_channels.client_cli import ConnectError, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_DELIVERY_BATCH,
@@ -109,26 +109,13 @@ def _resolve_color(no_color_flag: bool, fmt: str) -> bool:
     return sys.stdout.isatty()
 
 
-def _parse_connect_url(url: str) -> str:
-    """Return the absolute socket path. Raises ``typer.Exit(2)`` on
-    invalid input (scheme, missing path)."""
-    parsed = urlparse(url)
-    if parsed.scheme != "unix":
-        _err(
-            "bad-argument",
-            f"--connect scheme {parsed.scheme!r} is not supported",
-            "use unix:///abs/path/to/sock (only unix:// is available in v1)",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    socket_path = parsed.path or parsed.netloc
-    if not socket_path or not socket_path.startswith("/"):
-        _err(
-            "bad-argument",
-            f"--connect URL {url!r} has no absolute socket path",
-            "use unix:///abs/path/to/sock",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    return socket_path
+def _resolve_connect(url: str, tls_ca: str | None):
+    """Wrap :func:`resolve_connect` with CLI-shaped error reporting."""
+    try:
+        return resolve_connect(url, tls_ca=tls_ca)
+    except ConnectError as exc:
+        _err("bad-argument", str(exc), "see --help for the supported schemes")
+        raise typer.Exit(code=EXIT_USAGE) from exc
 
 
 @app.command()
@@ -140,13 +127,36 @@ def cli(
             envvar="AGENTM_SOCKET",
             metavar="URL",
             help=(
-                "Gateway socket URL. v1 supports only unix:///abs/path/to/sock; "
-                "other schemes are rejected with exit 2. Default: shared with "
-                "`agentm-gateway` ($XDG_RUNTIME_DIR/agentm-gw.sock if set, else "
-                "/tmp/agentm-gw-<uid>.sock). Env: AGENTM_SOCKET."
+                "Gateway URL. Supported schemes: unix:///abs/path/to/sock, "
+                "ws://host:port/path, wss://host:port/path. Default: shared "
+                "with `agentm-gateway` ($XDG_RUNTIME_DIR/agentm-gw.sock if "
+                "set, else /tmp/agentm-gw-<uid>.sock). Env: AGENTM_SOCKET."
             ),
         ),
     ] = DEFAULT_SOCKET_URL,
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            envvar="AGENTM_TOKEN",
+            help=(
+                "Bearer token sent in the hello envelope. Required for "
+                "ws/wss gateways with token auth. Env: AGENTM_TOKEN. "
+                "Note: visible in `ps`; prefer the env variable."
+            ),
+        ),
+    ] = None,
+    tls_ca: Annotated[
+        str | None,
+        typer.Option(
+            "--tls-ca",
+            metavar="PATH",
+            help=(
+                "CA bundle (PEM) to verify the gateway certificate. Only "
+                "meaningful with wss://. Default: system trust store."
+            ),
+        ),
+    ] = None,
     output_format: Annotated[
         str | None,
         typer.Option(
@@ -236,6 +246,8 @@ def cli(
         rc = asyncio.run(
             _arun(
                 connect=connect,
+                token=token,
+                tls_ca=tls_ca,
                 output_format=output_format,
                 no_color=no_color,
                 sender_id=sender_id,
@@ -254,6 +266,8 @@ def cli(
 async def _arun(
     *,
     connect: str,
+    token: str | None,
+    tls_ca: str | None,
     output_format: str | None,
     no_color: bool,
     sender_id: str,
@@ -269,7 +283,7 @@ async def _arun(
         asyncio.Queue() if fmt == "textual" else None
     )
 
-    socket_path = _parse_connect_url(connect)
+    _spec, transport = _resolve_connect(connect, tls_ca)
 
     # Peer id: stable-ish within a single run. The gateway uses this as
     # the synthetic channel name registered on the bus; pairing it with
@@ -319,9 +333,10 @@ async def _arun(
             return
 
     client = WireClient(
-        socket_path=socket_path,
+        transport=transport,
         peer_id=peer_id,
         peer_kind="chat_client",
+        token=token,
         on_outbound=on_outbound,
     )
 

--- a/contrib/channels-clients/worker/src/agentm_worker/cli.py
+++ b/contrib/channels-clients/worker/src/agentm_worker/cli.py
@@ -35,7 +35,7 @@ import typer
 from agentm.core.abi import EventBus
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
-from agentm_channels.client_cli import ConnectError, resolve_connect
+from agentm_channels.client_cli import ConnectError, ConnectOptions, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_ERROR,
@@ -286,9 +286,9 @@ def cli(
     try:
         rc = asyncio.run(
             _arun(
-                connect=connect,
-                token=token,
-                tls_ca=tls_ca,
+                connect_opts=ConnectOptions(
+                    connect=connect, token=token, tls_ca=tls_ca
+                ),
                 scenarios=scenarios,
                 cwd=resolved_cwd,
                 provider=provider,
@@ -306,16 +306,16 @@ def cli(
 
 async def _arun(
     *,
-    connect: str,
-    token: str | None,
-    tls_ca: str | None,
+    connect_opts: ConnectOptions,
     scenarios: list[str],
     cwd: str,
     provider: str | None,
     model: str | None,
     max_concurrency: int,
 ) -> int:
-    _spec, transport = _resolve_connect(connect, tls_ca)
+    connect = connect_opts.connect
+    token = connect_opts.token
+    _spec, transport = _resolve_connect(connect, connect_opts.tls_ca)
 
     peer_id = f"worker-{uuid.uuid4().hex[:8]}"
 

--- a/contrib/channels-clients/worker/src/agentm_worker/cli.py
+++ b/contrib/channels-clients/worker/src/agentm_worker/cli.py
@@ -29,13 +29,13 @@ import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlparse
 
 import typer
 
 from agentm.core.abi import EventBus
 from agentm_channels import DEFAULT_SOCKET_URL, autoload_dotenv
 from agentm_channels.client import AuthError, WireClient
+from agentm_channels.client_cli import ConnectError, resolve_connect
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_ERROR,
@@ -75,24 +75,12 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit(code=EXIT_OK)
 
 
-def _parse_connect_url(url: str) -> str:
-    parsed = urlparse(url)
-    if parsed.scheme != "unix":
-        _err(
-            "bad-argument",
-            f"--connect scheme {parsed.scheme!r} is not supported",
-            "use unix:///abs/path/to/sock (only unix:// is available in v1)",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    socket_path = parsed.path or parsed.netloc
-    if not socket_path or not socket_path.startswith("/"):
-        _err(
-            "bad-argument",
-            f"--connect URL {url!r} has no absolute socket path",
-            "use unix:///abs/path/to/sock",
-        )
-        raise typer.Exit(code=EXIT_USAGE)
-    return socket_path
+def _resolve_connect(url: str, tls_ca: str | None):
+    try:
+        return resolve_connect(url, tls_ca=tls_ca)
+    except ConnectError as exc:
+        _err("bad-argument", str(exc), "see --help for the supported schemes")
+        raise typer.Exit(code=EXIT_USAGE) from exc
 
 
 # -- session factory --------------------------------------------------
@@ -163,12 +151,34 @@ def cli(
             envvar="AGENTM_SOCKET",
             metavar="URL",
             help=(
-                "Gateway socket URL. v1 supports only unix:///abs/path/to/sock; "
-                "other schemes are rejected with exit 2. Default: shared with "
-                "`agentm-gateway`. Env: AGENTM_SOCKET."
+                "Gateway URL. Supported schemes: unix:///abs/path/to/sock, "
+                "ws://host:port/path, wss://host:port/path. Default: shared "
+                "with `agentm-gateway`. Env: AGENTM_SOCKET."
             ),
         ),
     ] = DEFAULT_SOCKET_URL,
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            envvar="AGENTM_TOKEN",
+            help=(
+                "Bearer token sent in the hello envelope. Required for "
+                "ws/wss gateways with token auth. Env: AGENTM_TOKEN."
+            ),
+        ),
+    ] = None,
+    tls_ca: Annotated[
+        str | None,
+        typer.Option(
+            "--tls-ca",
+            metavar="PATH",
+            help=(
+                "CA bundle (PEM) to verify the gateway certificate. Only "
+                "meaningful with wss://."
+            ),
+        ),
+    ] = None,
     scenario: Annotated[
         list[str] | None,
         typer.Option(
@@ -277,6 +287,8 @@ def cli(
         rc = asyncio.run(
             _arun(
                 connect=connect,
+                token=token,
+                tls_ca=tls_ca,
                 scenarios=scenarios,
                 cwd=resolved_cwd,
                 provider=provider,
@@ -295,13 +307,15 @@ def cli(
 async def _arun(
     *,
     connect: str,
+    token: str | None,
+    tls_ca: str | None,
     scenarios: list[str],
     cwd: str,
     provider: str | None,
     model: str | None,
     max_concurrency: int,
 ) -> int:
-    socket_path = _parse_connect_url(connect)
+    _spec, transport = _resolve_connect(connect, tls_ca)
 
     peer_id = f"worker-{uuid.uuid4().hex[:8]}"
 
@@ -341,9 +355,10 @@ async def _arun(
             stop_event.set()
 
     client = WireClient(
-        socket_path=socket_path,
+        transport=transport,
         peer_id=peer_id,
         peer_kind="agent_worker",
+        token=token,
         on_outbound=on_outbound,
         capabilities={"scenarios": scenarios, "cwd": cwd},
     )

--- a/contrib/channels/README.md
+++ b/contrib/channels/README.md
@@ -64,6 +64,44 @@ options and the literal `value=…` next to each. Type `=<value>` (e.g.
 `=approval-deadbeef:approve`) to click. Less ergonomic than a Feishu
 button, but exercises the exact same code path.
 
+## Cross-host (WebSocket) quickstart
+
+The gateway also speaks WebSocket so workers / clients can connect over
+the network. Authentication is by bearer token — each client must
+present a token from the gateway's allow-list.
+
+```bash
+# Pick / generate tokens, one per line. Blank lines and lines starting
+# with '#' are ignored.
+install -m 0600 /dev/stdin /etc/agentm/tokens <<'EOF'
+# alice's worker
+2c8f9d3a1e4b6f7c2a5d9e1f3b4c7a2d
+# bob's terminal
+8e1d2c4b6a9f3e5d7c1b4a6e9d2f5c8b
+EOF
+
+# Plaintext (terminate TLS in nginx or another reverse proxy):
+agentm-gateway --bind ws://0.0.0.0:7777/agentm \
+    --bind-token-file /etc/agentm/tokens
+
+# Or wss directly:
+agentm-gateway --bind wss://0.0.0.0:7777/agentm \
+    --bind-token-file /etc/agentm/tokens \
+    --tls-cert /etc/agentm/cert.pem --tls-key /etc/agentm/key.pem
+
+# Clients pass the token via env (avoids leaking through `ps`):
+AGENTM_TOKEN="$(sed -n '/^[^#]/p;q' /etc/agentm/tokens)" \
+  agentm-worker --connect ws://gw.example.com:7777/agentm
+```
+
+Reverse-proxying through nginx is supported out of the box because
+each WebSocket binary frame carries exactly one already-framed wire
+envelope — the proxy only needs the standard `proxy_set_header
+Upgrade`/`Connection` block and TLS termination. No example config is
+shipped; the standard
+[`websockets`](https://websockets.readthedocs.io/en/stable/topics/deployment.html)
+recipe applies.
+
 > **Deprecated:** the v0 in-process `channels:` yaml block still loads
 > for backwards compatibility, but emits a `DeprecationWarning` (and
 > an `agentm-gateway: warn: …` line on stderr at startup) and will be

--- a/contrib/channels/pyproject.toml
+++ b/contrib/channels/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyyaml>=6",
     "python-dotenv>=1.0",
     "typer>=0.25.1",
-    "websockets>=12",
+    "websockets>=13",
 ]
 
 [project.optional-dependencies]

--- a/contrib/channels/pyproject.toml
+++ b/contrib/channels/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml>=6",
     "python-dotenv>=1.0",
     "typer>=0.25.1",
+    "websockets>=12",
 ]
 
 [project.optional-dependencies]

--- a/contrib/channels/src/agentm_channels/auth/__init__.py
+++ b/contrib/channels/src/agentm_channels/auth/__init__.py
@@ -13,5 +13,6 @@ the only supported deployment shape in v1.
 from __future__ import annotations
 
 from .peercred import UnixPeerCredAuthenticator
+from .token import TokenAuthenticator
 
-__all__ = ["UnixPeerCredAuthenticator"]
+__all__ = ["TokenAuthenticator", "UnixPeerCredAuthenticator"]

--- a/contrib/channels/src/agentm_channels/auth/token.py
+++ b/contrib/channels/src/agentm_channels/auth/token.py
@@ -1,0 +1,57 @@
+"""Bearer-token :class:`Authenticator`.
+
+Reads ``hello.body.token`` (passed into ``authenticate`` by the server
+— see ``server._handle_connection``) and matches it against a static
+allow-list. An empty allow-list rejects every connection, mirroring
+the ``UnixPeerCredAuthenticator(set())`` "circuit breaker" shape.
+
+Tokens are matched verbatim; rotation/expiry is out of scope (see
+``.claude/plans/2026-05-12-gateway-websocket-transport.md``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+log = logging.getLogger("agentm_channels.auth")
+
+
+class TokenAuthenticator:
+    """Accept connections whose ``hello.body.token`` is in
+    ``allowed_tokens``.
+
+    Args:
+        allowed_tokens: A set of acceptable bearer tokens. An empty
+            set denies all (circuit-breaker).
+    """
+
+    def __init__(self, allowed_tokens: set[str]) -> None:
+        self._allowed_tokens = set(allowed_tokens)
+
+    async def authenticate(
+        self,
+        peer_kind: str,
+        peer_id: str,
+        token: str | None,
+        transport: asyncio.StreamWriter,  # noqa: ARG002 — token auth ignores transport
+    ) -> bool:
+        if token is None or token == "":
+            log.warning(
+                "token reject: peer=%s kind=%s — no token presented",
+                peer_id,
+                peer_kind,
+            )
+            return False
+        if token in self._allowed_tokens:
+            log.info("token accept: peer=%s kind=%s", peer_id, peer_kind)
+            return True
+        log.warning(
+            "token reject: peer=%s kind=%s — token not in allow-list",
+            peer_id,
+            peer_kind,
+        )
+        return False
+
+
+__all__ = ["TokenAuthenticator"]

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -212,12 +212,14 @@ class BindSpec:
     For unix scheme: ``socket_path`` is set, ``allow_uids`` of ``None``
     means any-uid (peer-cred reads the kernel uid but doesn't filter).
 
-    For ws/wss scheme: ``host`` / ``port`` / ``path`` are set, ``tokens``
+    For ws/wss scheme: ``host`` / ``port`` / ``url`` are set, ``tokens``
     holds the bearer-token allow-list (empty set when anonymous mode
-    is explicitly opted into via ``--bind-allow-anonymous``). TLS
-    material on the server side is cert + key only; there is no
-    client-cert verification today (a server ``--tls-ca`` knob would
-    be a premature feature).
+    is explicitly opted into via ``--bind-allow-anonymous``). The
+    request path is not gated server-side — a reverse proxy owns URL
+    routing — but the original URL is kept on ``url`` for log/check
+    output. TLS material on the server side is cert + key only; there
+    is no client-cert verification today (a server ``--tls-ca`` knob
+    would be a premature feature).
     """
 
     scheme: str
@@ -227,7 +229,7 @@ class BindSpec:
     # ws / wss
     host: str = ""
     port: int = 0
-    ws_path: str = "/"
+    url: str = ""
     tokens: frozenset[str] = frozenset()
     allow_anonymous: bool = False
     tls_cert: str | None = None
@@ -381,13 +383,13 @@ def _resolve_bind(
 
     host = parsed.hostname or "0.0.0.0"
     port = parsed.port or (443 if scheme == "wss" else 80)
-    ws_path = parsed.path or "/"
+    bind_url = f"{scheme}://{host}:{port}{parsed.path or '/'}"
 
     return BindSpec(
         scheme=scheme,
         host=host,
         port=port,
-        ws_path=ws_path,
+        url=bind_url,
         tokens=frozenset(tokens),
         allow_anonymous=bool(bind_allow_anonymous) and not tokens,
         tls_cert=eff_tls_cert,
@@ -411,7 +413,6 @@ def _build_server_transport(spec: BindSpec) -> ServerTransport:
     return WebSocketServerTransport(
         host=spec.host,
         port=spec.port,
-        path=spec.ws_path,
         ssl_context=ssl_context,
     )
 
@@ -811,10 +812,7 @@ async def _arun(
         else:
             bind_payload = {
                 "scheme": bind_spec.scheme,
-                "url": (
-                    f"{bind_spec.scheme}://{bind_spec.host}:{bind_spec.port}"
-                    f"{bind_spec.ws_path}"
-                ),
+                "url": bind_spec.url,
                 "token_count": len(bind_spec.tokens),
                 "allow_anonymous": bind_spec.allow_anonymous,
                 "tls": bind_spec.scheme == "wss",
@@ -878,11 +876,8 @@ async def _arun(
         )
     else:
         logger.info(
-            "wire server bound at %s://%s:%d%s (auth=%s)",
-            bind_spec.scheme,
-            bind_spec.host,
-            bind_spec.port,
-            bind_spec.ws_path,
+            "wire server bound at %s (auth=%s)",
+            bind_spec.url,
             "anonymous"
             if bind_spec.allow_anonymous
             else f"token({len(bind_spec.tokens)})",

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -55,13 +55,18 @@ from agentm.core.abi import EventBus
 
 from . import DEFAULT_SOCKET_URL, autoload_dotenv
 from .approval import ApprovalPolicy
-from .auth import UnixPeerCredAuthenticator
+from .auth import TokenAuthenticator, UnixPeerCredAuthenticator
 from .bus import MessageBus
 from .gateway import Gateway, GatewayConfig
 from .manager import ChannelManager
 from .outbox import SqliteInbox, SqliteOutbox
-from .server import WireServer
+from .server import Authenticator, WireServer
 from .session_bindings import SessionBindingStore
+from .transport import (
+    ServerTransport,
+    UnixServerTransport,
+    WebSocketServerTransport,
+)
 from .wire_bridge import DEFAULT_MAX_A2A_HOPS, WireBridge
 
 # Pull ``.env`` keys into ``os.environ`` BEFORE typer parses argv. The
@@ -202,11 +207,48 @@ def _build_session_factory(
 
 @dataclass(frozen=True)
 class BindSpec:
-    """Resolved ``--bind`` configuration. ``allow_uids`` of ``None``
-    means any-uid (peer-cred reads the kernel uid but doesn't filter)."""
+    """Resolved ``--bind`` configuration.
 
-    socket_path: str
-    allow_uids: frozenset[int] | None
+    For unix scheme: ``socket_path`` is set, ``allow_uids`` of ``None``
+    means any-uid (peer-cred reads the kernel uid but doesn't filter).
+
+    For ws/wss scheme: ``host`` / ``port`` / ``path`` are set, ``tokens``
+    holds the bearer-token allow-list (empty set when anonymous mode
+    is explicitly opted into via ``--bind-allow-anonymous``).
+    """
+
+    scheme: str
+    # unix
+    socket_path: str = ""
+    allow_uids: frozenset[int] | None = frozenset()
+    # ws / wss
+    host: str = ""
+    port: int = 0
+    ws_path: str = "/"
+    tokens: frozenset[str] = frozenset()
+    allow_anonymous: bool = False
+    tls_cert: str | None = None
+    tls_key: str | None = None
+    tls_ca: str | None = None
+
+
+def _load_tokens_file(path: str) -> set[str]:
+    """One token per line; blank lines and lines starting with ``#``
+    are skipped. Raises ``SystemExit`` on read errors.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(
+            f"--bind-token-file {path!r}: cannot read: {exc.strerror or exc}"
+        ) from exc
+    tokens: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        tokens.add(line)
+    return tokens
 
 
 def _resolve_bind(
@@ -214,64 +256,181 @@ def _resolve_bind(
     bind: str | None,
     bind_allow_uid: list[int] | None,
     bind_allow_any_uid: bool,
+    bind_token_file: str | None = None,
+    bind_allow_anonymous: bool = False,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
     cfg: dict[str, Any],
 ) -> BindSpec:
     """Merge CLI flags > yaml ``bind:`` section > shared default.
 
-    The gateway is always a wire-protocol daemon: when neither the CLI
-    flag nor the YAML ``bind:`` section sets a socket, fall back to
-    :data:`DEFAULT_SOCKET_URL`. Raises :class:`SystemExit` (exit code 2)
-    on invalid input — TCP scheme, or conflicting allow-uid flags.
+    Supports three schemes: ``unix://``, ``ws://``, ``wss://``. Raises
+    :class:`SystemExit` (exit code 2) on invalid input — unknown scheme,
+    conflicting flags, TLS-with-unix, wss-without-cert, or ws/wss
+    without token configuration.
     """
     yaml_bind = cfg.get("bind") if isinstance(cfg.get("bind"), dict) else None
     yaml_url = (yaml_bind or {}).get("socket")
     url = bind or yaml_url or DEFAULT_SOCKET_URL
     parsed = urlparse(str(url))
-    if parsed.scheme != "unix":
-        raise SystemExit(
-            f"--bind scheme {parsed.scheme!r} not supported; only unix:// is "
-            "available in v1 (TCP is deferred per "
-            ".claude/designs/client-server-architecture.md §5.2)."
-        )
-    socket_path = parsed.path or parsed.netloc
-    if not socket_path:
-        raise SystemExit(
-            f"--bind {url!r} has no socket path; use unix:///abs/path/to/sock"
-        )
+    scheme = parsed.scheme
 
-    cli_uids = list(bind_allow_uid or ())
-    cli_any = bool(bind_allow_any_uid)
-    if cli_uids and cli_any:
-        raise SystemExit(
-            "--bind-allow-uid and --bind-allow-any-uid are mutually exclusive."
-        )
+    yaml_token_auth = (yaml_bind or {}).get("token_auth") if yaml_bind else None
+    yaml_token_auth = yaml_token_auth if isinstance(yaml_token_auth, dict) else None
+    yaml_tls = (yaml_bind or {}).get("tls") if yaml_bind else None
+    yaml_tls = yaml_tls if isinstance(yaml_tls, dict) else None
 
-    if cli_uids or cli_any:
-        allow_uids: frozenset[int] | None = (
-            None if cli_any else frozenset(int(x) for x in cli_uids)
-        )
-    elif yaml_bind is not None and (
-        "allow_uids" in yaml_bind or "allow_any_uid" in yaml_bind
-    ):
-        if yaml_bind.get("allow_any_uid") and yaml_bind.get("allow_uids"):
+    eff_tls_cert = tls_cert or (yaml_tls.get("cert") if yaml_tls else None)
+    eff_tls_key = tls_key or (yaml_tls.get("key") if yaml_tls else None)
+    eff_tls_ca = tls_ca or (yaml_tls.get("ca") if yaml_tls else None)
+
+    if scheme == "unix":
+        if eff_tls_cert or eff_tls_key or eff_tls_ca:
             raise SystemExit(
-                "bind.allow_uids and bind.allow_any_uid are mutually exclusive."
+                "--tls-cert/--tls-key/--tls-ca are only valid with ws://wss:// binds, "
+                f"not {url!r}."
             )
-        if yaml_bind.get("allow_any_uid"):
-            allow_uids = None
-        else:
-            raw = yaml_bind.get("allow_uids") or []
-            if not isinstance(raw, list):
-                raise SystemExit("bind.allow_uids must be a list of integers.")
-            try:
-                allow_uids = frozenset(int(x) for x in raw)
-            except (TypeError, ValueError) as exc:
-                raise SystemExit(f"bind.allow_uids: invalid entry: {exc}") from exc
-    else:
-        # Most-secure default: current process uid only.
-        allow_uids = frozenset({os.geteuid()})
+        socket_path = parsed.path or parsed.netloc
+        if not socket_path:
+            raise SystemExit(
+                f"--bind {url!r} has no socket path; use unix:///abs/path/to/sock"
+            )
 
-    return BindSpec(socket_path=socket_path, allow_uids=allow_uids)
+        cli_uids = list(bind_allow_uid or ())
+        cli_any = bool(bind_allow_any_uid)
+        if cli_uids and cli_any:
+            raise SystemExit(
+                "--bind-allow-uid and --bind-allow-any-uid are mutually exclusive."
+            )
+
+        if cli_uids or cli_any:
+            allow_uids: frozenset[int] | None = (
+                None if cli_any else frozenset(int(x) for x in cli_uids)
+            )
+        elif yaml_bind is not None and (
+            "allow_uids" in yaml_bind or "allow_any_uid" in yaml_bind
+        ):
+            if yaml_bind.get("allow_any_uid") and yaml_bind.get("allow_uids"):
+                raise SystemExit(
+                    "bind.allow_uids and bind.allow_any_uid are mutually exclusive."
+                )
+            if yaml_bind.get("allow_any_uid"):
+                allow_uids = None
+            else:
+                raw = yaml_bind.get("allow_uids") or []
+                if not isinstance(raw, list):
+                    raise SystemExit("bind.allow_uids must be a list of integers.")
+                try:
+                    allow_uids = frozenset(int(x) for x in raw)
+                except (TypeError, ValueError) as exc:
+                    raise SystemExit(
+                        f"bind.allow_uids: invalid entry: {exc}"
+                    ) from exc
+        else:
+            # Most-secure default: current process uid only.
+            allow_uids = frozenset({os.geteuid()})
+
+        return BindSpec(
+            scheme="unix",
+            socket_path=socket_path,
+            allow_uids=allow_uids,
+        )
+
+    if scheme not in ("ws", "wss"):
+        raise SystemExit(
+            f"--bind scheme {scheme!r} not supported; use unix://, ws://, or wss://."
+        )
+
+    if scheme == "wss" and (not eff_tls_cert or not eff_tls_key):
+        raise SystemExit(
+            "wss:// bind requires --tls-cert and --tls-key (or bind.tls.cert/"
+            "bind.tls.key in YAML)."
+        )
+    if scheme == "ws" and (eff_tls_cert or eff_tls_key):
+        raise SystemExit(
+            "ws:// bind cannot use TLS; switch to wss:// or remove --tls-*."
+        )
+
+    # Token resolution: CLI flag > YAML.
+    cli_any_uid = bool(bind_allow_uid) or bool(bind_allow_any_uid)
+    if cli_any_uid:
+        raise SystemExit(
+            "--bind-allow-uid / --bind-allow-any-uid are unix-only; "
+            "use --bind-token-file with ws://wss://."
+        )
+
+    tokens: set[str] = set()
+    if bind_token_file:
+        tokens.update(_load_tokens_file(bind_token_file))
+    elif yaml_token_auth is not None:
+        yaml_tokens = yaml_token_auth.get("tokens")
+        yaml_tokens_file = yaml_token_auth.get("tokens_file")
+        if isinstance(yaml_tokens, list):
+            tokens.update(str(t).strip() for t in yaml_tokens if str(t).strip())
+        if yaml_tokens_file:
+            tokens.update(_load_tokens_file(str(yaml_tokens_file)))
+
+    if not tokens and not bind_allow_anonymous:
+        raise SystemExit(
+            f"{scheme}:// bind requires --bind-token-file (or "
+            "bind.token_auth in YAML). Pass --bind-allow-anonymous to "
+            "opt out (NOT recommended — anyone reachable on the network "
+            "can drive the gateway)."
+        )
+
+    host = parsed.hostname or "0.0.0.0"
+    port = parsed.port or (443 if scheme == "wss" else 80)
+    ws_path = parsed.path or "/"
+
+    return BindSpec(
+        scheme=scheme,
+        host=host,
+        port=port,
+        ws_path=ws_path,
+        tokens=frozenset(tokens),
+        allow_anonymous=bool(bind_allow_anonymous) and not tokens,
+        tls_cert=eff_tls_cert,
+        tls_key=eff_tls_key,
+        tls_ca=eff_tls_ca,
+    )
+
+
+def _build_server_transport(spec: BindSpec) -> ServerTransport:
+    """Materialize a :class:`ServerTransport` for an already-validated
+    :class:`BindSpec`. Pure factory — no side effects beyond constructing
+    the transport (no socket bind yet)."""
+    if spec.scheme == "unix":
+        return UnixServerTransport(spec.socket_path)
+    ssl_context = None
+    if spec.scheme == "wss":
+        import ssl
+
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        assert spec.tls_cert is not None and spec.tls_key is not None
+        ssl_context.load_cert_chain(certfile=spec.tls_cert, keyfile=spec.tls_key)
+        if spec.tls_ca:
+            ssl_context.load_verify_locations(cafile=spec.tls_ca)
+    return WebSocketServerTransport(
+        host=spec.host,
+        port=spec.port,
+        path=spec.ws_path,
+        ssl_context=ssl_context,
+    )
+
+
+def _build_bind_authenticator(spec: BindSpec) -> Authenticator:
+    if spec.scheme == "unix":
+        return UnixPeerCredAuthenticator(
+            allowed_uids=set(spec.allow_uids)
+            if spec.allow_uids is not None
+            else None
+        )
+    if spec.allow_anonymous:
+        from .server import AllowAllAuthenticator
+
+        return AllowAllAuthenticator()
+    return TokenAuthenticator(allowed_tokens=set(spec.tokens))
 
 
 # -------- typer app -----------------------------------------------------
@@ -364,12 +523,62 @@ def cli(
             "--bind",
             envvar="AGENTM_SOCKET",
             help=(
-                "Run the wire-protocol server on the given URL. v1 supports "
-                "only unix:///abs/path/to/sock. Default: $XDG_RUNTIME_DIR/"
-                "agentm-gw.sock or /tmp/agentm-gw-<uid>.sock. Authentication "
-                "is Unix peer-cred; by default only the current process's uid "
-                "may connect — override with --bind-allow-uid or "
-                "--bind-allow-any-uid. Env: AGENTM_SOCKET."
+                "Run the wire-protocol server on the given URL. Supported: "
+                "unix:///abs/path/to/sock (default; peer-cred auth, current uid "
+                "only unless --bind-allow-uid / --bind-allow-any-uid), "
+                "ws://host:port/path (token auth, plaintext — reverse-proxy "
+                "for TLS), wss://host:port/path (token auth, TLS via "
+                "--tls-cert/--tls-key). Env: AGENTM_SOCKET."
+            ),
+        ),
+    ] = None,
+    bind_token_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--bind-token-file",
+            metavar="PATH",
+            help=(
+                "Path to a file containing one bearer token per line "
+                "(blank lines and '#' comments are skipped). Required for "
+                "ws://wss:// binds unless --bind-allow-anonymous is set."
+            ),
+        ),
+    ] = None,
+    bind_allow_anonymous: Annotated[
+        bool,
+        typer.Option(
+            "--bind-allow-anonymous",
+            help=(
+                "Allow ws/wss bind without tokens. NOT recommended — anyone "
+                "reachable on the network can drive the gateway. Intended "
+                "for behind-a-trusted-reverse-proxy setups only."
+            ),
+        ),
+    ] = False,
+    tls_cert: Annotated[
+        Path | None,
+        typer.Option(
+            "--tls-cert",
+            metavar="PATH",
+            help="TLS certificate (PEM) for wss:// binds. Required for wss://.",
+        ),
+    ] = None,
+    tls_key: Annotated[
+        Path | None,
+        typer.Option(
+            "--tls-key",
+            metavar="PATH",
+            help="TLS private key (PEM) for wss:// binds. Required for wss://.",
+        ),
+    ] = None,
+    tls_ca: Annotated[
+        Path | None,
+        typer.Option(
+            "--tls-ca",
+            metavar="PATH",
+            help=(
+                "Optional CA bundle (PEM). Loaded into the server SSL context "
+                "for future client-cert verification; not enforced today."
             ),
         ),
     ] = None,
@@ -447,6 +656,11 @@ def cli(
 
       agentm-gateway --bind unix:///tmp/gw.sock --config gw.yaml
       agentm-terminal --connect unix:///tmp/gw.sock
+
+    For cross-host deployments, use WebSocket:
+
+      agentm-gateway --bind ws://0.0.0.0:7777/agentm --bind-token-file /etc/agentm/tokens
+      agentm-worker  --connect ws://gw.example.com:7777/agentm --token "$AGENTM_TOKEN"
     """
     logging.basicConfig(
         level=getattr(logging, str(log_level).upper(), logging.INFO),
@@ -467,6 +681,11 @@ def cli(
                 bind=bind,
                 bind_allow_uid=bind_allow_uid,
                 bind_allow_any_uid=bind_allow_any_uid,
+                bind_token_file=str(bind_token_file) if bind_token_file else None,
+                bind_allow_anonymous=bind_allow_anonymous,
+                tls_cert=str(tls_cert) if tls_cert else None,
+                tls_key=str(tls_key) if tls_key else None,
+                tls_ca=str(tls_ca) if tls_ca else None,
                 inproc_worker=not no_inproc_worker,
                 max_a2a_hops=max_a2a_hops,
                 check=check,
@@ -502,6 +721,11 @@ async def _arun(
     bind: str | None,
     bind_allow_uid: list[int] | None,
     bind_allow_any_uid: bool,
+    bind_token_file: str | None,
+    bind_allow_anonymous: bool,
+    tls_cert: str | None,
+    tls_key: str | None,
+    tls_ca: str | None,
     inproc_worker: bool,
     max_a2a_hops: int,
     check: bool,
@@ -523,6 +747,11 @@ async def _arun(
         bind=bind,
         bind_allow_uid=bind_allow_uid,
         bind_allow_any_uid=bind_allow_any_uid,
+        bind_token_file=bind_token_file,
+        bind_allow_anonymous=bind_allow_anonymous,
+        tls_cert=tls_cert,
+        tls_key=tls_key,
+        tls_ca=tls_ca,
         cfg=cfg,
     )
 
@@ -585,18 +814,33 @@ async def _arun(
 
     if check:
         logger.info("config OK: channels=%s", sorted(manager.channels))
-        check_payload: dict[str, Any] = {
-            "kind": "check",
-            "channels": sorted(manager.channels),
-            "state_dir": str(resolved_state_dir),
-            "bind": {
+        bind_payload: dict[str, Any]
+        if bind_spec.scheme == "unix":
+            bind_payload = {
+                "scheme": "unix",
                 "socket": f"unix://{bind_spec.socket_path}",
                 "allow_uids": (
                     sorted(bind_spec.allow_uids)
                     if bind_spec.allow_uids is not None
                     else None
                 ),
-            },
+            }
+        else:
+            bind_payload = {
+                "scheme": bind_spec.scheme,
+                "url": (
+                    f"{bind_spec.scheme}://{bind_spec.host}:{bind_spec.port}"
+                    f"{bind_spec.ws_path}"
+                ),
+                "token_count": len(bind_spec.tokens),
+                "allow_anonymous": bind_spec.allow_anonymous,
+                "tls": bind_spec.scheme == "wss",
+            }
+        check_payload: dict[str, Any] = {
+            "kind": "check",
+            "channels": sorted(manager.channels),
+            "state_dir": str(resolved_state_dir),
+            "bind": bind_payload,
         }
         sys.stdout.write(json.dumps(check_payload) + "\n")
         sys.stdout.flush()
@@ -628,13 +872,10 @@ async def _arun(
         allow_inproc=inproc_worker,
         max_a2a_hops=int(max_a2a_hops),
     )
-    authenticator = UnixPeerCredAuthenticator(
-        allowed_uids=set(bind_spec.allow_uids)
-        if bind_spec.allow_uids is not None
-        else None
-    )
+    authenticator = _build_bind_authenticator(bind_spec)
+    server_transport = _build_server_transport(bind_spec)
     wire_server = WireServer(
-        socket_path=bind_spec.socket_path,
+        transport=server_transport,
         outbox=wire_outbox,
         inbox=wire_inbox,
         on_inbound=bridge.handle_inbound,
@@ -644,13 +885,25 @@ async def _arun(
         on_worker_outbound=bridge.handle_worker_outbound,
     )
     await wire_server.start()
-    logger.info(
-        "wire server bound at unix://%s (allow_uids=%s)",
-        bind_spec.socket_path,
-        sorted(bind_spec.allow_uids)
-        if bind_spec.allow_uids is not None
-        else "any",
-    )
+    if bind_spec.scheme == "unix":
+        logger.info(
+            "wire server bound at unix://%s (allow_uids=%s)",
+            bind_spec.socket_path,
+            sorted(bind_spec.allow_uids)
+            if bind_spec.allow_uids is not None
+            else "any",
+        )
+    else:
+        logger.info(
+            "wire server bound at %s://%s:%d%s (auth=%s)",
+            bind_spec.scheme,
+            bind_spec.host,
+            bind_spec.port,
+            bind_spec.ws_path,
+            "anonymous"
+            if bind_spec.allow_anonymous
+            else f"token({len(bind_spec.tokens)})",
+        )
 
     logger.info(
         "gateway running with channels: %s", sorted(manager.channels) or "(none)"

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -214,7 +214,10 @@ class BindSpec:
 
     For ws/wss scheme: ``host`` / ``port`` / ``path`` are set, ``tokens``
     holds the bearer-token allow-list (empty set when anonymous mode
-    is explicitly opted into via ``--bind-allow-anonymous``).
+    is explicitly opted into via ``--bind-allow-anonymous``). TLS
+    material on the server side is cert + key only; there is no
+    client-cert verification today (a server ``--tls-ca`` knob would
+    be a premature feature).
     """
 
     scheme: str
@@ -229,7 +232,6 @@ class BindSpec:
     allow_anonymous: bool = False
     tls_cert: str | None = None
     tls_key: str | None = None
-    tls_ca: str | None = None
 
 
 def _load_tokens_file(path: str) -> set[str]:
@@ -260,7 +262,6 @@ def _resolve_bind(
     bind_allow_anonymous: bool = False,
     tls_cert: str | None = None,
     tls_key: str | None = None,
-    tls_ca: str | None = None,
     cfg: dict[str, Any],
 ) -> BindSpec:
     """Merge CLI flags > yaml ``bind:`` section > shared default.
@@ -283,12 +284,11 @@ def _resolve_bind(
 
     eff_tls_cert = tls_cert or (yaml_tls.get("cert") if yaml_tls else None)
     eff_tls_key = tls_key or (yaml_tls.get("key") if yaml_tls else None)
-    eff_tls_ca = tls_ca or (yaml_tls.get("ca") if yaml_tls else None)
 
     if scheme == "unix":
-        if eff_tls_cert or eff_tls_key or eff_tls_ca:
+        if eff_tls_cert or eff_tls_key:
             raise SystemExit(
-                "--tls-cert/--tls-key/--tls-ca are only valid with ws://wss:// binds, "
+                "--tls-cert/--tls-key are only valid with ws://wss:// binds, "
                 f"not {url!r}."
             )
         socket_path = parsed.path or parsed.netloc
@@ -392,7 +392,6 @@ def _resolve_bind(
         allow_anonymous=bool(bind_allow_anonymous) and not tokens,
         tls_cert=eff_tls_cert,
         tls_key=eff_tls_key,
-        tls_ca=eff_tls_ca,
     )
 
 
@@ -409,8 +408,6 @@ def _build_server_transport(spec: BindSpec) -> ServerTransport:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         assert spec.tls_cert is not None and spec.tls_key is not None
         ssl_context.load_cert_chain(certfile=spec.tls_cert, keyfile=spec.tls_key)
-        if spec.tls_ca:
-            ssl_context.load_verify_locations(cafile=spec.tls_ca)
     return WebSocketServerTransport(
         host=spec.host,
         port=spec.port,
@@ -571,17 +568,6 @@ def cli(
             help="TLS private key (PEM) for wss:// binds. Required for wss://.",
         ),
     ] = None,
-    tls_ca: Annotated[
-        Path | None,
-        typer.Option(
-            "--tls-ca",
-            metavar="PATH",
-            help=(
-                "Optional CA bundle (PEM). Loaded into the server SSL context "
-                "for future client-cert verification; not enforced today."
-            ),
-        ),
-    ] = None,
     bind_allow_uid: Annotated[
         list[int] | None,
         typer.Option(
@@ -685,7 +671,6 @@ def cli(
                 bind_allow_anonymous=bind_allow_anonymous,
                 tls_cert=str(tls_cert) if tls_cert else None,
                 tls_key=str(tls_key) if tls_key else None,
-                tls_ca=str(tls_ca) if tls_ca else None,
                 inproc_worker=not no_inproc_worker,
                 max_a2a_hops=max_a2a_hops,
                 check=check,
@@ -725,7 +710,6 @@ async def _arun(
     bind_allow_anonymous: bool,
     tls_cert: str | None,
     tls_key: str | None,
-    tls_ca: str | None,
     inproc_worker: bool,
     max_a2a_hops: int,
     check: bool,
@@ -751,7 +735,6 @@ async def _arun(
         bind_allow_anonymous=bind_allow_anonymous,
         tls_cert=tls_cert,
         tls_key=tls_key,
-        tls_ca=tls_ca,
         cfg=cfg,
     )
 

--- a/contrib/channels/src/agentm_channels/cli.py
+++ b/contrib/channels/src/agentm_channels/cli.py
@@ -206,6 +206,24 @@ def _build_session_factory(
 
 
 @dataclass(frozen=True)
+class BindOptions:
+    """Raw bind-related typer arguments, before resolution.
+
+    ``BindSpec`` is the *resolved* shape (after YAML/CLI/defaults merge);
+    ``BindOptions`` is the *raw* shape the typer callback collects so we
+    don't push 8 kwargs through ``_arun``'s signature.
+    """
+
+    bind: str | None = None
+    bind_allow_uid: list[int] | None = None
+    bind_allow_any_uid: bool = False
+    bind_token_file: str | None = None
+    bind_allow_anonymous: bool = False
+    tls_cert: str | None = None
+    tls_key: str | None = None
+
+
+@dataclass(frozen=True)
 class BindSpec:
     """Resolved ``--bind`` configuration.
 
@@ -656,6 +674,16 @@ def cli(
 
     resolved_cwd = cwd or str(Path.cwd())
 
+    bind_opts = BindOptions(
+        bind=bind,
+        bind_allow_uid=bind_allow_uid,
+        bind_allow_any_uid=bind_allow_any_uid,
+        bind_token_file=str(bind_token_file) if bind_token_file else None,
+        bind_allow_anonymous=bind_allow_anonymous,
+        tls_cert=str(tls_cert) if tls_cert else None,
+        tls_key=str(tls_key) if tls_key else None,
+    )
+
     try:
         rc = asyncio.run(
             _arun(
@@ -665,13 +693,7 @@ def cli(
                 state_dir=state_dir,
                 provider_flag=provider,
                 model_flag=model,
-                bind=bind,
-                bind_allow_uid=bind_allow_uid,
-                bind_allow_any_uid=bind_allow_any_uid,
-                bind_token_file=str(bind_token_file) if bind_token_file else None,
-                bind_allow_anonymous=bind_allow_anonymous,
-                tls_cert=str(tls_cert) if tls_cert else None,
-                tls_key=str(tls_key) if tls_key else None,
+                bind_opts=bind_opts,
                 inproc_worker=not no_inproc_worker,
                 max_a2a_hops=max_a2a_hops,
                 check=check,
@@ -704,13 +726,7 @@ async def _arun(
     state_dir: Path | None,
     provider_flag: str | None,
     model_flag: str | None,
-    bind: str | None,
-    bind_allow_uid: list[int] | None,
-    bind_allow_any_uid: bool,
-    bind_token_file: str | None,
-    bind_allow_anonymous: bool,
-    tls_cert: str | None,
-    tls_key: str | None,
+    bind_opts: BindOptions,
     inproc_worker: bool,
     max_a2a_hops: int,
     check: bool,
@@ -729,13 +745,13 @@ async def _arun(
         resolved_cwd = cwd
 
     bind_spec = _resolve_bind(
-        bind=bind,
-        bind_allow_uid=bind_allow_uid,
-        bind_allow_any_uid=bind_allow_any_uid,
-        bind_token_file=bind_token_file,
-        bind_allow_anonymous=bind_allow_anonymous,
-        tls_cert=tls_cert,
-        tls_key=tls_key,
+        bind=bind_opts.bind,
+        bind_allow_uid=bind_opts.bind_allow_uid,
+        bind_allow_any_uid=bind_opts.bind_allow_any_uid,
+        bind_token_file=bind_opts.bind_token_file,
+        bind_allow_anonymous=bind_opts.bind_allow_anonymous,
+        tls_cert=bind_opts.tls_cert,
+        tls_key=bind_opts.tls_key,
         cfg=cfg,
     )
 

--- a/contrib/channels/src/agentm_channels/client.py
+++ b/contrib/channels/src/agentm_channels/client.py
@@ -57,30 +57,27 @@ class WireClient:
 
     def __init__(
         self,
-        socket_path_or_transport: str | ClientTransport | None = None,
-        peer_id: str = "",
-        peer_kind: str = "",
         *,
-        socket_path: str | None = None,
+        peer_id: str,
+        peer_kind: str,
         transport: ClientTransport | None = None,
+        socket_path: str | None = None,
         token: str | None = None,
         on_outbound: OutboundHandler | None = None,
         capabilities: dict[str, Any] | None = None,
     ) -> None:
-        # Back-compat positional shim: callers historically passed
-        # ``WireClient(socket_path, peer_id, peer_kind, ...)``. New
-        # callers may pass ``transport=`` (or ``socket_path=``) by keyword.
-        if isinstance(socket_path_or_transport, str):
-            if socket_path is None:
-                socket_path = socket_path_or_transport
-        elif socket_path_or_transport is not None:
-            transport = socket_path_or_transport
+        # ``socket_path=`` is a Unix-socket convenience shortcut equivalent to
+        # ``transport=UnixClientTransport(socket_path)``; pass exactly one.
         if transport is None:
             if socket_path is None:
                 raise TypeError(
                     "WireClient requires either transport= or socket_path="
                 )
             transport = UnixClientTransport(socket_path)
+        elif socket_path is not None:
+            raise TypeError(
+                "WireClient: pass either transport= or socket_path=, not both"
+            )
         self._transport = transport
         self._peer_id = peer_id
         self._peer_kind = peer_kind

--- a/contrib/channels/src/agentm_channels/client.py
+++ b/contrib/channels/src/agentm_channels/client.py
@@ -19,6 +19,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from agentm_channels.transport import ClientTransport, UnixClientTransport
 from agentm_channels.wire import (
     KIND_BYE,
     KIND_DELIVERY_BATCH,
@@ -56,15 +57,31 @@ class WireClient:
 
     def __init__(
         self,
-        socket_path: str,
-        peer_id: str,
-        peer_kind: str,
+        socket_path_or_transport: str | ClientTransport | None = None,
+        peer_id: str = "",
+        peer_kind: str = "",
         *,
+        socket_path: str | None = None,
+        transport: ClientTransport | None = None,
         token: str | None = None,
         on_outbound: OutboundHandler | None = None,
         capabilities: dict[str, Any] | None = None,
     ) -> None:
-        self._socket_path = socket_path
+        # Back-compat positional shim: callers historically passed
+        # ``WireClient(socket_path, peer_id, peer_kind, ...)``. New
+        # callers may pass ``transport=`` (or ``socket_path=``) by keyword.
+        if isinstance(socket_path_or_transport, str):
+            if socket_path is None:
+                socket_path = socket_path_or_transport
+        elif socket_path_or_transport is not None:
+            transport = socket_path_or_transport
+        if transport is None:
+            if socket_path is None:
+                raise TypeError(
+                    "WireClient requires either transport= or socket_path="
+                )
+            transport = UnixClientTransport(socket_path)
+        self._transport = transport
         self._peer_id = peer_id
         self._peer_kind = peer_kind
         self._token = token
@@ -80,9 +97,7 @@ class WireClient:
     # -- lifecycle ----------------------------------------------------
 
     async def connect(self) -> None:
-        self._reader, self._writer = await asyncio.open_unix_connection(
-            path=self._socket_path
-        )
+        self._reader, self._writer = await self._transport.connect()
         hello = Envelope(
             v=WIRE_VERSION,
             id=f"hello-{self._peer_id}-{int(time.time() * 1000)}",

--- a/contrib/channels/src/agentm_channels/client_cli.py
+++ b/contrib/channels/src/agentm_channels/client_cli.py
@@ -28,6 +28,18 @@ class ConnectSpec:
     uri: str = ""  # ws/wss
 
 
+@dataclass(frozen=True)
+class ConnectOptions:
+    """Raw client-side ``--connect`` typer arguments before resolution.
+
+    Per-CLI ``_arun`` helpers take this in place of three loose kwargs.
+    """
+
+    connect: str
+    token: str | None = None
+    tls_ca: str | None = None
+
+
 def resolve_connect(
     url: str,
     *,
@@ -73,4 +85,4 @@ def resolve_connect(
     )
 
 
-__all__ = ["ConnectError", "ConnectSpec", "resolve_connect"]
+__all__ = ["ConnectError", "ConnectOptions", "ConnectSpec", "resolve_connect"]

--- a/contrib/channels/src/agentm_channels/client_cli.py
+++ b/contrib/channels/src/agentm_channels/client_cli.py
@@ -1,0 +1,76 @@
+"""Shared client-side ``--connect`` resolver.
+
+The terminal / worker / feishu CLIs all parse the same set of URL
+schemes and TLS knobs. Centralizing the dispatch keeps their per-CLI
+help text consistent and the error messages identical.
+"""
+
+from __future__ import annotations
+
+import ssl
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from .transport import ClientTransport, UnixClientTransport, WebSocketClientTransport
+
+
+class ConnectError(ValueError):
+    """Raised when the ``--connect`` URL is malformed or paired with
+    incompatible flags (e.g. ``--tls-ca`` on a unix:// URL)."""
+
+
+@dataclass(frozen=True)
+class ConnectSpec:
+    """Resolved client-side endpoint."""
+
+    scheme: str
+    socket_path: str = ""  # unix
+    uri: str = ""  # ws/wss
+
+
+def resolve_connect(
+    url: str,
+    *,
+    tls_ca: str | None = None,
+) -> tuple[ConnectSpec, ClientTransport]:
+    """Parse ``url`` and return (spec, transport).
+
+    Raises :class:`ConnectError` with a human-readable message on bad input.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme
+    if scheme == "unix":
+        if tls_ca:
+            raise ConnectError(
+                "--tls-ca is only meaningful with wss:// (got unix://)."
+            )
+        socket_path = parsed.path or parsed.netloc
+        if not socket_path or not socket_path.startswith("/"):
+            raise ConnectError(
+                f"--connect URL {url!r} has no absolute socket path"
+            )
+        return (
+            ConnectSpec(scheme="unix", socket_path=socket_path),
+            UnixClientTransport(socket_path),
+        )
+    if scheme in ("ws", "wss"):
+        if scheme == "ws" and tls_ca:
+            raise ConnectError(
+                "--tls-ca is only meaningful with wss:// (got ws://)."
+            )
+        ssl_context: ssl.SSLContext | None = None
+        if scheme == "wss":
+            ssl_context = ssl.create_default_context()
+            if tls_ca:
+                ssl_context.load_verify_locations(cafile=tls_ca)
+        return (
+            ConnectSpec(scheme=scheme, uri=url),
+            WebSocketClientTransport(url, ssl_context=ssl_context),
+        )
+    raise ConnectError(
+        f"--connect scheme {scheme!r} is not supported; "
+        "use unix://, ws://, or wss://."
+    )
+
+
+__all__ = ["ConnectError", "ConnectSpec", "resolve_connect"]

--- a/contrib/channels/src/agentm_channels/server.py
+++ b/contrib/channels/src/agentm_channels/server.py
@@ -144,13 +144,12 @@ class WireServer:
 
     def __init__(
         self,
-        outbox_or_socket: OutboxStore | str | None = None,
-        outbox: OutboxStore | None = None,
-        inbox: InboxLog | None = None,
-        on_inbound: InboundHandler | None = None,
         *,
-        socket_path: str | None = None,
+        outbox: OutboxStore,
+        inbox: InboxLog,
+        on_inbound: InboundHandler,
         transport: ServerTransport | None = None,
+        socket_path: str | None = None,
         authenticator: Authenticator | None = None,
         delivery_batch_max: int = 32,
         lease_ttl: float = 30.0,
@@ -160,25 +159,18 @@ class WireServer:
         on_peer_disconnect: PeerDisconnectHandler | None = None,
         on_worker_outbound: WorkerOutboundHandler | None = None,
     ) -> None:
-        # Back-compat positional shim: callers that historically passed
-        # ``WireServer(socket_path, outbox, inbox, on_inbound)`` still work.
-        # New callers pass ``transport=`` (or ``socket_path=``) by keyword
-        # along with ``outbox=``/``inbox=``/``on_inbound=``.
-        if isinstance(outbox_or_socket, str):
-            if socket_path is None:
-                socket_path = outbox_or_socket
-        elif outbox_or_socket is not None:
-            outbox = outbox_or_socket
-        if outbox is None or inbox is None or on_inbound is None:
-            raise TypeError(
-                "WireServer requires outbox, inbox, and on_inbound arguments"
-            )
+        # ``socket_path=`` is a Unix-socket convenience shortcut equivalent to
+        # ``transport=UnixServerTransport(socket_path)``; pass exactly one.
         if transport is None:
             if socket_path is None:
                 raise TypeError(
                     "WireServer requires either transport= or socket_path="
                 )
             transport = UnixServerTransport(socket_path)
+        elif socket_path is not None:
+            raise TypeError(
+                "WireServer: pass either transport= or socket_path=, not both"
+            )
         # Peer-cred auth depends on AF_UNIX kernel credentials; pairing
         # it with a WebSocket transport would silently degrade to
         # rejection-of-everything (no socket extra_info), which is

--- a/contrib/channels/src/agentm_channels/server.py
+++ b/contrib/channels/src/agentm_channels/server.py
@@ -37,7 +37,12 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
-from agentm_channels.transport import ServerTransport, UnixServerTransport
+from agentm_channels.auth import UnixPeerCredAuthenticator
+from agentm_channels.transport import (
+    ServerTransport,
+    UnixServerTransport,
+    WebSocketServerTransport,
+)
 from agentm_channels.outbox import (
     InboxLog,
     OutboxRecord,
@@ -174,6 +179,17 @@ class WireServer:
                     "WireServer requires either transport= or socket_path="
                 )
             transport = UnixServerTransport(socket_path)
+        # Peer-cred auth depends on AF_UNIX kernel credentials; pairing
+        # it with a WebSocket transport would silently degrade to
+        # rejection-of-everything (no socket extra_info), which is
+        # confusing. Fail fast at construction.
+        if isinstance(transport, WebSocketServerTransport) and isinstance(
+            authenticator, UnixPeerCredAuthenticator
+        ):
+            raise ValueError(
+                "UnixPeerCredAuthenticator is incompatible with "
+                "WebSocketServerTransport; use TokenAuthenticator over WS"
+            )
         self._transport = transport
         self._outbox = outbox
         self._inbox = inbox

--- a/contrib/channels/src/agentm_channels/server.py
+++ b/contrib/channels/src/agentm_channels/server.py
@@ -37,6 +37,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
+from agentm_channels.transport import ServerTransport, UnixServerTransport
 from agentm_channels.outbox import (
     InboxLog,
     OutboxRecord,
@@ -138,11 +139,13 @@ class WireServer:
 
     def __init__(
         self,
-        socket_path: str,
-        outbox: OutboxStore,
-        inbox: InboxLog,
-        on_inbound: InboundHandler,
+        outbox_or_socket: OutboxStore | str | None = None,
+        outbox: OutboxStore | None = None,
+        inbox: InboxLog | None = None,
+        on_inbound: InboundHandler | None = None,
         *,
+        socket_path: str | None = None,
+        transport: ServerTransport | None = None,
         authenticator: Authenticator | None = None,
         delivery_batch_max: int = 32,
         lease_ttl: float = 30.0,
@@ -152,7 +155,26 @@ class WireServer:
         on_peer_disconnect: PeerDisconnectHandler | None = None,
         on_worker_outbound: WorkerOutboundHandler | None = None,
     ) -> None:
-        self._socket_path = socket_path
+        # Back-compat positional shim: callers that historically passed
+        # ``WireServer(socket_path, outbox, inbox, on_inbound)`` still work.
+        # New callers pass ``transport=`` (or ``socket_path=``) by keyword
+        # along with ``outbox=``/``inbox=``/``on_inbound=``.
+        if isinstance(outbox_or_socket, str):
+            if socket_path is None:
+                socket_path = outbox_or_socket
+        elif outbox_or_socket is not None:
+            outbox = outbox_or_socket
+        if outbox is None or inbox is None or on_inbound is None:
+            raise TypeError(
+                "WireServer requires outbox, inbox, and on_inbound arguments"
+            )
+        if transport is None:
+            if socket_path is None:
+                raise TypeError(
+                    "WireServer requires either transport= or socket_path="
+                )
+            transport = UnixServerTransport(socket_path)
+        self._transport = transport
         self._outbox = outbox
         self._inbox = inbox
         self._on_inbound = on_inbound
@@ -185,7 +207,7 @@ class WireServer:
             _next_retry_at_min if callable(_next_retry_at_min) else lambda _peer_id: None
         )
         self._registry = PeerRegistry()
-        self._server: asyncio.base_events.Server | None = None
+        self._started = False
         self._stopped = False
         self._conn_tasks: set[asyncio.Task[None]] = set()
         self._delivery_tasks: dict[str, asyncio.Task[None]] = {}
@@ -199,26 +221,17 @@ class WireServer:
     # -- lifecycle ----------------------------------------------------
 
     async def start(self) -> None:
-        if self._server is not None:
+        if self._started:
             return
-        # Clean any stale socket left by a crashed predecessor.
-        with contextlib.suppress(FileNotFoundError):
-            if os.path.exists(self._socket_path):
-                os.unlink(self._socket_path)
         self._loop = asyncio.get_running_loop()
-        self._server = await asyncio.start_unix_server(
-            self._handle_connection, path=self._socket_path
-        )
+        await self._transport.serve(self._handle_connection)
+        self._started = True
 
     async def stop(self) -> None:
         if self._stopped:
             return
         self._stopped = True
-        if self._server is not None:
-            self._server.close()
-            with contextlib.suppress(Exception):
-                await self._server.wait_closed()
-            self._server = None
+        await self._transport.close()
         # Cancel all delivery workers and connection tasks.
         for task in list(self._delivery_tasks.values()):
             task.cancel()
@@ -231,8 +244,6 @@ class WireServer:
                 await task
         self._delivery_tasks.clear()
         self._conn_tasks.clear()
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(self._socket_path)
 
     @property
     def registry(self) -> PeerRegistry:

--- a/contrib/channels/src/agentm_channels/transport/__init__.py
+++ b/contrib/channels/src/agentm_channels/transport/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from .base import ClientTransport, ConnectionHandler, ServerTransport
 from .unix import UnixClientTransport, UnixServerTransport
+from .websocket import WebSocketClientTransport, WebSocketServerTransport
 
 __all__ = [
     "ClientTransport",
@@ -17,4 +18,6 @@ __all__ = [
     "ServerTransport",
     "UnixClientTransport",
     "UnixServerTransport",
+    "WebSocketClientTransport",
+    "WebSocketServerTransport",
 ]

--- a/contrib/channels/src/agentm_channels/transport/__init__.py
+++ b/contrib/channels/src/agentm_channels/transport/__init__.py
@@ -1,0 +1,20 @@
+"""Transport abstraction for the channels wire layer.
+
+PR1 of `.claude/plans/2026-05-12-gateway-websocket-transport.md`:
+extract the Unix-socket plumbing out of :class:`WireServer` /
+:class:`WireClient` behind a transport-agnostic interface. PR2 will
+add a WebSocket implementation alongside :mod:`unix`.
+"""
+
+from __future__ import annotations
+
+from .base import ClientTransport, ConnectionHandler, ServerTransport
+from .unix import UnixClientTransport, UnixServerTransport
+
+__all__ = [
+    "ClientTransport",
+    "ConnectionHandler",
+    "ServerTransport",
+    "UnixClientTransport",
+    "UnixServerTransport",
+]

--- a/contrib/channels/src/agentm_channels/transport/_stream_adapter.py
+++ b/contrib/channels/src/agentm_channels/transport/_stream_adapter.py
@@ -21,6 +21,7 @@ We target the modern :mod:`websockets.asyncio` connection class
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 
 from websockets.asyncio.connection import Connection
@@ -104,6 +105,10 @@ class WebSocketStreamWriter:
         self._ws = ws
         self._buf = bytearray()
         self._closed = False
+        # ``close()`` schedules an async ws.close() task; we keep a
+        # reference so ``wait_closed()`` can join it (and so the loop
+        # doesn't garbage-collect it mid-flight).
+        self._close_task: asyncio.Task[None] | None = None
 
     def write(self, data: bytes) -> None:
         if self._closed:
@@ -129,11 +134,16 @@ class WebSocketStreamWriter:
     def close(self) -> None:
         self._closed = True
         if self._ws.close_code is None:
-            # ``Connection.close()`` is async; fire-and-forget here to
-            # match the sync ``StreamWriter.close()`` contract.
-            asyncio.get_event_loop().create_task(self._ws.close())
+            # ``Connection.close()`` is async; schedule it on the running
+            # loop to match the sync ``StreamWriter.close()`` contract,
+            # and stash the task so ``wait_closed()`` can join it.
+            loop = asyncio.get_running_loop()
+            self._close_task = loop.create_task(self._ws.close())
 
     async def wait_closed(self) -> None:
+        if self._close_task is not None:
+            with contextlib.suppress(Exception):
+                await self._close_task
         try:
             await self._ws.wait_closed()
         except Exception:

--- a/contrib/channels/src/agentm_channels/transport/_stream_adapter.py
+++ b/contrib/channels/src/agentm_channels/transport/_stream_adapter.py
@@ -1,0 +1,152 @@
+"""asyncio StreamReader/StreamWriter shims over a ``websockets`` connection.
+
+The wire layer expects an :class:`asyncio.StreamReader` /
+:class:`asyncio.StreamWriter` byte stream — see ``wire/framing.py`` and
+``server._read_one_frame``. WebSocket connections speak in discrete
+*messages*, not a byte stream, so we bridge the two while preserving
+the "one envelope per WebSocket message" invariant (Phase 2 design,
+``.claude/plans/2026-05-12-gateway-websocket-transport.md``).
+
+The reader pulls binary messages on demand and exposes them as a
+contiguous byte buffer to ``readexactly``. The writer accumulates the
+framing bytes a caller writes and flushes them as a single
+``ws.send(bytes)`` call when ``drain()`` is invoked — one wire frame
+(length-prefix header + JSON body) maps to one WS binary message.
+
+We target the modern :mod:`websockets.asyncio` connection class
+(``websockets>=13``) — that's what :func:`websockets.serve` and
+:func:`websockets.connect` return.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from websockets.asyncio.connection import Connection
+from websockets.exceptions import ConnectionClosed
+
+
+class WebSocketStreamReader:
+    """asyncio-StreamReader-shaped reader over a WebSocket connection.
+
+    Only the subset that the framing reader needs is implemented —
+    today that is :meth:`readexactly` (see ``server._read_one_frame``).
+    Closure surfaces as :class:`asyncio.IncompleteReadError`, matching
+    ``StreamReader.readexactly`` semantics.
+    """
+
+    def __init__(self, ws: Connection) -> None:
+        self._ws = ws
+        self._buf = bytearray()
+        self._eof = False
+
+    async def read(self, n: int = -1) -> bytes:
+        """Up-to-``n`` bytes; returns ``b""`` on close (StreamReader contract).
+
+        Used by ``server._read_loop`` / ``client._read_loop`` for the
+        bulk streaming path. If the buffer is empty we await one
+        binary message; otherwise we return whatever's buffered (up to
+        ``n``) immediately to keep latency low.
+        """
+        if not self._buf:
+            if self._eof:
+                return b""
+            try:
+                msg = await self._ws.recv()
+            except ConnectionClosed:
+                self._eof = True
+                return b""
+            if isinstance(msg, str):
+                self._eof = True
+                return b""
+            self._buf.extend(msg)
+        if n < 0 or n >= len(self._buf):
+            out = bytes(self._buf)
+            self._buf.clear()
+            return out
+        out = bytes(self._buf[:n])
+        del self._buf[:n]
+        return out
+
+    async def readexactly(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            if self._eof:
+                raise asyncio.IncompleteReadError(bytes(self._buf), n)
+            try:
+                msg = await self._ws.recv()
+            except ConnectionClosed:
+                self._eof = True
+                raise asyncio.IncompleteReadError(bytes(self._buf), n) from None
+            if isinstance(msg, str):
+                # Wire is binary-only by contract; a text frame is a
+                # protocol violation → behave like EOF.
+                self._eof = True
+                raise asyncio.IncompleteReadError(bytes(self._buf), n)
+            self._buf.extend(msg)
+        out = bytes(self._buf[:n])
+        del self._buf[:n]
+        return out
+
+
+class WebSocketStreamWriter:
+    """asyncio-StreamWriter-shaped writer over a WebSocket connection.
+
+    ``write()`` is synchronous and just buffers bytes. ``drain()``
+    flushes everything accumulated so far as ONE binary message, which
+    preserves the wire invariant that one framed envelope == one WS
+    message. The wire ``_send`` helper writes the full encoded
+    envelope before awaiting drain, so the buffer holds exactly one
+    frame at that point.
+    """
+
+    def __init__(self, ws: Connection) -> None:
+        self._ws = ws
+        self._buf = bytearray()
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        if self._closed:
+            raise ConnectionResetError("writer is closed")
+        self._buf.extend(data)
+
+    async def drain(self) -> None:
+        if not self._buf:
+            return
+        payload = bytes(self._buf)
+        self._buf.clear()
+        try:
+            await self._ws.send(payload)
+        except ConnectionClosed as exc:
+            raise ConnectionResetError("websocket closed") from exc
+
+    def is_closing(self) -> bool:
+        # ``Connection`` does not expose a public ``closed`` flag on all
+        # versions, but ``close_code`` becomes non-None once closing
+        # starts.
+        return self._closed or self._ws.close_code is not None
+
+    def close(self) -> None:
+        self._closed = True
+        if self._ws.close_code is None:
+            # ``Connection.close()`` is async; fire-and-forget here to
+            # match the sync ``StreamWriter.close()`` contract.
+            asyncio.get_event_loop().create_task(self._ws.close())
+
+    async def wait_closed(self) -> None:
+        try:
+            await self._ws.wait_closed()
+        except Exception:
+            pass
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        # Peer-cred auth calls ``get_extra_info("socket")``; WS has no
+        # AF_UNIX peer credential, so we return ``default`` and rely on
+        # the server's startup-time isinstance check to refuse the
+        # pairing entirely.
+        if name == "peername":
+            return self._ws.remote_address
+        return default
+
+
+__all__ = ["WebSocketStreamReader", "WebSocketStreamWriter"]

--- a/contrib/channels/src/agentm_channels/transport/base.py
+++ b/contrib/channels/src/agentm_channels/transport/base.py
@@ -1,0 +1,47 @@
+"""Transport protocols for the channels wire layer.
+
+The wire framing (length-prefixed JSON envelopes, see
+:mod:`agentm_channels.wire`) is transport-agnostic; this module pins
+down the seam between the framing-aware server/client and the
+underlying byte stream. Implementations expose the connection as an
+:class:`asyncio.StreamReader` / :class:`asyncio.StreamWriter` pair so
+the existing ``_read_one_frame`` / ``_send`` helpers work unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+ConnectionHandler = Callable[
+    [asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]
+]
+
+
+@runtime_checkable
+class ServerTransport(Protocol):
+    """Bind-side transport: accepts connections and dispatches them."""
+
+    async def serve(self, handle: ConnectionHandler) -> None:
+        """Start accepting connections; return once listening.
+
+        Each accepted connection invokes ``handle(reader, writer)`` as a
+        task owned by the transport.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Stop accepting; release listener-level resources. Idempotent."""
+        ...
+
+
+@runtime_checkable
+class ClientTransport(Protocol):
+    """Connect-side transport: opens a single byte-stream connection."""
+
+    async def connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        ...
+
+
+__all__ = ["ClientTransport", "ConnectionHandler", "ServerTransport"]

--- a/contrib/channels/src/agentm_channels/transport/unix.py
+++ b/contrib/channels/src/agentm_channels/transport/unix.py
@@ -1,0 +1,66 @@
+"""Unix-socket implementations of :class:`ServerTransport` and
+:class:`ClientTransport`.
+
+Behaviour is identical to the pre-PR1 inline logic in ``server.py`` /
+``client.py``: the server cleans a stale socket file on bind and on
+close; the client opens via :func:`asyncio.open_unix_connection`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+
+from .base import ConnectionHandler
+
+
+class UnixServerTransport:
+    """Bind to an `AF_UNIX` socket at ``socket_path``."""
+
+    def __init__(self, socket_path: str) -> None:
+        self._socket_path = socket_path
+        self._server: asyncio.base_events.Server | None = None
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    async def serve(self, handle: ConnectionHandler) -> None:
+        if self._server is not None:
+            return
+        # Stale-socket cleanup: a crashed predecessor may have left the
+        # socket file on disk; start_unix_server would then fail with
+        # EADDRINUSE.
+        with contextlib.suppress(FileNotFoundError):
+            if os.path.exists(self._socket_path):
+                os.unlink(self._socket_path)
+        self._server = await asyncio.start_unix_server(
+            handle, path=self._socket_path
+        )
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+            self._server = None
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(self._socket_path)
+
+
+class UnixClientTransport:
+    """Connect to an `AF_UNIX` socket at ``socket_path``."""
+
+    def __init__(self, socket_path: str) -> None:
+        self._socket_path = socket_path
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    async def connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        return await asyncio.open_unix_connection(path=self._socket_path)
+
+
+__all__ = ["UnixClientTransport", "UnixServerTransport"]

--- a/contrib/channels/src/agentm_channels/transport/websocket.py
+++ b/contrib/channels/src/agentm_channels/transport/websocket.py
@@ -1,0 +1,127 @@
+"""WebSocket :class:`ServerTransport` and :class:`ClientTransport`.
+
+Each WebSocket *binary message* carries exactly one already-framed
+envelope (length-prefix header + JSON body bytes from
+``wire/framing.py``). The framing reader / writer never see WebSockets
+directly — :mod:`._stream_adapter` exposes the connection as
+asyncio-StreamReader/StreamWriter-shaped objects so
+``server._read_one_frame`` and ``server._send`` work unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+
+from websockets.asyncio.client import ClientConnection, connect as ws_connect
+from websockets.asyncio.server import ServerConnection, serve as ws_serve
+
+from ._stream_adapter import WebSocketStreamReader, WebSocketStreamWriter
+from .base import ConnectionHandler
+
+
+class WebSocketServerTransport:
+    """Bind a WebSocket listener on ``host:port``.
+
+    ``path`` is the URL path mounted by the listener. Today we accept
+    any path the client requests (the handler doesn't enforce it) —
+    the field is kept so callers can carry it through configuration
+    and reverse-proxy mappings.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        path: str = "/",
+        ssl_context: ssl.SSLContext | None = None,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._path = path
+        self._ssl = ssl_context
+        self._server: object | None = None
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        # Resolved port after binding (useful when caller passed 0).
+        if self._server is not None:
+            sockets = getattr(self._server, "sockets", None)
+            if sockets:
+                return int(sockets[0].getsockname()[1])
+        return self._port
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    async def serve(self, handle: ConnectionHandler) -> None:
+        if self._server is not None:
+            return
+
+        async def _handler(ws: ServerConnection) -> None:
+            reader = WebSocketStreamReader(ws)
+            writer = WebSocketStreamWriter(ws)
+            try:
+                # The wire framing helpers expect StreamReader /
+                # StreamWriter; our adapters duck-type those.
+                await handle(reader, writer)  # type: ignore[arg-type]
+            finally:
+                if ws.close_code is None:
+                    await ws.close()
+
+        # ``websockets.serve`` returns an awaitable that resolves to a
+        # ``Server`` once the listener is bound.
+        self._server = await ws_serve(
+            _handler,
+            host=self._host,
+            port=self._port,
+            ssl=self._ssl,
+        )
+
+    async def close(self) -> None:
+        if self._server is None:
+            return
+        server = self._server
+        self._server = None
+        close_fn = getattr(server, "close", None)
+        if close_fn is not None:
+            close_fn()
+        wait_fn = getattr(server, "wait_closed", None)
+        if wait_fn is not None:
+            try:
+                await wait_fn()
+            except Exception:
+                pass
+
+
+class WebSocketClientTransport:
+    """Connect to ``uri`` (``ws://...`` or ``wss://...``)."""
+
+    def __init__(self, uri: str, ssl_context: ssl.SSLContext | None = None) -> None:
+        self._uri = uri
+        self._ssl = ssl_context
+        self._ws: ClientConnection | None = None
+
+    @property
+    def uri(self) -> str:
+        return self._uri
+
+    async def connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        kwargs: dict[str, object] = {}
+        if self._ssl is not None:
+            kwargs["ssl"] = self._ssl
+        ws: ClientConnection = await ws_connect(self._uri, **kwargs)  # type: ignore[arg-type]
+        self._ws = ws
+        reader = WebSocketStreamReader(ws)
+        writer = WebSocketStreamWriter(ws)
+        # Duck-typed return; callers use only the StreamReader/Writer
+        # subset that the wire helpers exercise.
+        return reader, writer  # type: ignore[return-value]
+
+
+__all__ = ["WebSocketClientTransport", "WebSocketServerTransport"]

--- a/contrib/channels/src/agentm_channels/transport/websocket.py
+++ b/contrib/channels/src/agentm_channels/transport/websocket.py
@@ -23,22 +23,19 @@ from .base import ConnectionHandler
 class WebSocketServerTransport:
     """Bind a WebSocket listener on ``host:port``.
 
-    ``path`` is the URL path mounted by the listener. Today we accept
-    any path the client requests (the handler doesn't enforce it) —
-    the field is kept so callers can carry it through configuration
-    and reverse-proxy mappings.
+    URL path routing is intentionally not enforced here — a reverse
+    proxy in front of the listener owns the URL surface today, and the
+    handshake accepts any path the client requests.
     """
 
     def __init__(
         self,
         host: str,
         port: int,
-        path: str = "/",
         ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         self._host = host
         self._port = port
-        self._path = path
         self._ssl = ssl_context
         self._server: object | None = None
 
@@ -54,10 +51,6 @@ class WebSocketServerTransport:
             if sockets:
                 return int(sockets[0].getsockname()[1])
         return self._port
-
-    @property
-    def path(self) -> str:
-        return self._path
 
     async def serve(self, handle: ConnectionHandler) -> None:
         if self._server is not None:

--- a/contrib/channels/tests/cli/test_bind_e2e.py
+++ b/contrib/channels/tests/cli/test_bind_e2e.py
@@ -107,7 +107,7 @@ async def test_wire_peer_inbound_round_trips_through_gateway() -> None:
             received.append(env)
 
         client = WireClient(
-            sock, peer_id="p1", peer_kind="chat_client", on_outbound=on_outbound
+        socket_path=sock, peer_id="p1", peer_kind="chat_client", on_outbound=on_outbound
         )
         try:
             await client.connect()
@@ -175,7 +175,8 @@ async def test_wire_peer_rejected_by_uid_policy() -> None:
         try:
             from agentm_channels.client import AuthError
 
-            client = WireClient(sock, peer_id="p1", peer_kind="chat_client")
+            client = WireClient(
+        socket_path=sock, peer_id="p1", peer_kind="chat_client")
             with pytest.raises(AuthError) as exc:
                 await client.connect()
             assert exc.value.code == "auth_failed"

--- a/contrib/channels/tests/cli/test_ws_bind_flag_parsing.py
+++ b/contrib/channels/tests/cli/test_ws_bind_flag_parsing.py
@@ -1,0 +1,167 @@
+"""WebSocket-flavoured ``--bind`` flag parsing for ``agentm-gateway``.
+
+Covers the new ws:// / wss:// dispatch added in PR3 of
+``.claude/plans/2026-05-12-gateway-websocket-transport.md``: schema
+validation, mandatory token configuration, mandatory TLS material for
+wss://, and the ``--bind-token-file`` parser.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentm_channels.cli import _load_tokens_file, _resolve_bind
+
+
+def test_resolve_bind_ws_requires_tokens() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            bind="ws://0.0.0.0:7777/agentm",
+            bind_allow_uid=None,
+            bind_allow_any_uid=False,
+            cfg={},
+        )
+    assert "ws://" in str(exc.value) or "ws" in str(exc.value)
+    assert "token" in str(exc.value).lower()
+
+
+def test_resolve_bind_wss_requires_cert_and_key() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            bind="wss://0.0.0.0:7777/agentm",
+            bind_allow_uid=None,
+            bind_allow_any_uid=False,
+            bind_token_file=None,
+            bind_allow_anonymous=True,
+            cfg={},
+        )
+    msg = str(exc.value).lower()
+    assert "tls" in msg or "wss" in msg
+    assert "cert" in msg or "key" in msg
+
+
+def test_resolve_bind_ws_with_tls_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            bind="ws://0.0.0.0:7777/agentm",
+            bind_allow_uid=None,
+            bind_allow_any_uid=False,
+            bind_allow_anonymous=True,
+            tls_cert="/tmp/cert.pem",
+            tls_key="/tmp/key.pem",
+            cfg={},
+        )
+    assert "ws://" in str(exc.value)
+
+
+def test_resolve_bind_unix_with_tls_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            bind="unix:///tmp/x.sock",
+            bind_allow_uid=None,
+            bind_allow_any_uid=False,
+            tls_cert="/tmp/cert.pem",
+            cfg={},
+        )
+    assert "unix" in str(exc.value).lower() or "tls" in str(exc.value).lower()
+
+
+def test_resolve_bind_ws_with_allow_uid_rejected() -> None:
+    # Peer-cred uid flags are unix-only.
+    with pytest.raises(SystemExit) as exc:
+        _resolve_bind(
+            bind="ws://0.0.0.0:7777/agentm",
+            bind_allow_uid=[1000],
+            bind_allow_any_uid=False,
+            cfg={},
+        )
+    assert "unix" in str(exc.value).lower()
+
+
+def test_load_tokens_file_skips_comments_and_blanks() -> None:
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".tokens", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(
+            "# leading comment\n"
+            "\n"
+            "alpha\n"
+            "  beta  \n"  # whitespace stripped
+            "   # indented comment, still skipped\n"
+            "\n"
+            "gamma\n"
+        )
+        path = f.name
+    try:
+        tokens = _load_tokens_file(path)
+    finally:
+        os.unlink(path)
+    assert tokens == {"alpha", "beta", "gamma"}
+
+
+def test_resolve_bind_ws_with_token_file_resolves(tmp_path: Path) -> None:
+    tokens_file = tmp_path / "tokens"
+    tokens_file.write_text("# header\nfoo\nbar\n", encoding="utf-8")
+    spec = _resolve_bind(
+        bind="ws://0.0.0.0:7777/agentm",
+        bind_allow_uid=None,
+        bind_allow_any_uid=False,
+        bind_token_file=str(tokens_file),
+        cfg={},
+    )
+    assert spec.scheme == "ws"
+    assert spec.host == "0.0.0.0"
+    assert spec.port == 7777
+    assert spec.ws_path == "/agentm"
+    assert spec.tokens == frozenset({"foo", "bar"})
+
+
+def test_check_ws_without_tokens_fails_fast() -> None:
+    """End-to-end: --bind ws:// without tokens exits 2."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agentm_channels.cli",
+            "--bind",
+            "ws://127.0.0.1:0/agentm",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "AGENTM_SKIP_DOTENV": "1"},
+    )
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    assert "token" in (proc.stderr + proc.stdout).lower()
+
+
+def test_check_wss_without_tls_material_fails_fast(tmp_path: Path) -> None:
+    """End-to-end: --bind wss:// without --tls-cert/--tls-key exits 2."""
+    tokens_file = tmp_path / "tokens"
+    tokens_file.write_text("alpha\n", encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agentm_channels.cli",
+            "--bind",
+            "wss://127.0.0.1:0/agentm",
+            "--bind-token-file",
+            str(tokens_file),
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "AGENTM_SKIP_DOTENV": "1"},
+    )
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    combined = (proc.stderr + proc.stdout).lower()
+    assert "tls" in combined or "cert" in combined

--- a/contrib/channels/tests/cli/test_ws_bind_flag_parsing.py
+++ b/contrib/channels/tests/cli/test_ws_bind_flag_parsing.py
@@ -118,7 +118,7 @@ def test_resolve_bind_ws_with_token_file_resolves(tmp_path: Path) -> None:
     assert spec.scheme == "ws"
     assert spec.host == "0.0.0.0"
     assert spec.port == 7777
-    assert spec.ws_path == "/agentm"
+    assert spec.url == "ws://0.0.0.0:7777/agentm"
     assert spec.tokens == frozenset({"foo", "bar"})
 
 

--- a/contrib/channels/tests/server/test_auth_failure.py
+++ b/contrib/channels/tests/server/test_auth_failure.py
@@ -38,19 +38,22 @@ async def test_wrong_token_rejected(socket_path: str, db_path: str) -> None:
     outbox = SqliteOutbox(db_path)
     inbox = SqliteInbox(db_path)
     server = WireServer(
-        socket_path, outbox, inbox, _noop, authenticator=TokenAuth("good", "trusted")
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop, authenticator=TokenAuth("good", "trusted")
     )
     await server.start()
     try:
         evil = WireClient(
-            socket_path, peer_id="evil", peer_kind="chat_client", token="wrong"
+        socket_path=socket_path, peer_id="evil", peer_kind="chat_client", token="wrong"
         )
         with pytest.raises(AuthError) as exc_info:
             await evil.connect()
         assert exc_info.value.code == "auth_failed"
         # Confirm the *good* peer still works.
         good = WireClient(
-            socket_path, peer_id="trusted", peer_kind="chat_client", token="good"
+        socket_path=socket_path, peer_id="trusted", peer_kind="chat_client", token="good"
         )
         await good.connect()
         assert good.welcome() is not None

--- a/contrib/channels/tests/server/test_catchup_batching.py
+++ b/contrib/channels/tests/server/test_catchup_batching.py
@@ -42,7 +42,10 @@ async def test_50_messages_arrive_as_batches(socket_path: str, db_path: str) -> 
 
     BATCH_MAX = 32
     server = WireServer(
-        socket_path, outbox, inbox, _noop, delivery_batch_max=BATCH_MAX
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop, delivery_batch_max=BATCH_MAX
     )
     await server.start()
 
@@ -144,7 +147,11 @@ async def test_batch_envelope_carries_reason_and_session_key(
             ),
         )
 
-    server = WireServer(socket_path, outbox, inbox, _noop, delivery_batch_max=32)
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop, delivery_batch_max=32)
     await server.start()
     try:
         reader, writer = await asyncio.open_unix_connection(socket_path)
@@ -200,7 +207,11 @@ async def test_batch_session_key_none_when_records_diverge(
         ),
     )
 
-    server = WireServer(socket_path, outbox, inbox, _noop, delivery_batch_max=32)
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop, delivery_batch_max=32)
     await server.start()
     try:
         reader, writer = await asyncio.open_unix_connection(socket_path)
@@ -236,7 +247,11 @@ async def test_steady_state_single_outbound_not_batched(
     outbox = SqliteOutbox(db_path)
     inbox = SqliteInbox(db_path)
 
-    server = WireServer(socket_path, outbox, inbox, _noop, delivery_batch_max=32)
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop, delivery_batch_max=32)
     await server.start()
     try:
         reader, writer = await asyncio.open_unix_connection(socket_path)

--- a/contrib/channels/tests/server/test_dead_letter.py
+++ b/contrib/channels/tests/server/test_dead_letter.py
@@ -67,10 +67,10 @@ async def test_dead_letter_after_max_attempts(socket_path: str, db_path: str) ->
     # in production. Simulating 5 reconnect cycles for one test would
     # bloat the suite without adding behavioural coverage.
     server = WireServer(
-        socket_path,
-        outbox,
-        inbox,
-        _noop,
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
         delivery_batch_max=1,
         max_delivery_attempts=1,
     )
@@ -91,7 +91,8 @@ async def test_dead_letter_after_max_attempts(socket_path: str, db_path: str) ->
     try:
         from agentm_channels.client import WireClient
 
-        client = WireClient(socket_path, peer_id="D", peer_kind="chat_client")
+        client = WireClient(
+        socket_path=socket_path, peer_id="D", peer_kind="chat_client")
         await client.connect()
         ok = await wait_for(
             lambda: outbox.dead_letter_count("D") >= 1, timeout=5.0

--- a/contrib/channels/tests/server/test_durability_restart.py
+++ b/contrib/channels/tests/server/test_durability_restart.py
@@ -95,7 +95,10 @@ async def test_durability_across_restart(socket_path: str, db_path: str) -> None
     outbox = SqliteOutbox(db_path, lease_ttl=0.3)
     inbox = SqliteInbox(db_path)
     server = WireServer(
-        socket_path, outbox, inbox, _noop_inbound, delivery_batch_max=1
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop_inbound, delivery_batch_max=1
     )
     # Patch register() to swap the writer before delivery starts.
     real_register = server._registry.register
@@ -114,7 +117,7 @@ async def test_durability_across_restart(socket_path: str, db_path: str) -> None
 
     try:
         client = WireClient(
-            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_1
+        socket_path=socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_1
         )
         await client.connect()
         # Welcome arrived (1 write). 2 more writes succeed → 2 envelopes.
@@ -137,7 +140,10 @@ async def test_durability_across_restart(socket_path: str, db_path: str) -> None
     outbox = SqliteOutbox(db_path, lease_ttl=0.3)
     inbox = SqliteInbox(db_path)
     server = WireServer(
-        socket_path, outbox, inbox, _noop_inbound, delivery_batch_max=8
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop_inbound, delivery_batch_max=8
     )
     await server.start()
 
@@ -146,7 +152,7 @@ async def test_durability_across_restart(socket_path: str, db_path: str) -> None
 
     try:
         client2 = WireClient(
-            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_2
+        socket_path=socket_path, peer_id="A", peer_kind="chat_client", on_outbound=on_outbound_2
         )
         await client2.connect()
         # Expect the leftover envelopes to land.

--- a/contrib/channels/tests/server/test_echo.py
+++ b/contrib/channels/tests/server/test_echo.py
@@ -27,7 +27,11 @@ async def test_echo_inbound_to_outbound(socket_path: str, db_path: str) -> None:
         )
         outbox.enqueue(session.peer_id, echo)
 
-    server = WireServer(socket_path, outbox, inbox, on_inbound)
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=on_inbound)
     await server.start()
 
     async def collect(env: Envelope) -> None:
@@ -37,7 +41,7 @@ async def test_echo_inbound_to_outbound(socket_path: str, db_path: str) -> None:
         from agentm_channels.client import WireClient
 
         client = WireClient(
-            socket_path, peer_id="A", peer_kind="chat_client", on_outbound=collect
+        socket_path=socket_path, peer_id="A", peer_kind="chat_client", on_outbound=collect
         )
         await client.connect()
         await client.send_inbound({"text": "hi"}, env_id="m1")

--- a/contrib/channels/tests/server/test_handshake.py
+++ b/contrib/channels/tests/server/test_handshake.py
@@ -18,10 +18,15 @@ async def _noop_inbound(_session: object, _env: object) -> None:
 async def test_hello_welcome_roundtrip(socket_path: str, db_path: str) -> None:
     outbox = SqliteOutbox(db_path)
     inbox = SqliteInbox(db_path)
-    server = WireServer(socket_path, outbox, inbox, _noop_inbound)
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop_inbound)
     await server.start()
     try:
-        client = WireClient(socket_path, peer_id="P1", peer_kind="chat_client")
+        client = WireClient(
+        socket_path=socket_path, peer_id="P1", peer_kind="chat_client")
         await client.connect()
         welcome = client.welcome()
         assert welcome is not None
@@ -51,10 +56,15 @@ async def test_authenticator_reject_closes_connection(
 ) -> None:
     outbox = SqliteOutbox(db_path)
     inbox = SqliteInbox(db_path)
-    server = WireServer(socket_path, outbox, inbox, _noop_inbound, authenticator=RejectingAuth())
+    server = WireServer(
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop_inbound, authenticator=RejectingAuth())
     await server.start()
     try:
-        client = WireClient(socket_path, peer_id="banned", peer_kind="chat_client")
+        client = WireClient(
+        socket_path=socket_path, peer_id="banned", peer_kind="chat_client")
         with pytest.raises(AuthError) as exc_info:
             await client.connect()
         assert exc_info.value.code == "auth_failed"

--- a/contrib/channels/tests/server/test_slow_consumer.py
+++ b/contrib/channels/tests/server/test_slow_consumer.py
@@ -40,10 +40,10 @@ async def test_slow_consumer_logs_and_does_not_lose(
         )
 
     server = WireServer(
-        socket_path,
-        outbox,
-        inbox,
-        _noop,
+        socket_path=socket_path,
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
         delivery_batch_max=1,  # force a slow drip so high-water trips before drain
         slow_consumer_high_water=10,
     )
@@ -57,7 +57,7 @@ async def test_slow_consumer_logs_and_does_not_lose(
 
     try:
         client = WireClient(
-            socket_path, peer_id="C", peer_kind="chat_client", on_outbound=slow_handler
+        socket_path=socket_path, peer_id="C", peer_kind="chat_client", on_outbound=slow_handler
         )
         await client.connect()
         await wait_for(lambda: len(received) >= 30, timeout=10.0)

--- a/contrib/channels/tests/transport/conftest.py
+++ b/contrib/channels/tests/transport/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures for WebSocket transport tests."""
+
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+def tmp_dir() -> Iterator[str]:
+    with tempfile.TemporaryDirectory(prefix="agentm-wsx-") as d:
+        yield d
+
+
+@pytest.fixture
+def db_path(tmp_dir: str) -> str:
+    return os.path.join(tmp_dir, "outbox.sqlite")
+
+
+@pytest.fixture
+def socket_path(tmp_dir: str) -> str:
+    return os.path.join(tmp_dir, "gateway.sock")

--- a/contrib/channels/tests/transport/test_websocket_bind_with_peercred_rejected.py
+++ b/contrib/channels/tests/transport/test_websocket_bind_with_peercred_rejected.py
@@ -1,0 +1,38 @@
+"""Refuse the (peer-cred auth, WS transport) pairing at construction.
+
+Peer-cred reads AF_UNIX kernel credentials — those don't exist on a
+WebSocket transport. Failing fast in ``WireServer.__init__`` is the
+explicit guard rail (see ``.claude/plans/2026-05-12-gateway-websocket-transport.md``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentm_channels.auth import UnixPeerCredAuthenticator
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.transport import WebSocketServerTransport
+from agentm_channels.wire import Envelope
+
+
+async def _noop(_s: PeerSession, _e: Envelope) -> None:
+    return None
+
+
+async def test_ws_with_peercred_auth_rejected(free_port: int, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    try:
+        with pytest.raises(ValueError, match="UnixPeerCred"):
+            WireServer(
+                outbox=outbox,
+                inbox=inbox,
+                on_inbound=_noop,
+                transport=WebSocketServerTransport("127.0.0.1", free_port),
+                authenticator=UnixPeerCredAuthenticator(),
+            )
+    finally:
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/transport/test_websocket_echo.py
+++ b/contrib/channels/tests/transport/test_websocket_echo.py
@@ -1,0 +1,61 @@
+"""WebSocket round-trip: one framed envelope decodes byte-identical
+versus a Unix-socket round-trip.
+
+Drives the wire framing directly through the adapter (no full server)
+so we isolate the transport seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from agentm_channels.transport import (
+    WebSocketClientTransport,
+    WebSocketServerTransport,
+)
+from agentm_channels.wire import WIRE_VERSION, Envelope, encode
+
+# Reuse the same helpers the wire server uses.
+from agentm_channels.server import _read_one_frame, _send
+
+
+def _make_env() -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id="m1",
+        kind="inbound",
+        ts=time.time(),
+        body={"hello": "world", "n": 42},
+    )
+
+
+async def test_ws_envelope_roundtrip(free_port: int) -> None:
+    received: list[Envelope] = []
+    server_done = asyncio.Event()
+
+    async def handle(reader, writer) -> None:  # type: ignore[no-untyped-def]
+        env = await _read_one_frame(reader)
+        if env is not None:
+            received.append(env)
+        # Echo it back.
+        if env is not None:
+            await _send(writer, env)
+        server_done.set()
+
+    server = WebSocketServerTransport("127.0.0.1", free_port)
+    await server.serve(handle)
+    try:
+        client = WebSocketClientTransport(f"ws://127.0.0.1:{free_port}/")
+        reader, writer = await client.connect()
+        sent = _make_env()
+        await _send(writer, sent)
+        echoed = await asyncio.wait_for(_read_one_frame(reader), timeout=3.0)
+        await asyncio.wait_for(server_done.wait(), timeout=3.0)
+
+        assert echoed is not None
+        # Byte-identical decode invariant: re-encoding both must match.
+        assert encode(echoed) == encode(sent)
+        assert received and encode(received[0]) == encode(sent)
+    finally:
+        await server.close()

--- a/contrib/channels/tests/transport/test_websocket_redelivery.py
+++ b/contrib/channels/tests/transport/test_websocket_redelivery.py
@@ -1,0 +1,130 @@
+"""Outbox redelivery over WS reconnect.
+
+Mirrors ``tests/server/test_durability_restart.py`` for the WebSocket
+transport: drop a peer mid-flight, restart the server with the same
+sqlite outbox, reconnect, and verify the in-flight envelopes get
+redelivered (exactly once across both sessions when combined with the
+ones already drained).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+from agentm_channels.client import WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.transport import (
+    WebSocketClientTransport,
+    WebSocketServerTransport,
+)
+from agentm_channels.wire import WIRE_VERSION, Envelope
+
+
+async def _noop(_s: PeerSession, _e: Envelope) -> None:
+    return None
+
+
+def _outbound(env_id: str) -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id=env_id,
+        kind="outbound",
+        ts=time.time(),
+        body={"seq": env_id},
+    )
+
+
+async def _wait(predicate, timeout: float = 5.0, interval: float = 0.02) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(interval)
+    return predicate()
+
+
+async def test_ws_redelivery_across_reconnect(tmp_dir: str, free_port: int) -> None:
+    db_path = os.path.join(tmp_dir, "outbox.sqlite")
+
+    seen_session1: list[str] = []
+    seen_session2: list[str] = []
+
+    # --- session 1: connect peer, drop before anything is enqueued --
+    outbox = SqliteOutbox(db_path, lease_ttl=0.3)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
+        transport=WebSocketServerTransport("127.0.0.1", free_port),
+        delivery_batch_max=1,
+    )
+    await server.start()
+
+    async def on_outbound_1(env: Envelope) -> None:
+        seen_session1.append(env.id)
+
+    try:
+        client = WireClient(
+            transport=WebSocketClientTransport(f"ws://127.0.0.1:{free_port}/"),
+            peer_id="A",
+            peer_kind="chat_client",
+            on_outbound=on_outbound_1,
+        )
+        await client.connect()
+        await _wait(lambda: "A" in server.registry, timeout=2.0)
+        # Hard-close the client so the connection drops; envelopes
+        # enqueued AFTER this point are not delivered to session 1.
+        if client._read_task is not None:  # type: ignore[attr-defined]
+            client._read_task.cancel()  # type: ignore[attr-defined]
+        # Wait for the server to notice the disconnect.
+        await _wait(lambda: "A" not in server.registry, timeout=2.0)
+        # Now enqueue 3 envelopes — they sit pending in the outbox.
+        for i in range(3):
+            outbox.enqueue("A", _outbound(f"m{i}"))
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+    # Let leases expire so any pending leased rows are eligible again.
+    await asyncio.sleep(0.5)
+
+    # --- session 2: fresh server, same sqlite, same port ------------
+    outbox = SqliteOutbox(db_path, lease_ttl=0.3)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
+        transport=WebSocketServerTransport("127.0.0.1", free_port),
+        delivery_batch_max=8,
+    )
+    await server.start()
+
+    async def on_outbound_2(env: Envelope) -> None:
+        seen_session2.append(env.id)
+
+    try:
+        client2 = WireClient(
+            transport=WebSocketClientTransport(f"ws://127.0.0.1:{free_port}/"),
+            peer_id="A",
+            peer_kind="chat_client",
+            on_outbound=on_outbound_2,
+        )
+        await client2.connect()
+        ok = await _wait(lambda: len(seen_session2) >= 3, timeout=5.0)
+        assert ok
+        # Each pending envelope arrives exactly once on session 2;
+        # session 1 saw none of them (it was already dropped).
+        assert sorted(seen_session2) == ["m0", "m1", "m2"]
+        assert seen_session1 == []
+        await client2.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/contrib/channels/tests/transport/test_websocket_token_auth.py
+++ b/contrib/channels/tests/transport/test_websocket_token_auth.py
@@ -1,0 +1,89 @@
+"""Token auth gating over WebSocket.
+
+- bad token → server rejects the hello; peer never enters the registry.
+- good token → handshake completes and the peer registers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentm_channels.auth import TokenAuthenticator
+from agentm_channels.client import AuthError, WireClient
+from agentm_channels.outbox import SqliteInbox, SqliteOutbox
+from agentm_channels.peer import PeerSession
+from agentm_channels.server import WireServer
+from agentm_channels.transport import (
+    WebSocketClientTransport,
+    WebSocketServerTransport,
+)
+from agentm_channels.wire import Envelope
+
+
+async def _noop(_s: PeerSession, _e: Envelope) -> None:
+    return None
+
+
+async def test_ws_token_auth_rejects_bad_token(free_port: int, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
+        transport=WebSocketServerTransport("127.0.0.1", free_port),
+        authenticator=TokenAuthenticator({"good"}),
+    )
+    await server.start()
+    try:
+        client = WireClient(
+            transport=WebSocketClientTransport(f"ws://127.0.0.1:{free_port}/"),
+            peer_id="bad-peer",
+            peer_kind="chat_client",
+            token="bad",
+        )
+        with pytest.raises(AuthError):
+            await client.connect()
+
+        # Give the server a moment to finalise; the peer must NOT be in
+        # the registry.
+        await asyncio.sleep(0.05)
+        assert "bad-peer" not in server.registry
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()
+
+
+async def test_ws_token_auth_accepts_good_token(free_port: int, db_path: str) -> None:
+    outbox = SqliteOutbox(db_path)
+    inbox = SqliteInbox(db_path)
+    server = WireServer(
+        outbox=outbox,
+        inbox=inbox,
+        on_inbound=_noop,
+        transport=WebSocketServerTransport("127.0.0.1", free_port),
+        authenticator=TokenAuthenticator({"good"}),
+    )
+    await server.start()
+    try:
+        client = WireClient(
+            transport=WebSocketClientTransport(f"ws://127.0.0.1:{free_port}/"),
+            peer_id="good-peer",
+            peer_kind="chat_client",
+            token="good",
+        )
+        await client.connect()
+        # Wait briefly for the registry to register.
+        for _ in range(50):
+            if "good-peer" in server.registry:
+                break
+            await asyncio.sleep(0.02)
+        assert "good-peer" in server.registry
+        await client.close()
+    finally:
+        await server.stop()
+        outbox.close()
+        inbox.close()

--- a/src/agentm/cli.py
+++ b/src/agentm/cli.py
@@ -441,7 +441,10 @@ def run_cmd(
             "       use the channels gateway instead:\n"
             "         agentm-gateway --bind unix:///tmp/agentm/gw.sock\n"
             "         agentm-worker  --connect unix:///tmp/agentm/gw.sock\n"
-            "         agentm-terminal --connect unix:///tmp/agentm/gw.sock --format textual",
+            "         agentm-terminal --connect unix:///tmp/agentm/gw.sock --format textual\n"
+            "       Cross-host (WebSocket + token):\n"
+            "         agentm-gateway --bind ws://0.0.0.0:7777/agentm --bind-token-file /etc/agentm/tokens\n"
+            "         agentm-worker  --connect ws://gw.example.com:7777/agentm --token \"$AGENTM_TOKEN\"",
             file=sys.stderr,
         )
         raise typer.Exit(code=2)

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "typer", specifier = ">=0.25.1" },
-    { name = "websockets", specifier = ">=12" },
+    { name = "websockets", specifier = ">=13" },
 ]
 provides-extras = ["dev"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,6 @@ otel = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "duckdb" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -79,7 +78,6 @@ provides-extras = ["agent-env", "otel"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "duckdb", specifier = ">=1.5.2" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ otel = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "duckdb" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -78,6 +79,7 @@ provides-extras = ["agent-env", "otel"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "duckdb", specifier = ">=1.5.2" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -95,6 +97,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -114,6 +117,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "typer", specifier = ">=0.25.1" },
+    { name = "websockets", specifier = ">=12" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary

Adds WebSocket support to `agentm-gateway` and its clients (`agentm-worker`, `agentm-terminal`, `agentm-feishu`). Default remains `unix://`; WS is opt-in via `ws://` / `wss://` URLs.

Plan: `.claude/plans/2026-05-12-gateway-websocket-transport.md`

## What's new

- **Transport abstraction** — `ServerTransport` / `ClientTransport` Protocols in `contrib/channels/src/agentm_channels/transport/`. Unix and WebSocket are sibling implementations; wire framing (length-prefix JSON) is reused verbatim — one envelope per WS binary message.
- **Token auth** — `TokenAuthenticator` reads `hello.body.token`. `UnixPeerCredAuthenticator` works only with unix sockets; pairing it with WS fails fast at both CLI and `WireServer.__init__`.
- **TLS** — `wss://` server: `--tls-cert` / `--tls-key`. Clients: `--tls-ca` for pinning a self-signed gateway. mTLS deferred.
- **CLI / env** — Gateway: `--bind-token-file`, `--bind-allow-anonymous`, `--tls-cert`, `--tls-key`. Clients: `--token` (or `AGENTM_TOKEN`), `--tls-ca`.

## Safety gates

- `wss://` without cert/key → fail.
- `ws://` / `wss://` without tokens AND without `--bind-allow-anonymous` → fail.
- `unix://` + any `--tls-*` → fail.
- Peer-cred auth + WS transport → fail.

## Out of scope

mTLS, HTTP/SSE fallback, token rotation, reverse-proxy config samples.

## Test plan

- [x] `uv run pytest contrib/channels/tests -q` → **152 passed** (138 pre-existing unix + 14 new WS/CLI)
- [x] `uv run ruff check contrib/channels/src/ contrib/channels-clients/ src/agentm/cli.py` → clean
- [x] `uv run mypy contrib/channels/src/agentm_channels/{cli,client_cli,server,client}.py contrib/channels/src/agentm_channels/transport/` → clean
- [ ] Manual smoke: `agentm-gateway --bind ws://127.0.0.1:7777/agentm --bind-token-file /tmp/tok` + `agentm-terminal --connect ws://127.0.0.1:7777/agentm --token "$(cat /tmp/tok)"`

## Review trail

boundary-reviewer pass: 0 block / 4 warn / 5 nit. Warns 1-3 + nits 4-6 fixed in the four `refactor(channels): ...` commits at the tip. Remaining nits (`WireClient.abort()` test helper, doc note about channels-internal pluggability) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)