### PR TITLE
fix(rca_hfsm): per-token claim semantics fixes #156

### DIFF
--- a/contrib/scenarios/rca_hfsm/src/agentm_rca_hfsm/atoms/rca_hgraph_store.py
+++ b/contrib/scenarios/rca_hfsm/src/agentm_rca_hfsm/atoms/rca_hgraph_store.py
@@ -10,7 +10,10 @@ The token mechanism is the structural reply to "any atom that calls
 ``api.get_service('rca.hgraph.write')`` becomes a writer". Instead, this atom
 publishes a per-install random token via ``rca.hgraph.write_token`` and the
 write handle is only obtainable by calling ``claim_write_handle(token)``
-*once* per token. A second claim (with any token) raises ``RuntimeError``.
+*once* per token. Each call to :func:`install` mints a fresh token, so
+multiple sessions in the same process each get an independent (token, handle)
+pair; the one-shot rule is per token, not per process. A second claim of the
+same token (or any unknown token) raises ``RuntimeError``.
 
 §11 single-file contract: stdlib + ``agentm.core.abi.*`` +
 ``agentm.extensions.*`` only. The sibling ``schema`` import is a pure-data
@@ -212,8 +215,10 @@ _claimed: Final[set[str]] = set()
 def claim_write_handle(token: str) -> _WriteHandle:
     """Return the write handle for the install whose token matches ``token``.
 
-    First successful claim consumes the token: any subsequent call — with
-    the same token, a different token, or an unknown token — raises
+    The one-shot rule is scoped to the token, not the process: each
+    ``install`` mints a fresh token, so multiple sessions in the same
+    process each get an independent (token, handle) pair. Any subsequent
+    claim of the **same** token — or of an unknown token — raises
     ``RuntimeError``. This is the structural enforcement of design §7.4
     (single-writer property) without exposing the write API as a service.
 
@@ -221,22 +226,22 @@ def claim_write_handle(token: str) -> _WriteHandle:
     ``tests/test_store_single_writer.py``.
     """
 
-    if _claimed:
+    if token in _claimed:
         raise RuntimeError(
-            "rca.hgraph write handle has already been claimed; "
-            "the falsification gate is the only legal writer (design §7.4)"
+            f"rca.hgraph write handle for token={token!r} has already been "
+            "claimed; the falsification gate is the only legal writer "
+            "(design §7.4) and may only claim its own token once"
         )
     handle = _pending.pop(token, None)
     if handle is None:
-        # No pending install matches; mark the registry consumed so a
-        # legitimate later claim with the right token also raises.
-        # Concretely: a misconfigured atom that calls claim_write_handle
-        # before the store installs, or with a stale token, must not be
-        # able to retry and silently win the race.
+        # Mark the offending token as consumed so a retry with the same
+        # bogus value still raises. A misconfigured atom that calls
+        # claim_write_handle before the store installs (or with a stale
+        # token) must not be able to silently win the race on retry.
         _claimed.add(token)
         raise RuntimeError(
             f"no pending rca.hgraph install matches token={token!r}; "
-            "single-writer registry is now locked"
+            "token rejected"
         )
     _claimed.add(token)
     return handle

--- a/contrib/scenarios/rca_hfsm/tests/test_multi_session_in_process.py
+++ b/contrib/scenarios/rca_hfsm/tests/test_multi_session_in_process.py
@@ -1,0 +1,96 @@
+"""Regression test for #156 — multiple sessions in one process.
+
+Until 2026-05-14 the store atom's claim registry was treated as a
+process-wide one-shot lock (``if _claimed: raise``). The first session
+bootstrap consumed the lock; every subsequent bootstrap in the same
+process raised in ``claim_write_handle``, the falsification gate's
+``install`` propagated that as ``RuntimeError`` into the substrate's
+silent-swallow path (``session_factory._install_with_events``'s
+``except``), and the cascade of "rca.gate missing" errors silently
+stripped the five ``rca_evidence_tools`` tools from the LLM's catalog.
+
+The fix made the one-shot rule per-token rather than per-process — each
+``install`` mints a fresh token and only that token is consumed on claim.
+This file fails if that rule regresses, without depending on the rest
+of the smoke-test wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentm_rca_hfsm.atoms import (
+    rca_evidence_tools,
+    rca_falsification_gate,
+    rca_hgraph_store,
+)
+
+from tests._gate_fixtures import StubAPI
+from tests._phase1_mimic_judges import all_mimics
+
+
+def _install_session_stack(api: StubAPI) -> None:
+    """Drive the same install ladder the manifest declares.
+
+    Mounts store → judges → gate → evidence tools without touching the
+    module-level ``_reset_for_tests`` hook. A second call in the same
+    process must succeed without resetting state.
+    """
+
+    rca_hgraph_store.install(api, {})
+    for service_name, mimic in all_mimics().items():
+        api.set_service(service_name, mimic)
+    rca_falsification_gate.install(api, {})
+    rca_evidence_tools.install(api, {})
+
+
+def test_second_session_in_process_keeps_all_evidence_tools() -> None:
+    rca_hgraph_store._reset_for_tests()
+
+    api_a = StubAPI()
+    _install_session_stack(api_a)
+    tools_a = {t.name for t in api_a.tools}
+
+    # Second session in the same process — no reset between installs.
+    api_b = StubAPI()
+    _install_session_stack(api_b)
+    tools_b = {t.name for t in api_b.tools}
+
+    evidence_tools = {
+        "record_symptom",
+        "record_observation",
+        "propose_hypothesis",
+        "attach_check",
+        "propose_update",
+    }
+    assert evidence_tools.issubset(tools_a), (
+        f"first session missing tools: {evidence_tools - tools_a}"
+    )
+    assert evidence_tools.issubset(tools_b), (
+        f"second session lost evidence tools (issue #156 regression): "
+        f"{evidence_tools - tools_b}"
+    )
+
+    # Each session must have published its own ``rca.gate`` instance.
+    gate_a = api_a.get_service("rca.gate")
+    gate_b = api_b.get_service("rca.gate")
+    assert gate_a is not None and gate_b is not None
+    assert gate_a is not gate_b
+
+
+def test_eight_sequential_sessions_each_install_cleanly() -> None:
+    """Stress the per-token rule: eight sessions, every gate must install."""
+
+    rca_hgraph_store._reset_for_tests()
+
+    tokens: list[Any] = []
+    for _ in range(8):
+        api = StubAPI()
+        _install_session_stack(api)
+        token = api.get_service("rca.hgraph.write_token")
+        assert isinstance(token, str) and token
+        tokens.append(token)
+        # The gate must have claimed (and therefore consumed) this token.
+        assert api.get_service("rca.gate") is not None
+
+    assert len(set(tokens)) == 8, "tokens must be unique across installs"

--- a/contrib/scenarios/rca_hfsm/tests/test_store_single_writer.py
+++ b/contrib/scenarios/rca_hfsm/tests/test_store_single_writer.py
@@ -63,19 +63,46 @@ def test_second_claim_with_different_token_also_raises() -> None:
         rca_hgraph_store.claim_write_handle("not-the-real-token")
 
 
-def test_claim_with_unknown_token_raises_and_locks_registry() -> None:
+def test_claim_with_unknown_token_raises_then_legit_token_still_works() -> None:
     api = _StubAPI()
     rca_hgraph_store.install(api, {})
     token = api.get_service("rca.hgraph.write_token")
 
-    # An attempt with a bogus token must raise.
+    # An attempt with a bogus token must raise (and the bogus token is
+    # marked claimed so a retry with the same bogus value still raises).
+    with pytest.raises(RuntimeError):
+        rca_hgraph_store.claim_write_handle("wrong")
     with pytest.raises(RuntimeError):
         rca_hgraph_store.claim_write_handle("wrong")
 
-    # And the legitimate token can no longer be redeemed afterwards — the
-    # single-writer invariant is "exactly one call succeeds, ever".
+    # The legitimate token is unaffected by tampering on a different
+    # token — the one-shot rule is scoped per token, not registry-wide,
+    # so multiple sessions in the same process can each redeem their own
+    # token (regression test for #156). Per-token poisoning still applies:
+    # claiming the legit token twice raises on the second call.
+    rca_hgraph_store.claim_write_handle(token)
     with pytest.raises(RuntimeError):
         rca_hgraph_store.claim_write_handle(token)
+
+
+def test_multiple_installs_each_redeem_their_own_token() -> None:
+    """Regression for #156 — process-wide registry must not block legit sessions.
+
+    Two ``install`` calls in the same process must each surface a unique
+    write token, and each token must redeem its corresponding handle.
+    """
+    api_a = _StubAPI()
+    rca_hgraph_store.install(api_a, {})
+    token_a = api_a.get_service("rca.hgraph.write_token")
+
+    api_b = _StubAPI()
+    rca_hgraph_store.install(api_b, {})
+    token_b = api_b.get_service("rca.hgraph.write_token")
+
+    assert token_a != token_b
+    handle_a = rca_hgraph_store.claim_write_handle(token_a)
+    handle_b = rca_hgraph_store.claim_write_handle(token_b)
+    assert handle_a is not handle_b
 
 
 def test_read_service_remains_available_after_install() -> None:


### PR DESCRIPTION
Closes #156.

## Summary

- Root cause: `rca_hgraph_store.claim_write_handle` used a process-wide one-shot lock (`if _claimed: raise`) instead of per-token semantics. The first session bootstrap consumed the lock; every subsequent bootstrap in the same process raised, cascading through the dependent atoms and silently stripping the five evidence tools from the LLM's catalog.
- Fix: scope the one-shot rule to the token. Each `install` mints a fresh `secrets.token_hex(16)`; `claim_write_handle` checks `if token in _claimed` instead. Design §7.4 single-writer invariant is preserved per token; multiple sessions in the same process now coexist.
- Regression test: two-session and eight-session smoke tests in `test_multi_session_in_process.py` exercise exactly the cascade the eval runner triggered.

## Diagnosis

The issue was filed as a "core substrate race". It is not a race and not in the substrate:

- `install()` is sync, runs serially in `session_factory.create_agent_session`'s `for module_path, ext_cfg in to_load:` loop. No `asyncio.gather`, no concurrent installs.
- The first session of a process produces all 13 tools. The second+ session produces 8 (missing the five from `rca_evidence_tools`). This is *deterministic*, not random.
- Stepping through the install ladder for session #2 (instrumented `session_factory._install_with_events`'s except branch to print) showed:
  ```
  !!! INSTALL FAILED rca_falsification_gate: RuntimeError('rca.hgraph write handle has already been claimed; ...')
  !!! INSTALL FAILED rca_evidence_tools:      RuntimeError('rca_evidence_tools: rca.gate missing; ...')
  !!! INSTALL FAILED rca_observation_cache:   RuntimeError('rca_observation_cache: rca.hgraph.read and rca.gate must be published; ...')
  ```
  Single failing atom → 3 cascaded failures → 5 missing tools.

The "non-determinism" in the original report came from the eval runner processing cases sequentially in one process: case 01 saw 13 tools (first session), cases 02/03 saw 8 (later sessions).

## Why the cascade was invisible

`session_factory.create_agent_session` swallows install exceptions and emits a `DiagnosticEvent(level='error', source='extension_loader', ...)`. The default `agentm` CLI subscribes to `DiagnosticEvent.CHANNEL` and prints to stderr — but the eval runner (`run_phase2_eval.py`) doesn't subscribe, so the errors vanished. This is a substrate UX issue worth tracking separately (see "Follow-ups" below), but it is not the root cause of #156.

## Why core substrate is **not** changed

- Install ordering is correct; manifest order is honored.
- No async/`gather` window between install and catalog snapshot. Catalog is built incrementally as each install calls `api.register_tool`, finalized when the install loop returns.
- The `_install_with_events` error swallow is intentional design — an optional atom (e.g., `duckdb_sql` with no `AGENTM_RCA_DATA_DIR`) should not take down the whole scenario.

A scenario-only fix is correct.

## Test plan

- [x] `cd contrib/scenarios/rca_hfsm && uv run pytest tests/` — 138 passed.
- [x] `uv run pytest --tb=short -q` (root) — 235 passed, 3 skipped (UI).
- [x] `uv run ruff check contrib/scenarios/rca_hfsm/src/agentm_rca_hfsm/atoms/rca_hgraph_store.py contrib/scenarios/rca_hfsm/tests/test_*` — clean.
- [x] `uv run mypy contrib/scenarios/rca_hfsm/src/agentm_rca_hfsm/atoms/rca_hgraph_store.py` — clean.
- [x] Standalone repro (`/tmp/repro_156.py`, 4 sessions in one process) — pre-fix: 1× 11 tools + 3× 6 tools; post-fix: 4× 11 tools (the missing 2 from 13 are duckdb_sql, gated by `AGENTM_RCA_DATA_DIR` env var the synthetic repro doesn't set).
- [x] Reverted the fix in a stash, ran `test_multi_session_in_process.py` — fails with the exact #156 error message. Restored.

## Follow-ups (not in this PR)

- Substrate UX: install-error visibility. The eval runner and other embedders silently lose install errors because they don't hook `DiagnosticEvent`. Options: opt-in `strict_extensions` flag on `AgentSessionConfig`, or a default stderr sink in `session_factory` that embedders can suppress. Not in scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)