### PR TITLE
Add strict A/B auditor fork experiments

### DIFF
--- a/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
+++ b/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
@@ -1517,7 +1517,15 @@ async def _run_auditor(
         return None, raw_blocks
 
 
+# Public aliases for downstream eval orchestrators that need to reconstruct
+# extractor/auditor inputs offline (e.g. agentm_rca baseline-fork mode).
+flatten_assistant_blocks = _flatten_assistant_blocks
+serialize_full_trajectory = _serialize_full_trajectory
+
+
 __all__ = [
     "MANIFEST",
+    "flatten_assistant_blocks",
     "install",
+    "serialize_full_trajectory",
 ]

--- a/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
+++ b/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
@@ -2,7 +2,7 @@
 
 See `.claude/designs/llmharness-cognitive-audit.md` for the full design.
 
-Phase 1 (extractor) on every TurnEndEvent:
+Phase 1 (extractor) on the configured TurnEndEvent cadence:
 * Slice the trajectory window since the last cursor.
 * Build a per-firing :class:`ExtractionState`, populate ``turn_texts``
   with rendered turn content (used by the witness pipeline).
@@ -139,6 +139,7 @@ MANIFEST = ExtensionManifest(
         "type": "object",
         "properties": {
             "mode": {"type": "string", "enum": ["async", "sync"]},
+            "extractor_interval_turns": {"type": "integer", "minimum": 1},
             "audit_interval_turns": {"type": "integer", "minimum": 1},
             "audit_summary_threshold": {"type": "integer", "minimum": 0},
             "prompt_override_extractor": {"type": "string"},
@@ -269,6 +270,7 @@ MANIFEST = ExtensionManifest(
 
 
 _DEFAULT_AUDIT_INTERVAL_TURNS = 3
+_DEFAULT_EXTRACTOR_INTERVAL_TURNS = 1
 _DEFAULT_RECENT_VERDICTS = _et.RECENT_VERDICTS_FOR_AUDITOR
 # 600s (10min) accommodates slow / proxied LLM endpoints (e.g. Warpgate-
 # fronted OpenAI-compatible servers at ~14s/call); a low default drops
@@ -462,6 +464,11 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     k = int(config.get("audit_interval_turns", _DEFAULT_AUDIT_INTERVAL_TURNS))
     if k < 1:
         k = _DEFAULT_AUDIT_INTERVAL_TURNS
+    extractor_k = int(
+        config.get("extractor_interval_turns", _DEFAULT_EXTRACTOR_INTERVAL_TURNS)
+    )
+    if extractor_k < 1:
+        extractor_k = _DEFAULT_EXTRACTOR_INTERVAL_TURNS
 
     summary_threshold_raw = config.get("audit_summary_threshold", _DEFAULT_AUDIT_SUMMARY_THRESHOLD)
     try:
@@ -573,13 +580,17 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
             nonlocal turn_count
             turn_count += 1
             messages_snapshot = tuple(event.messages)
-            extractor_ok = await _drain_extractor(
-                api=api,
-                job=_ExtractorJob(messages=messages_snapshot),
-                extractor_extensions=extractor_extensions,
-                extractor_provider=extractor_provider,
-            )
-            if enable_auditor and extractor_ok and (turn_count % k) == 0:
+            auditor_due = enable_auditor and (turn_count % k) == 0
+            extractor_due = (turn_count % extractor_k) == 0 or auditor_due
+            extractor_ok = True
+            if extractor_due:
+                extractor_ok = await _drain_extractor(
+                    api=api,
+                    job=_ExtractorJob(messages=messages_snapshot),
+                    extractor_extensions=extractor_extensions,
+                    extractor_provider=extractor_provider,
+                )
+            if auditor_due and extractor_ok:
                 await _drain_auditor(
                     api=api,
                     auditor_settings=auditor_settings,
@@ -619,10 +630,15 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     def _on_turn_end(event: TurnEndEvent) -> None:
         nonlocal turn_count
         turn_count += 1
-        _ensure_worker()
         messages_snapshot = tuple(event.messages)
-        queue.put_nowait(_ExtractorJob(messages=messages_snapshot))
-        if enable_auditor and (turn_count % k) == 0:
+        auditor_due = enable_auditor and (turn_count % k) == 0
+        extractor_due = (turn_count % extractor_k) == 0 or auditor_due
+        if not extractor_due and not auditor_due:
+            return
+        _ensure_worker()
+        if extractor_due:
+            queue.put_nowait(_ExtractorJob(messages=messages_snapshot))
+        if auditor_due:
             queue.put_nowait(_AuditorJob(messages=messages_snapshot))
 
     async def _on_session_shutdown(_event: SessionShutdownEvent) -> None:

--- a/contrib/extensions/llmharness/src/llmharness/aggregate/collector.py
+++ b/contrib/extensions/llmharness/src/llmharness/aggregate/collector.py
@@ -85,7 +85,8 @@ def _attach_auditor_graph_refs(
             for ext in extractor_firings
             if ext.status == "ok"
             and ext.output is not None
-            and (ext.ts_ns <= auditor.ts_ns or ext.turn_index <= auditor.turn_index)
+            and ext.ts_ns <= auditor.ts_ns
+            and ext.turn_index <= auditor.turn_index
         ]
         graph_ref = prior[-1].sequence if prior else 0
         input_payload = dict(auditor.input_payload)

--- a/contrib/extensions/llmharness/src/llmharness/aggregate/collector.py
+++ b/contrib/extensions/llmharness/src/llmharness/aggregate/collector.py
@@ -5,6 +5,7 @@ Pure function. No I/O writes; reads only the two sidecar files.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -25,10 +26,16 @@ def _firing_input_payload(rec: ReplayRecord) -> dict[str, Any]:
         "summary_threshold": ck.get("summary_threshold"),
     }
     if rec.phase == "auditor":
+        tools = ck.get("tools") or []
+        trajectory_snapshot = ck.get("trajectory_snapshot")
         out["findings"] = ck.get("findings") or []
         out["check_errors"] = ck.get("check_errors") or {}
         out["continuation_notes"] = ck.get("continuation_notes") or []
-        out["tools"] = ck.get("tools") or []
+        out["tools"] = tools
+        out["tools_profile"] = "minimal" if tools == ["submit_verdict"] else "custom"
+        out["trajectory_snapshot_len"] = (
+            len(trajectory_snapshot) if isinstance(trajectory_snapshot, list) else 0
+        )
     return out
 
 
@@ -58,6 +65,33 @@ def _to_firing(rec: ReplayRecord, sequence: int) -> FiringRecord:
         latency_ms=int(rec.latency_ms or 0),
         raw_assistant_messages=list(rec.raw_assistant_messages),
     )
+
+
+def _attach_auditor_graph_refs(
+    *,
+    auditor_firings: list[FiringRecord],
+    extractor_firings: list[FiringRecord],
+) -> list[FiringRecord]:
+    """Annotate auditor inputs with the graph snapshot they reviewed.
+
+    The web case viewer expects every auditor firing to point at the most
+    recent extractor snapshot. Older aggregate output omitted this because
+    the replay record stores extractor/auditor firings independently.
+    """
+    out: list[FiringRecord] = []
+    for auditor in auditor_firings:
+        prior = [
+            ext
+            for ext in extractor_firings
+            if ext.status == "ok"
+            and ext.output is not None
+            and (ext.ts_ns <= auditor.ts_ns or ext.turn_index <= auditor.turn_index)
+        ]
+        graph_ref = prior[-1].sequence if prior else 0
+        input_payload = dict(auditor.input_payload)
+        input_payload["graph_snapshot_ref"] = graph_ref
+        out.append(replace(auditor, input_payload=input_payload))
+    return out
 
 
 def _accumulate_graph(
@@ -248,6 +282,10 @@ def collect_case(
     auditor_firings = [
         _to_firing(r, seq) for seq, r in enumerate(auditor_records, start=1)
     ]
+    auditor_firings = _attach_auditor_graph_refs(
+        auditor_firings=auditor_firings,
+        extractor_firings=extractor_firings,
+    )
 
     meta_obj = read_sample_meta(meta_path) if meta_path is not None else None
     sample_id = (

--- a/contrib/extensions/llmharness/src/llmharness/audit/auditor/prompts/auditor_minimal.md
+++ b/contrib/extensions/llmharness/src/llmharness/audit/auditor/prompts/auditor_minimal.md
@@ -50,6 +50,13 @@ ids. Triggers worth flagging (non-exhaustive):
 - A repeated `act` signature already shown to be unproductive.
 - A `concl` overreaching what the cited `evid` actually establishes.
 - An imminent irreversible `act` with no precondition verification.
+- A narrowing drift: earlier `evid` names multiple material symptoms,
+  affected services, failing endpoints, or candidate causes, but later
+  `hyp` / `dec` events pursue only one branch while another named branch
+  remains unresolved. Surface only when the unresolved branch is concrete
+  and material, not when it is merely low-priority noise. The suggestion
+  should tell the agent to resolve or explicitly rule out that branch
+  before committing to a final causal story.
 
 If you cannot name a specific concern with specific ids, stay silent.
 A missed real drift costs less than a wrong reminder that erodes

--- a/contrib/extensions/llmharness/tests/test_two_phase_audit_integration.py
+++ b/contrib/extensions/llmharness/tests/test_two_phase_audit_integration.py
@@ -56,7 +56,9 @@ from llmharness.audit.entry_types import (
     EXTRACTOR_EMPTY,
     EXTRACTOR_NO_CALL,
     EXTRACTOR_PARTIAL,
+    VERDICT,
 )
+from llmharness.audit.auditor import SUBMIT_VERDICT_TOOL_NAME
 from llmharness.audit.extractor import SUBMIT_EVENTS_TOOL_NAME
 
 # --- shared constants -------------------------------------------------------
@@ -195,16 +197,7 @@ class _V31StubProvider:
         raise AssertionError(f"unknown stub mode {self.mode!r}")
 
     async def _auditor_iter(self) -> AsyncIterator[AssistantStreamEvent]:
-        # Auditor should never fire in these tests. If it does (e.g. k
-        # accidentally lowered), terminate cleanly so the session shuts
-        # down without hanging.
-        msg = AssistantMessage(
-            role="assistant",
-            content=[TextContent(type="text", text="(auditor stub — not exercised)")],
-            timestamp=999.0,
-            stop_reason="end_turn",
-        )
-        yield MessageEnd(message=msg)
+        yield MessageEnd(message=_submit_verdict_call())
 
 
 def _submit_events_call(*, events: list[dict[str, Any]]) -> AssistantMessage:
@@ -222,6 +215,30 @@ def _submit_events_call(*, events: list[dict[str, Any]]) -> AssistantMessage:
             )
         ],
         timestamp=600.0,
+        stop_reason="tool_use",
+    )
+
+
+def _submit_verdict_call() -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[
+            ToolCallBlock(
+                type="tool_call",
+                id="verdict-1",
+                name=SUBMIT_VERDICT_TOOL_NAME,
+                arguments={
+                    "verdict": {
+                        "surface_reminder": False,
+                        "reminder_text": "",
+                        "continuation_notes": ["stub auditor saw the graph"],
+                        "matched_event_ids": [],
+                        "cited_cards": [],
+                    }
+                },
+            )
+        ],
+        timestamp=999.0,
         stop_reason="tool_use",
     )
 
@@ -279,8 +296,58 @@ def _build_session_config(*, cwd: str, provider_module: str) -> AgentSessionConf
     )
 
 
+def _build_interval_session_config(
+    *,
+    cwd: str,
+    provider_module: str,
+    interval_turns: int,
+) -> AgentSessionConfig:
+    config = _build_session_config(cwd=cwd, provider_module=provider_module)
+    extensions = list(config.extensions)
+    extensions[-1] = (
+        "llmharness.adapters.agentm",
+        {
+            "mode": "sync",
+            "extractor_interval_turns": interval_turns,
+            "audit_interval_turns": interval_turns,
+            "cards_tools_config": None,
+            "observability_config": None,
+        },
+    )
+    config.extensions = extensions
+    return config
+
+
 def _entries(session: AgentSession, entry_type: str) -> list[Any]:
     return [e for e in session.session_manager.get_active_branch() if e.type == entry_type]
+
+
+@pytest.mark.asyncio
+async def test_extractor_and_auditor_fire_together_on_configured_interval(
+    tmp_path: Path,
+) -> None:
+    provider = _V31StubProvider(mode="happy")
+    provider_module = _install_provider_module(
+        "tests._fake_v31_interval_provider", provider
+    )
+
+    session = await AgentSession.create(
+        _build_interval_session_config(
+            cwd=str(tmp_path),
+            provider_module=provider_module,
+            interval_turns=3,
+        )
+    )
+    await session.prompt("user turn 1")
+    await session.prompt("user turn 2")
+    await session.prompt("user turn 3")
+    await session.shutdown()
+
+    assert provider.parent_calls == 3
+    assert provider.extractor_calls == 1
+    assert provider.auditor_calls == 1
+    assert len(_entries(session, AUDIT_EVENT)) == 2
+    assert len(_entries(session, VERDICT)) == 1
 
 
 # --- Scenario 1: happy path ------------------------------------------------

--- a/contrib/scenarios/rca/manifest.harness.sync.extractor5.yaml
+++ b/contrib/scenarios/rca/manifest.harness.sync.extractor5.yaml
@@ -1,0 +1,23 @@
+name: rca:harness.sync.extractor5
+description: rca:harness.sync with extractor firing every 5 main-agent turns and auditor disabled.
+task_class: rca_baseline
+
+extensions:
+  - module: agentm.extensions.builtin.operations_local
+  - module: agentm_rca.tools.thinkdepth_sql
+  - module: agentm_rca.tools.finalize
+  - module: agentm.extensions.builtin.observability
+  - module: agentm.extensions.builtin.otel_tracing
+  - module: contrib.extensions.rcabench_contract
+  - module: agentm_rca.prompt_loader
+    config:
+      prompt: investigator.md
+      personas: false
+  - module: agentm_rca.runtime_context
+  - module: llmharness.adapters.agentm
+    config:
+      mode: sync
+      extractor_interval_turns: 5
+      audit_interval_turns: 5
+      enable_auditor: false
+      enable_reminders: false

--- a/contrib/scenarios/rca/manifest.harness.sync.opinions.yaml
+++ b/contrib/scenarios/rca/manifest.harness.sync.opinions.yaml
@@ -26,9 +26,12 @@ extensions:
       personas: false
   - module: agentm_rca.runtime_context
 
-  # Sync audit, opinions-only: enable_reminders=false keeps the audit
-  # output observable while preventing main-agent intervention.
+  # Sync audit, opinions-only: every 5 main-agent turns, run extractor
+  # first and then auditor; enable_reminders=false keeps the audit output
+  # observable while preventing main-agent intervention.
   - module: llmharness.adapters.agentm
     config:
       mode: sync
+      extractor_interval_turns: 5
+      audit_interval_turns: 5
       enable_reminders: false

--- a/contrib/scenarios/rca/manifest.harness.sync.opinions10.yaml
+++ b/contrib/scenarios/rca/manifest.harness.sync.opinions10.yaml
@@ -1,0 +1,31 @@
+name: rca:harness.sync.opinions10
+description: |
+  Opinions-only harness variant for baseline-fork intervention experiments.
+
+  The main RCA agent is never modified by auditor reminders in this
+  scenario. Extractor and auditor still run synchronously every 10 main-agent
+  turns and persist replay sidecars. A separate eval orchestration mode can
+  then inspect those fixed-baseline auditor verdicts, fork from a selected
+  turn, seed the reminder into the fork, and continue the new branch.
+
+task_class: rca_baseline
+
+extensions:
+  - module: agentm.extensions.builtin.operations_local
+  - module: agentm_rca.tools.thinkdepth_sql
+  - module: agentm_rca.tools.finalize
+  - module: agentm.extensions.builtin.observability
+  - module: agentm.extensions.builtin.otel_tracing
+  - module: contrib.extensions.rcabench_contract
+  - module: agentm_rca.prompt_loader
+    config:
+      prompt: investigator.md
+      personas: false
+  - module: agentm_rca.runtime_context
+  - module: llmharness.adapters.agentm
+    config:
+      mode: sync
+      extractor_interval_turns: 10
+      audit_interval_turns: 10
+      enable_auditor: true
+      enable_reminders: false

--- a/contrib/scenarios/rca/manifest.harness.sync.yaml
+++ b/contrib/scenarios/rca/manifest.harness.sync.yaml
@@ -8,7 +8,7 @@ description: |
   for the extractor (always) and auditor (every k turns) to finish
   before it issues the next LLM call. That guarantees:
 
-    * Every turn has a paired ``llmharness.audit_event`` set persisted.
+    * Every configured extractor interval has a paired ``llmharness.audit_event`` set persisted.
     * Every k turns has a paired ``llmharness.verdict``.
     * No data is lost on session shutdown timeouts (nothing is queued).
 
@@ -48,7 +48,10 @@ extensions:
   # The only line that differs from manifest.harness.yaml: ``mode: sync``.
   # Per-turn wall time grows by the extractor child latency (~10-15s for a
   # haiku-class model, ~20-30s for a frontier model); plan budgets
-  # accordingly. Auditor child fires every ``audit_interval_turns`` turns.
+  # accordingly. Extractor and auditor both fire every 5 main-agent turns;
+  # extractor runs first, then auditor judges the freshly updated graph.
   - module: llmharness.adapters.agentm
     config:
       mode: sync
+      extractor_interval_turns: 5
+      audit_interval_turns: 5

--- a/contrib/scenarios/rca/manifest.harness.yaml
+++ b/contrib/scenarios/rca/manifest.harness.yaml
@@ -6,8 +6,9 @@ description: |
   ``rca:baseline`` (no drift on the investigator side), with
   ``llmharness.adapters.agentm`` mounted on top to provide:
 
-    * Phase 1 — per-turn extractor that converts each TurnEndEvent into
-      structured ``Event`` entries on the session bus.
+    * Phase 1 — cadence-controlled extractor that converts recent
+      TurnEndEvent windows into structured ``Event`` entries on the
+      session bus.
     * Phase 2 — every-k-turns graph auditor that emits ``Verdict`` /
       ``Reminder`` entries; ``drift=true`` reminders are delivered to the
       main agent as synthetic user messages on the next
@@ -53,12 +54,10 @@ extensions:
   # --- cognitive-audit adapter (the only addition over baseline) ---
   # Mounted as a flat-file extension; the package is installed via
   # ``pip install -e contrib/extensions/llmharness`` (see its CLAUDE.md).
-  # Defaults: audit_interval_turns=3, recent_verdicts=5. Override here
-  # if you want a tighter / looser audit cadence per eval campaign.
+  # Extractor and auditor fire every 5 main-agent turns; extractor runs
+  # first, then auditor judges the freshly updated graph.
   - module: llmharness.adapters.agentm
     config:
-      # DEBUG: sync mode — each turn_end blocks the main agent until the
-      # extractor (and any due auditor) child session completes. Slower
-      # per-turn but no shutdown drain backlog. Useful for measuring the
-      # v3.1 single-tool extractor's per-firing cost.
       mode: sync
+      extractor_interval_turns: 5
+      audit_interval_turns: 5

--- a/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
+++ b/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
@@ -30,6 +30,7 @@ construction through ``ExtensionAPI`` instead.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import os
 from typing import Any
@@ -59,6 +60,14 @@ _DEFAULT_MAX_TURNS = 128
 _EMPTY_AGENT_RCA_OUTPUT: dict[str, list[Any]] = {
     "root_causes": [],
     "propagation": [],
+}
+
+_INTERVENTION_BASELINE_FORK = "baseline_fork"
+_BASELINE_FORK_ALIASES = {
+    "baseline_fork",
+    "baseline-fork",
+    "fork_audit",
+    "fork-audit",
 }
 
 
@@ -136,6 +145,46 @@ def _coerce_max_turns(value: Any, fallback: int) -> int:
     return result if result > 0 else fallback
 
 
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off", ""}:
+        return False
+    return default
+
+
+@dataclass(frozen=True)
+class _ReminderCandidate:
+    turn_index: int
+    text: str
+    record: Any
+
+
+@dataclass(frozen=True)
+class _OfflineAuditRun:
+    reminder: _ReminderCandidate | None
+    records: list[Any]
+
+
+@dataclass(frozen=True)
+class _SessionRun:
+    result: AgentResult
+    final_messages: list[Any]
+    response: str
+    submission_dump: Any
+    submit_final_report_seen: bool
+    system_prompt: str
+    session_id: str
+    root_session_id: str
+    session_log_id: str
+    audit_replay_path: str
+
+
 class AgentMAgent(BaseAgent):
     """Run an RCA investigation through an in-process AgentM session."""
 
@@ -147,6 +196,11 @@ class AgentMAgent(BaseAgent):
         provider: str | None = None,
         exp_id: str | None = None,
         max_turns: Any = None,
+        intervention_mode: str | None = None,
+        control_scenario: str | None = None,
+        branch_scenario: str | None = None,
+        fork_audit: Any = None,
+        fork_policy: str = "first_surface",
         **_extra: Any,
     ) -> None:
         # ``rcabench-platform`` passes ``exp_id`` plus any ``--ak key=value``
@@ -162,6 +216,28 @@ class AgentMAgent(BaseAgent):
         )
         self._exp_id = exp_id
         self._max_turns = _coerce_max_turns(max_turns, _DEFAULT_MAX_TURNS)
+        if intervention_mode:
+            mode = intervention_mode.strip()
+            self._intervention_mode = (
+                _INTERVENTION_BASELINE_FORK
+                if mode in _BASELINE_FORK_ALIASES
+                else mode
+            )
+        elif _coerce_bool(fork_audit):
+            self._intervention_mode = _INTERVENTION_BASELINE_FORK
+        else:
+            self._intervention_mode = None
+        self._fork_policy = fork_policy
+        self._control_scenario = (
+            control_scenario
+            or os.environ.get("AGENTM_FORK_CONTROL_SCENARIO")
+            or _default_control_scenario(scenario)
+        )
+        self._branch_scenario = (
+            branch_scenario
+            or os.environ.get("AGENTM_FORK_BRANCH_SCENARIO")
+            or self._control_scenario
+        )
 
     @staticmethod
     def name() -> str:
@@ -176,6 +252,147 @@ class AgentMAgent(BaseAgent):
         data_dir: str,
         **kwargs: Any,
     ) -> AgentResult:
+        if self._intervention_mode == _INTERVENTION_BASELINE_FORK:
+            return await self._run_baseline_fork(
+                incident=incident,
+                data_dir=data_dir,
+                **kwargs,
+            )
+        if self._intervention_mode:
+            raise ValueError(f"unknown intervention_mode={self._intervention_mode!r}")
+        return await self._run_single_session(
+            incident=incident,
+            data_dir=data_dir,
+            scenario=self._scenario,
+            **kwargs,
+        )
+
+    async def _run_single_session(
+        self,
+        *,
+        incident: str | None,
+        data_dir: str,
+        scenario: str,
+        initial_messages: list[Any] | None = None,
+        seed_reminder_text: str | None = None,
+        metadata_extra: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AgentResult:
+        run = await self._execute_session(
+            incident=incident,
+            data_dir=data_dir,
+            scenario=scenario,
+            initial_messages=initial_messages,
+            seed_reminder_text=seed_reminder_text,
+            **kwargs,
+        )
+        if not metadata_extra:
+            return run.result
+        metadata = dict(run.result.metadata or {})
+        metadata.update(metadata_extra)
+        return AgentResult(
+            response=run.result.response,
+            trajectory=run.result.trajectory,
+            trace_id=run.result.trace_id,
+            metadata=metadata,
+        )
+
+    async def _run_baseline_fork(
+        self,
+        *,
+        incident: str,
+        data_dir: str,
+        **kwargs: Any,
+    ) -> AgentResult:
+        if self._fork_policy != "first_surface":
+            raise ValueError(
+                "baseline_fork currently supports only fork_policy='first_surface'"
+            )
+
+        control = await self._execute_session(
+            incident=incident,
+            data_dir=data_dir,
+            scenario=self._control_scenario,
+            **kwargs,
+        )
+        offline_audit = await _run_offline_auditor_over_control(
+            control=control,
+            cwd=os.getcwd(),
+            provider=_build_provider(self._provider, self._model),
+        )
+        reminder = offline_audit.reminder
+        if reminder is None:
+            metadata = dict(control.result.metadata or {})
+            metadata["intervention_mode"] = _INTERVENTION_BASELINE_FORK
+            metadata["intervention_status"] = "no_surface_reminder"
+            metadata["control_scenario"] = self._control_scenario
+            metadata["branch_scenario"] = self._branch_scenario
+            metadata["control"] = _run_metadata(control)
+            metadata["offline_auditor_firings"] = len(offline_audit.records)
+            return AgentResult(
+                response=control.result.response,
+                trajectory=control.result.trajectory,
+                trace_id=control.result.trace_id,
+                metadata=metadata,
+            )
+
+        prefix_messages = _fork_prefix_messages(
+            control.final_messages,
+            turn_index=reminder.turn_index,
+        )
+        branch = await self._execute_session(
+            incident=None,
+            data_dir=data_dir,
+            scenario=self._branch_scenario,
+            initial_messages=prefix_messages,
+            seed_reminder_text=reminder.text,
+            **kwargs,
+        )
+        branch_audit = await _run_offline_auditor_over_control(
+            control=branch,
+            cwd=os.getcwd(),
+            provider=_build_provider(self._provider, self._model),
+            stop_on_first_surface=False,
+        )
+        strict_replay_path = _write_strict_ab_replay(
+            control=control,
+            branch=branch,
+            offline_auditor_records=offline_audit.records,
+            branch_auditor_records=branch_audit.records,
+            reminder=reminder,
+            cwd=os.getcwd(),
+        )
+        metadata = dict(branch.result.metadata or {})
+        metadata["intervention_mode"] = _INTERVENTION_BASELINE_FORK
+        metadata["intervention_status"] = "forked"
+        metadata["control_scenario"] = self._control_scenario
+        metadata["branch_scenario"] = self._branch_scenario
+        metadata["strict_ab_replay_path"] = strict_replay_path
+        metadata["fork"] = {
+            "policy": self._fork_policy,
+            "turn_index": reminder.turn_index,
+            "reminder_text": reminder.text,
+            "prefix_message_count": len(prefix_messages),
+        }
+        metadata["control"] = _run_metadata(control)
+        metadata["branch"] = _run_metadata(branch)
+        return AgentResult(
+            response=branch.result.response,
+            trajectory=branch.result.trajectory,
+            trace_id=branch.result.trace_id,
+            metadata=metadata,
+        )
+
+    async def _execute_session(
+        self,
+        *,
+        incident: str | None,
+        data_dir: str,
+        scenario: str,
+        initial_messages: list[Any] | None = None,
+        seed_reminder_text: str | None = None,
+        **kwargs: Any,
+    ) -> _SessionRun:
         from agentm.core.abi import (
             BeforeSendToLlmEvent,
             EventBus,
@@ -251,7 +468,7 @@ class AgentMAgent(BaseAgent):
         # Mount conditionally — binding is dead weight without the harness
         # adapter that produces the replay sidecar in the first place.
         extra_extensions: list[tuple[str, dict[str, Any]]] = []
-        if "harness" in self._scenario:
+        if "harness" in scenario:
             sample_id = os.path.basename(data_dir.rstrip("/")) or "unknown"
             extra_extensions.append(
                 (
@@ -268,12 +485,20 @@ class AgentMAgent(BaseAgent):
                     },
                 )
             )
+        if seed_reminder_text:
+            extra_extensions.append(
+                (
+                    "llmharness.replay.reminder_seed",
+                    {"text": seed_reminder_text},
+                )
+            )
 
         config = AgentSessionConfig(
             cwd=os.getcwd(),
             provider=(provider_module, provider_config),
-            scenario=self._scenario,
+            scenario=scenario,
             extra_extensions=extra_extensions,
+            initial_messages=list(initial_messages or []),
             bus=bus,
             loop_config=LoopConfig(max_turns=max_turns),
         )
@@ -282,7 +507,10 @@ class AgentMAgent(BaseAgent):
         try:
             if ctx is not None:
                 ctx.emit({"type": "running", "run_id": session.session_id})
-            final_messages = await session.prompt(incident)
+            if incident is None:
+                final_messages = await session.tick()
+            else:
+                final_messages = await session.prompt(incident)
         finally:
             await session.shutdown()
 
@@ -297,7 +525,7 @@ class AgentMAgent(BaseAgent):
             )
 
         trajectory = _build_trajectory(
-            agent_name=f"agentm:{self._scenario}",
+            agent_name=f"agentm:{scenario}",
             system_prompt=captured["system_prompt"],
             final_messages=final_messages,
         )
@@ -310,19 +538,428 @@ class AgentMAgent(BaseAgent):
         # every spawned extractor / auditor child JSONL. ``session_id``
         # is kept in metadata for completeness — it identifies the
         # parent's session-root span specifically.
-        return AgentResult(
+        session_log_id = session.session_manager.get_session_id()
+        audit_replay_path = os.path.join(
+            os.getcwd(), ".agentm", "audit_replay", f"{session_log_id}.jsonl"
+        )
+        metadata = {
+            "model": self._model,
+            "scenario": scenario,
+            "max_turns": max_turns,
+            "submit_final_report_seen": submission is not None,
+            "submission": submission_dump,
+            "session_id": session.session_id,
+            "session_log_id": session_log_id,
+            "audit_replay_path": audit_replay_path,
+        }
+        result = AgentResult(
             response=response,
             trajectory=trajectory,
             trace_id=session.root_session_id,
-            metadata={
-                "model": self._model,
-                "scenario": self._scenario,
-                "max_turns": max_turns,
-                "submit_final_report_seen": submission is not None,
-                "submission": submission_dump,
-                "session_id": session.session_id,
-            },
+            metadata=metadata,
         )
+        return _SessionRun(
+            result=result,
+            final_messages=final_messages,
+            response=response,
+            submission_dump=submission_dump,
+            submit_final_report_seen=submission is not None,
+            system_prompt=captured["system_prompt"],
+            session_id=session.session_id,
+            root_session_id=session.root_session_id,
+            session_log_id=session_log_id,
+            audit_replay_path=audit_replay_path,
+        )
+
+
+def _default_control_scenario(scenario: str) -> str:
+    """Pick a no-auditor control scenario for strict A/B fork mode."""
+    if scenario in {
+        "rca:harness.sync",
+        "rca:harness.sync.opinions",
+        "rca:harness.sync.opinions10",
+    }:
+        return "rca:harness.sync.extractor5"
+    return scenario
+
+
+def _coerce_schema_list(cls: Any, items: Any) -> list[Any]:
+    out: list[Any] = []
+    if not isinstance(items, list):
+        return out
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        try:
+            out.append(cls.from_dict(item))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return out
+
+
+async def _run_offline_auditor_over_control(
+    *,
+    control: _SessionRun,
+    cwd: str,
+    provider: tuple[str, dict[str, Any]] | None,
+    stop_on_first_surface: bool = True,
+) -> _OfflineAuditRun:
+    """Run auditor side-channel over the fixed control trajectory.
+
+    Strict A/B means the control session must not mount the auditor. This
+    helper reconstructs each auditor firing from the extractor-only replay
+    sidecar, so the judgment is made against an immutable control prefix.
+    """
+    from pathlib import Path
+
+    from llmharness.adapters.agentm import (
+        _flatten_assistant_blocks,
+        _serialize_full_trajectory,
+    )
+    from llmharness.audit.auditor.output import (
+        AuditorOutputError,
+        RawVerdictOutput,
+    )
+    from llmharness.audit.phase import merge_to_phases
+    from llmharness.replay.record import ReplayRecord, iter_records, now_ns
+    from llmharness.replay.runner import replay_auditor_record
+    from llmharness.schema import Edge, Event
+
+    replay_path = Path(control.audit_replay_path)
+    if not replay_path.exists():
+        return _OfflineAuditRun(reminder=None, records=[])
+
+    events: list[Any] = []
+    edges: list[Any] = []
+    phases: list[Any] = []
+    recent_verdicts: list[dict[str, Any]] = []
+    continuation_notes: list[str] = []
+    auditor_records: list[Any] = []
+
+    extractor_records = [
+        rec
+        for rec in iter_records(replay_path)
+        if rec.phase == "extractor" and rec.status == "ok" and rec.output
+    ]
+    extractor_records.sort(key=lambda rec: (rec.ts_ns, rec.turn_index))
+
+    for extractor_record in extractor_records:
+        output = extractor_record.output or {}
+        new_events = _coerce_schema_list(Event, output.get("events") or [])
+        new_edges = _coerce_schema_list(Edge, output.get("edges") or [])
+        events.extend(new_events)
+        edges.extend(new_edges)
+        phases.extend(merge_to_phases(new_events))
+
+        cut = min(max(extractor_record.turn_index + 1, 0), len(control.final_messages))
+        trajectory_snapshot = _serialize_full_trajectory(control.final_messages[:cut])
+        compose_kwargs = {
+            "base_prompt": None,
+            "cards_tools_config": {},
+            "observability_config": {},
+            "trajectory_snapshot": trajectory_snapshot,
+            "events": [ev.to_dict() for ev in events],
+            "edges": [ed.to_dict() for ed in edges],
+            "phases": [ph.to_dict() for ph in phases],
+            "findings": [],
+            "check_errors": {},
+            "continuation_notes": list(continuation_notes),
+            "summary_threshold": 30,
+            "tools": ["submit_verdict"],
+        }
+        payload = {
+            "graph": [ev.to_dict() for ev in events],
+            "recent_verdicts": list(recent_verdicts),
+            "continuation_notes_from_prior_firing": list(continuation_notes),
+        }
+        replay_record = ReplayRecord(
+            phase="auditor",
+            turn_index=extractor_record.turn_index,
+            root_session_id=control.session_log_id,
+            ts_ns=(extractor_record.ts_ns or now_ns()) + 1,
+            compose_kwargs=compose_kwargs,
+            payload=payload,
+            provider=None,
+            output=None,
+            status="ok",
+        )
+        phase_result = await replay_auditor_record(
+            replay_record,
+            cwd=cwd,
+            provider_override=provider,
+        )
+        verdict_dict: dict[str, Any] | None = None
+        if phase_result.status == "ok" and isinstance(phase_result.output, dict):
+            try:
+                verdict_dict = RawVerdictOutput.from_dict(
+                    phase_result.output
+                ).to_verdict().to_dict()
+            except AuditorOutputError:
+                verdict_dict = None
+        auditor_record = ReplayRecord(
+            phase="auditor",
+            turn_index=extractor_record.turn_index,
+            root_session_id=control.session_log_id,
+            ts_ns=replay_record.ts_ns,
+            compose_kwargs=compose_kwargs,
+            payload=payload,
+            provider=[provider[0], provider[1]] if provider else None,
+            output=verdict_dict,
+            status=phase_result.status if verdict_dict is not None else "no_call",
+            error=phase_result.error,
+            latency_ms=phase_result.latency_ms,
+            raw_assistant_messages=_flatten_assistant_blocks(phase_result.messages),
+        )
+        auditor_records.append(auditor_record)
+
+        verdict = verdict_dict
+        if verdict is not None:
+            recent_verdicts.append(verdict)
+            raw_notes = verdict.get("continuation_notes")
+            continuation_notes = [
+                str(n) for n in raw_notes if isinstance(n, str)
+            ] if isinstance(raw_notes, list) else []
+
+        if not verdict or not verdict.get("surface_reminder"):
+            continue
+        text = verdict.get("reminder_text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        reminder = _ReminderCandidate(
+            turn_index=extractor_record.turn_index,
+            text=text,
+            record=auditor_record,
+        )
+        if stop_on_first_surface:
+            return _OfflineAuditRun(reminder=reminder, records=auditor_records)
+
+    first_reminder = next(
+        (
+            _ReminderCandidate(
+                turn_index=int(record.turn_index),
+                text=str((record.output or {}).get("reminder_text", "")),
+                record=record,
+            )
+            for record in auditor_records
+            if isinstance(record.output, dict)
+            and record.output.get("surface_reminder")
+            and str(record.output.get("reminder_text", "")).strip()
+        ),
+        None,
+    )
+    return _OfflineAuditRun(reminder=first_reminder, records=auditor_records)
+
+
+def _clone_replay_record(
+    record: Any,
+    *,
+    root_session_id: str,
+    ts_ns: int | None = None,
+) -> Any:
+    from llmharness.replay.record import ReplayRecord
+
+    provider = record.provider
+    if isinstance(provider, list):
+        provider = list(provider)
+    return ReplayRecord(
+        phase=record.phase,
+        turn_index=int(record.turn_index),
+        root_session_id=root_session_id,
+        ts_ns=int(ts_ns if ts_ns is not None else record.ts_ns),
+        compose_kwargs=dict(record.compose_kwargs or {}),
+        payload=dict(record.payload or {}),
+        provider=provider,
+        output=dict(record.output) if isinstance(record.output, dict) else record.output,
+        status=record.status,
+        error=record.error,
+        latency_ms=int(record.latency_ms or 0),
+        extras=dict(record.extras or {}),
+        raw_assistant_messages=list(record.raw_assistant_messages or []),
+    )
+
+
+def _write_strict_ab_replay(
+    *,
+    control: _SessionRun,
+    branch: _SessionRun,
+    offline_auditor_records: list[Any],
+    branch_auditor_records: list[Any] | None = None,
+    reminder: _ReminderCandidate,
+    cwd: str,
+) -> str:
+    """Materialize the website sidecar for the with-auditor branch.
+
+    The sidecar is intentionally composed as:
+    control extractor/auditor prefix -> branch extractor/auditor tail. Silent
+    auditor verdicts are persisted too, so the case viewer shows one auditor
+    firing for every extractor firing while only the surfaced reminder changes
+    the main-agent trajectory.
+    """
+    from pathlib import Path
+
+    from llmharness.replay.record import iter_records, write_record
+
+    out_path = (
+        Path(cwd)
+        / ".agentm"
+        / "audit_replay"
+        / f"{branch.session_log_id}.strict_ab.jsonl"
+    )
+    if out_path.exists():
+        out_path.unlink()
+
+    control_records = list(iter_records(Path(control.audit_replay_path)))
+    branch_records = list(iter_records(Path(branch.audit_replay_path)))
+    root_session_id = branch.session_log_id
+    control_auditors_by_turn = {
+        int(record.turn_index): record for record in offline_auditor_records
+    }
+    branch_auditors_by_turn = {
+        int(record.turn_index): record for record in (branch_auditor_records or [])
+    }
+
+    for record in control_records:
+        if record.phase != "extractor":
+            continue
+        if int(record.turn_index) > reminder.turn_index:
+            continue
+        write_record(
+            out_path,
+            _clone_replay_record(record, root_session_id=root_session_id),
+        )
+        auditor = control_auditors_by_turn.get(int(record.turn_index))
+        if auditor is not None:
+            write_record(
+                out_path,
+                _clone_replay_record(auditor, root_session_id=root_session_id),
+            )
+
+    branch_tail_written = False
+    for record in branch_records:
+        if record.phase != "extractor":
+            continue
+        if int(record.turn_index) <= reminder.turn_index:
+            continue
+        branch_tail_written = True
+        write_record(
+            out_path,
+            _clone_replay_record(record, root_session_id=root_session_id),
+        )
+        auditor = branch_auditors_by_turn.get(int(record.turn_index))
+        if auditor is not None:
+            write_record(
+                out_path,
+                _clone_replay_record(auditor, root_session_id=root_session_id),
+            )
+
+    if not branch_tail_written:
+        for record in branch_records:
+            if record.phase != "extractor":
+                continue
+            write_record(
+                out_path,
+                _clone_replay_record(record, root_session_id=root_session_id),
+            )
+            auditor = branch_auditors_by_turn.get(int(record.turn_index))
+            if auditor is not None:
+                write_record(
+                    out_path,
+                    _clone_replay_record(auditor, root_session_id=root_session_id),
+                )
+
+    return str(out_path)
+
+
+def _find_first_surface_reminder(audit_replay_path: str) -> _ReminderCandidate | None:
+    """Pick the first auditor verdict that would have affected the agent.
+
+    The baseline-fork experiment runs the baseline with reminders disabled,
+    so the replay sidecar is the only place where auditor decisions live.
+    """
+    if not os.path.exists(audit_replay_path):
+        return None
+
+    with open(audit_replay_path, encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if record.get("phase") != "auditor":
+                continue
+            if record.get("status") != "ok":
+                continue
+            output = record.get("output")
+            if not isinstance(output, dict):
+                continue
+            if not output.get("surface_reminder"):
+                continue
+            text = output.get("reminder_text")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            try:
+                turn_index = int(record.get("turn_index"))
+            except (TypeError, ValueError):
+                continue
+            return _ReminderCandidate(
+                turn_index=turn_index,
+                text=text,
+                record=record,
+            )
+    return None
+
+
+def _fork_prefix_messages(final_messages: list[Any], *, turn_index: int) -> list[Any]:
+    """Return the main-agent prefix that matches live reminder delivery.
+
+    ``llmharness`` records the auditor turn at ``TurnEndEvent`` time, which
+    is after the assistant message but before tool execution. In the live
+    path the reminder is injected only after the turn's tool results have
+    been appended, so a prefix fork must include the paired ToolResultMessage
+    when the turn's assistant message made tool calls.
+    """
+    if turn_index < 0:
+        return []
+    cut = min(turn_index + 1, len(final_messages))
+    if cut >= len(final_messages):
+        return list(final_messages[:cut])
+
+    from agentm.core.abi.messages import (
+        AssistantMessage,
+        ToolCallBlock,
+        ToolResultMessage,
+    )
+
+    current = final_messages[turn_index] if turn_index < len(final_messages) else None
+    following = final_messages[cut]
+    if isinstance(current, AssistantMessage) and isinstance(
+        following, ToolResultMessage
+    ):
+        assistant_tool_call_ids = {
+            block.id for block in current.content if isinstance(block, ToolCallBlock)
+        }
+        result_tool_call_ids = {
+            block.tool_call_id
+            for block in following.content
+            if hasattr(block, "tool_call_id")
+        }
+        if assistant_tool_call_ids & result_tool_call_ids:
+            cut += 1
+    return list(final_messages[:cut])
+
+
+def _run_metadata(run: _SessionRun) -> dict[str, Any]:
+    return {
+        "response": run.response,
+        "submission": run.submission_dump,
+        "submit_final_report_seen": run.submit_final_report_seen,
+        "session_id": run.session_id,
+        "root_session_id": run.root_session_id,
+        "session_log_id": run.session_log_id,
+        "audit_replay_path": run.audit_replay_path,
+    }
 
 
 def _build_trajectory(

--- a/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
+++ b/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
@@ -613,8 +613,8 @@ async def _run_offline_auditor_over_control(
     from pathlib import Path
 
     from llmharness.adapters.agentm import (
-        _flatten_assistant_blocks,
-        _serialize_full_trajectory,
+        flatten_assistant_blocks,
+        serialize_full_trajectory,
     )
     from llmharness.audit.auditor.output import (
         AuditorOutputError,
@@ -652,7 +652,7 @@ async def _run_offline_auditor_over_control(
         phases.extend(merge_to_phases(new_events))
 
         cut = min(max(extractor_record.turn_index + 1, 0), len(control.final_messages))
-        trajectory_snapshot = _serialize_full_trajectory(control.final_messages[:cut])
+        trajectory_snapshot = serialize_full_trajectory(control.final_messages[:cut])
         compose_kwargs = {
             "base_prompt": None,
             "cards_tools_config": {},
@@ -708,7 +708,7 @@ async def _run_offline_auditor_over_control(
             status=phase_result.status if verdict_dict is not None else "no_call",
             error=phase_result.error,
             latency_ms=phase_result.latency_ms,
-            raw_assistant_messages=_flatten_assistant_blocks(phase_result.messages),
+            raw_assistant_messages=flatten_assistant_blocks(phase_result.messages),
         )
         auditor_records.append(auditor_record)
 
@@ -868,47 +868,6 @@ def _write_strict_ab_replay(
                 )
 
     return str(out_path)
-
-
-def _find_first_surface_reminder(audit_replay_path: str) -> _ReminderCandidate | None:
-    """Pick the first auditor verdict that would have affected the agent.
-
-    The baseline-fork experiment runs the baseline with reminders disabled,
-    so the replay sidecar is the only place where auditor decisions live.
-    """
-    if not os.path.exists(audit_replay_path):
-        return None
-
-    with open(audit_replay_path, encoding="utf-8") as handle:
-        for line in handle:
-            if not line.strip():
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if record.get("phase") != "auditor":
-                continue
-            if record.get("status") != "ok":
-                continue
-            output = record.get("output")
-            if not isinstance(output, dict):
-                continue
-            if not output.get("surface_reminder"):
-                continue
-            text = output.get("reminder_text")
-            if not isinstance(text, str) or not text.strip():
-                continue
-            try:
-                turn_index = int(record.get("turn_index"))
-            except (TypeError, ValueError):
-                continue
-            return _ReminderCandidate(
-                turn_index=turn_index,
-                text=text,
-                record=record,
-            )
-    return None
 
 
 def _fork_prefix_messages(final_messages: list[Any], *, turn_index: int) -> list[Any]:


### PR DESCRIPTION
## Summary
- add `extractor_interval_turns` so llmharness can run extractor on a configurable cadence while still forcing extractor before due auditor firings
- add strict A/B auditor fork orchestration for RCA evals: run a no-auditor control, audit the fixed control trajectory offline, then fork only when an auditor reminder surfaces
- improve case aggregation metadata for auditor records so the viewer can link auditor inputs to graph snapshots
- add RCA harness manifests for extractor-only / opinions-only cadence experiments
- add a generic auditor prompt trigger for narrowing drift, where the agent over-focuses on one branch while another material evidence branch remains unresolved

## Validation
- `uv run --frozen --no-sync pytest contrib/extensions/llmharness/tests/test_two_phase_audit_integration.py contrib/extensions/llmharness/tests/test_reminder_seed_tick_integration.py -q`
- `uv run --frozen --no-sync python -m py_compile contrib/scenarios/rca/src/agentm_rca/eval/agent.py contrib/extensions/llmharness/src/llmharness/adapters/agentm.py contrib/extensions/llmharness/src/llmharness/aggregate/collector.py`

## RCA row8 strict A/B smoke
- Control/no-auditor case: https://118.196.98.178:8082/cases/0522-5TURNS-ROW8-NOAUDITOR/openrca-2-lite-n500-t20-row8
- With-auditor V2 case: https://118.196.98.178:8082/cases/0522-5TURNS-ROW8-WITHAUDITOR-V2/openrca-2-lite-n500-t20-row8
- In this case, no-auditor reports only `search`; the strict fork after auditor reminder reports `recommendation` + `search` at service level.
