### PR TITLE
feat(llmharness): event-source the cross-firing audit graph

### DIFF
--- a/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
+++ b/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
@@ -102,6 +102,13 @@ from ..audit.extractor import (
     compose_extractor_extensions,
 )
 from ..audit.extractor.prompt import load_extractor_prompt
+from ..audit.graph_fold import fold_graph
+from ..audit.graph_ops import (
+    EdgeUpsert,
+    GraphOp,
+    NodeUpsert,
+    parse_op,
+)
 from ..audit.phase import merge_to_phases
 from ..audit.registry import SERVICE_KEY as AUDIT_REGISTRY_SERVICE_KEY
 from ..audit.registry import AuditCheckRegistry, CheckContext
@@ -289,6 +296,7 @@ _REMINDER_PREAMBLE = _SHARED_REMINDER_PREAMBLE
 # Entry-type bindings (every literal must come from entry_types.py).
 _AUDIT_EVENT_ENTRY_TYPE = _et.AUDIT_EVENT
 _AUDIT_EDGE_ENTRY_TYPE = _et.AUDIT_EDGE
+_AUDIT_GRAPH_OP_ENTRY_TYPE = _et.AUDIT_GRAPH_OP
 _AUDIT_PHASE_ENTRY_TYPE = _et.AUDIT_PHASE
 _VERDICT_ENTRY_TYPE = _et.VERDICT
 _EXTRACTOR_CURSOR_ENTRY_TYPE = _et.EXTRACTOR_CURSOR
@@ -329,10 +337,25 @@ class _BranchState:
 
 
 def _scan_branch(branch: list[SessionEntry], *, recent_verdicts_n: int) -> _BranchState:
-    """Single-pass extraction of cursor + graph + edges + phases + verdicts."""
+    """Single-pass extraction of cursor + graph + edges + phases + verdicts.
+
+    Event-sourcing refactor (2026-05-22): the live graph is the **fold**
+    of an ordered op log. This scanner accumulates ops from three
+    sources in branch order:
+
+    * :data:`AUDIT_GRAPH_OP` entries — first-class ops produced by the
+      event-sourcing extractor; parsed via :func:`parse_op`.
+    * Legacy :data:`AUDIT_EVENT` entries — translated to
+      :class:`NodeUpsert`. Used by sessions written before the refactor;
+      mixed sessions Just Work because ops are folded in branch order.
+    * Legacy :data:`AUDIT_EDGE` entries — translated to
+      :class:`EdgeUpsert`.
+
+    Phases keep their own list — they're auditor-side metadata, not part
+    of the graph op log.
+    """
     cursor_last_turn_index = -1
-    graph: list[Event] = []
-    edges: list[Edge] = []
+    ops: list[GraphOp] = []
     phases: list[Phase] = []
     verdicts: list[dict[str, Any]] = []
 
@@ -340,16 +363,41 @@ def _scan_branch(branch: list[SessionEntry], *, recent_verdicts_n: int) -> _Bran
         payload = entry.payload
         if not isinstance(payload, dict):
             continue
-        if entry.type == _AUDIT_EVENT_ENTRY_TYPE:
+        if entry.type == _AUDIT_GRAPH_OP_ENTRY_TYPE:
             try:
-                graph.append(Event.from_dict(payload))
+                ops.append(parse_op(payload))
             except (KeyError, ValueError, TypeError):
                 continue
+        elif entry.type == _AUDIT_EVENT_ENTRY_TYPE:
+            try:
+                ev = Event.from_dict(payload)
+            except (KeyError, ValueError, TypeError):
+                continue
+            ops.append(
+                NodeUpsert(
+                    id=ev.id,
+                    kind=ev.kind.value,
+                    summary=ev.summary,
+                    source_turns=tuple(ev.source_turns),
+                )
+            )
         elif entry.type == _AUDIT_EDGE_ENTRY_TYPE:
             try:
-                edges.append(Edge.from_dict(payload))
+                ed = Edge.from_dict(payload)
             except (KeyError, ValueError, TypeError):
                 continue
+            ops.append(
+                EdgeUpsert(
+                    src=ed.src,
+                    dst=ed.dst,
+                    kind=ed.kind.value,
+                    reason=ed.reason,
+                    cited_entities=ed.cited_entities,
+                    cited_quote=ed.cited_quote,
+                    src_turns=ed.src_turns,
+                    dst_turns=ed.dst_turns,
+                )
+            )
         elif entry.type == _AUDIT_PHASE_ENTRY_TYPE:
             try:
                 phases.append(Phase.from_dict(payload))
@@ -361,6 +409,10 @@ def _scan_branch(branch: list[SessionEntry], *, recent_verdicts_n: int) -> _Bran
             raw = payload.get("last_turn_index")
             if isinstance(raw, int) and not isinstance(raw, bool):
                 cursor_last_turn_index = raw
+
+    folded = fold_graph(ops)
+    graph: list[Event] = folded.nodes_list()
+    edges: list[Edge] = folded.edges_list()
 
     last_continuation_notes: list[str] = []
     if verdicts:
@@ -842,6 +894,15 @@ async def _drain_extractor(
         if 0 <= t < len(messages):
             state.turn_texts[t] = _render_message_text(messages[t])
     state.recent_graph = recent_graph_events
+    # Event-sourcing seed: the apply_* surface needs the folded
+    # prior-firings view to validate cross-firing edits. Populate from
+    # the same branch scan that produced ``recent_graph_events``.
+    state.recent_graph_dict = {e.id: e for e in recent_graph_events}
+    state.recent_edges_dict = {
+        (ed.src, ed.dst, ed.kind.value): ed for ed in branch_state.edges
+    }
+    # Refold so the apply_* surface sees the prior graph from op zero.
+    state._refold()
 
     # Globally-unique event ids: this firing's events must continue the
     # global sequence rather than restart at 1. Pick the smallest id
@@ -979,6 +1040,29 @@ async def _drain_extractor(
         )
         return True
 
+    # Event-sourcing: persist the firing's op log as one
+    # ``AUDIT_GRAPH_OP`` entry per op so any future scan can replay the
+    # exact state changes this firing made. ``firing_id`` is the index
+    # of this firing in the session (derived from the existing op log
+    # size on the branch so we don't have to track it across firings);
+    # ``op_index`` is the position within the firing.
+    firing_id = sum(
+        1
+        for e in branch
+        if isinstance(e.payload, dict) and e.type == _AUDIT_GRAPH_OP_ENTRY_TYPE
+        and e.payload.get("op_index") == 0
+    )
+    for op_index, op in enumerate(state.pending_ops):
+        payload = op.to_dict()
+        payload["firing_id"] = firing_id
+        payload["op_index"] = op_index
+        payload["caused_by_turn_window"] = list(turn_window)
+        api.session.append_entry(_AUDIT_GRAPH_OP_ENTRY_TYPE, payload)
+
+    # Legacy emit: keep writing AUDIT_EVENT / AUDIT_EDGE entries so the
+    # auditor, aggregate, replay, and web-viewer paths continue to work
+    # without modification while the event-sourcing migration is rolled
+    # out. The scanner translates both stripes into the same fold view.
     for ev in output.events:
         api.session.append_entry(_AUDIT_EVENT_ENTRY_TYPE, ev.to_dict())
     for ed in output.edges:

--- a/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
+++ b/contrib/extensions/llmharness/src/llmharness/adapters/agentm.py
@@ -373,12 +373,18 @@ def _scan_branch(branch: list[SessionEntry], *, recent_verdicts_n: int) -> _Bran
                 ev = Event.from_dict(payload)
             except (KeyError, ValueError, TypeError):
                 continue
+            # external_refs MUST round-trip through the synthesized op
+            # so the auditor and the next firing's recent_graph see the
+            # cross-firing edges the prior firing recorded. Dropping
+            # them silently makes the cumulative graph regress to
+            # per-firing islands.
             ops.append(
                 NodeUpsert(
                     id=ev.id,
                     kind=ev.kind.value,
                     summary=ev.summary,
                     source_turns=tuple(ev.source_turns),
+                    external_refs=ev.external_refs,
                 )
             )
         elif entry.type == _AUDIT_EDGE_ENTRY_TYPE:
@@ -625,6 +631,11 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
 
     pending_reminders: list[Reminder] = []
     turn_count = 0
+    # Session-scoped firing counter — a 1-element box so ``_drain_extractor``
+    # can mutate it through the closure. Incremented only when a firing
+    # actually persists ops; failed / empty firings don't burn an id. See
+    # the M4 invariant test in ``test_firing_id_invariant``.
+    firing_counter: list[int] = [0]
 
     if mode == "sync":
 
@@ -641,6 +652,7 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
                     job=_ExtractorJob(messages=messages_snapshot),
                     extractor_extensions=extractor_extensions,
                     extractor_provider=extractor_provider,
+                    firing_counter=firing_counter,
                 )
             if auditor_due and extractor_ok:
                 await _drain_auditor(
@@ -675,6 +687,7 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
                     auditor_settings=auditor_settings,
                     extractor_provider=extractor_provider,
                     auditor_provider=auditor_provider,
+                    firing_counter=firing_counter,
                 ),
                 name="llmharness-audit-worker",
             )
@@ -801,6 +814,7 @@ async def _drain_queue(
     auditor_settings: _AuditorSettings,
     extractor_provider: tuple[str, dict[str, Any]] | None,
     auditor_provider: tuple[str, dict[str, Any]] | None,
+    firing_counter: list[int],
 ) -> None:
     """Serial worker. Owns all session-mutating audit writes."""
     _last_extractor_held_cursor: bool = False
@@ -819,6 +833,7 @@ async def _drain_queue(
                     job=job,
                     extractor_extensions=extractor_extensions,
                     extractor_provider=extractor_provider,
+                    firing_counter=firing_counter,
                 )
                 _last_extractor_held_cursor = not extractor_ok
             elif isinstance(job, _AuditorJob):
@@ -852,11 +867,19 @@ async def _drain_extractor(
     job: _ExtractorJob,
     extractor_extensions: list[tuple[str, dict[str, Any]]],
     extractor_provider: tuple[str, dict[str, Any]] | None,
+    firing_counter: list[int],
 ) -> bool:
     """Run one v3 extractor firing.
 
     Returns ``True`` on success or partial-success (cursor advanced).
     Returns ``False`` on no_call / empty / error paths (cursor held).
+
+    ``firing_counter`` is a 1-element mutable box (closure pattern)
+    owned by ``install``: it's the stable session-scoped count of
+    ops-bearing firings, used as the persisted ``firing_id``. We
+    increment ONLY after a successful op persistence so failed /
+    empty firings don't burn an id and the per-session sequence stays
+    contiguous.
     """
     branch = api.session.get_branch()
     branch_state = _scan_branch(branch, recent_verdicts_n=_DEFAULT_RECENT_VERDICTS)
@@ -1023,9 +1046,21 @@ async def _drain_extractor(
         },
     )
 
-    # Empty submission on a non-trivial window is a typed failure; on a
-    # trivial (user-only) window an empty output is normal.
-    if not output.events and not output.edges and not output.dropped_edges:
+    # Empty firing classification.
+    #
+    # The maintainer model means a firing can produce ops that ONLY
+    # edit prior-firing nodes (e.g. a single ``NodeDelete`` merging a
+    # duplicate). Such a firing has empty ``output.events`` / ``edges``
+    # / ``dropped_edges`` (those snapshot the legacy
+    # ``_events_pending`` / ``_edges_pending`` lists, which are only
+    # populated by ``commit_batch``/``finalize``), but a non-empty
+    # ``state.pending_ops``. Gating "empty" on the legacy snapshot
+    # would silently drop the maintainer's op log on the floor.
+    has_legacy_output = bool(
+        output.events or output.edges or output.dropped_edges
+    )
+    has_ops = bool(state.pending_ops)
+    if not has_legacy_output and not has_ops:
         if _window_is_non_trivial(window_messages):
             _record_failure(api, _EXTRACTOR_EMPTY_ENTRY, {"turn_window": turn_window})
             return False
@@ -1042,27 +1077,29 @@ async def _drain_extractor(
 
     # Event-sourcing: persist the firing's op log as one
     # ``AUDIT_GRAPH_OP`` entry per op so any future scan can replay the
-    # exact state changes this firing made. ``firing_id`` is the index
-    # of this firing in the session (derived from the existing op log
-    # size on the branch so we don't have to track it across firings);
-    # ``op_index`` is the position within the firing.
-    firing_id = sum(
-        1
-        for e in branch
-        if isinstance(e.payload, dict) and e.type == _AUDIT_GRAPH_OP_ENTRY_TYPE
-        and e.payload.get("op_index") == 0
-    )
+    # exact state changes this firing made. ``firing_id`` is supplied
+    # by the install-level closure (M4): it is a stable session-scoped
+    # counter incremented once per ops-bearing firing, NOT recomputed
+    # from the branch (the prior heuristic — counting ``op_index==0``
+    # entries — collapses if any future change emits a firing whose
+    # first op has a non-zero index, e.g. partial recovery / retry).
+    firing_id = firing_counter[0]
     for op_index, op in enumerate(state.pending_ops):
         payload = op.to_dict()
         payload["firing_id"] = firing_id
         payload["op_index"] = op_index
         payload["caused_by_turn_window"] = list(turn_window)
         api.session.append_entry(_AUDIT_GRAPH_OP_ENTRY_TYPE, payload)
+    if has_ops:
+        firing_counter[0] += 1
 
     # Legacy emit: keep writing AUDIT_EVENT / AUDIT_EDGE entries so the
     # auditor, aggregate, replay, and web-viewer paths continue to work
     # without modification while the event-sourcing migration is rolled
     # out. The scanner translates both stripes into the same fold view.
+    # Skipped when this firing only produced ops that edit prior-firing
+    # nodes (e.g. pure NodeDelete) — there's nothing legacy-shaped to
+    # persist, and the scanner reads the ops back via AUDIT_GRAPH_OP.
     for ev in output.events:
         api.session.append_entry(_AUDIT_EVENT_ENTRY_TYPE, ev.to_dict())
     for ed in output.edges:

--- a/contrib/extensions/llmharness/src/llmharness/audit/entry_types.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/entry_types.py
@@ -33,6 +33,18 @@ AUDIT_EVENT = "llmharness.audit_event"
 # One accepted Edge record. Payload: ``Edge.to_dict()``. Persisted
 # alongside ``AUDIT_EVENT`` entries so graph traversal can replay both.
 AUDIT_EDGE = "llmharness.audit_edge"
+# One graph op produced by an extractor firing under the event-sourcing
+# refactor (2026-05-22). Payload is the result of
+# ``llmharness.audit.graph_ops.GraphOp.to_dict()`` — i.e. an ``"op"``
+# discriminator (``node_upsert`` / ``node_delete`` / ``edge_upsert`` /
+# ``edge_delete``) plus the op-specific fields, augmented with firing
+# metadata: ``firing_id`` (int), ``op_index`` (int — the op's position
+# inside its firing), and ``caused_by_turn_window`` (``[lo, hi]``
+# inclusive trajectory range of the new-turn window the firing
+# consumed). The legacy ``AUDIT_EVENT`` / ``AUDIT_EDGE`` entries are
+# still written alongside ops for back-compat with existing readers;
+# scanners translate them into ops in branch order.
+AUDIT_GRAPH_OP = "llmharness.audit_graph_op"
 # One Phase record produced by the mechanical merger
 # (``audit.phase.merge_to_phases``). Persisted after the raw events of
 # a successful firing so the auditor can read a coalesced "basic block"

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/prompts/extractor_default.md
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/prompts/extractor_default.md
@@ -793,8 +793,14 @@ Core tools plus four atomic graph-edit tools:
 Each event has:
 
 - `id` — global integer. Start from `next_event_id` (in the
-  payload) and increment strictly. Never restart at 1. Never reuse
-  an id already in `recent_graph`.
+  payload) and increment strictly for any *new* node. Never restart
+  at 1. Do not reuse an id that is **still present in the current
+  graph** — i.e. any id you can see in `recent_graph` or that you
+  have just emitted in this firing. Ids that have been deleted in
+  this firing via `delete_node` ARE eligible for re-use: that is
+  the merge-duplicate path (delete the old, then re-issue with the
+  canonical id). To *edit* an existing live node, pass its id to
+  `upsert_node` — that is an in-place revision, not a re-use.
 - `kind` — one of: `task`, `hyp`, `act`, `evid`, `dec`, `concl`.
 - `summary` — natural prose; see above.
 - `source_turns` — trajectory indices this event derives from;

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/prompts/extractor_default.md
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/prompts/extractor_default.md
@@ -4,6 +4,66 @@ graph of events with grounded edges. You do not judge — that's the
 auditor's job. Your job is to build a faithful picture and submit it
 through the extractor tools.
 
+## The persistent graph
+
+The audit graph is **persistent across firings**. You are not building
+a fresh graph each time — you are **maintaining** a single big graph
+that grows and improves as the investigation unfolds.
+
+Each firing you receive:
+
+- the current graph as `recent_graph` (full prior nodes + edges, with
+  source-turn texts attached so witnesses are decidable);
+- the new turn window covering the turns the main agent produced since
+  the last firing.
+
+Your job is to apply a sequence of *edits* (graph ops) that produce
+the new state of the graph. Every tool call is an op, recorded in an
+ordered log; given the initial empty graph plus that log, the live
+graph is exactly the **fold** of the log. Replays of any historical
+state are reproducible.
+
+What you may do this firing:
+
+- **Add new nodes/edges** for moves the agent made in the new turn
+  window. This is the common case.
+- **Revise stale nodes** — call `upsert_node` with an existing id to
+  refine its summary, fix its kind, or extend its `source_turns` as
+  the same act/evid continues across more turns. Same with
+  `upsert_edge`: the second call replaces the first.
+- **Merge duplicates** — if you discover two prior nodes describe the
+  same move, pick one as canonical and `delete_node` the other. Edges
+  incident to the deleted node cascade automatically. If you want any
+  of those edges to land on the canonical node, re-issue them with
+  `upsert_edge` pointing at the canonical id.
+
+Tool semantics:
+
+- `upsert_node` / `upsert_edge` are last-write-wins on their key
+  (`id` for nodes, `(src, dst, kind)` for edges).
+- `delete_node(id)` cascades — every edge whose `src` or `dst` is
+  that id disappears at fold time. You do NOT need to manually delete
+  edges first.
+- `delete_edge(src, dst, kind)` is keyed by all three fields; `kind`
+  is **mandatory** because the same `(src, dst)` pair can carry both
+  a `data` edge and a `ref` edge.
+- Witness rules still hold: `kind='ref'` edges require `cited_quote`
+  to appear (case+ws normalized) in the src node's `source_turns`
+  text; `kind='data'` requires non-empty `cited_entities`. The atomic
+  edit path now enforces ref witnesses too — fabricated quotes are
+  rejected at `upsert_edge` time.
+
+You will **always** see the prior graph in `recent_graph`. Treat it
+as your own working tree — read it, decide what's stale, and either
+leave it alone or revise it. Most firings only add; a minority refine
+existing nodes; a small minority merge duplicates. Avoid churn —
+don't restate a node just to rewrite its summary in a way the
+auditor cannot distinguish from the original.
+
+The rest of this prompt describes the same node/edge semantics as
+before. Read it as the rulebook for the edits you emit, whether you
+are adding fresh nodes or revising old ones.
+
 ## What the graph is, fundamentally
 
 The agent has a hidden reasoning structure: which guesses it

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/state.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/state.py
@@ -36,6 +36,14 @@ from typing import Any
 
 from ...schema import Edge, EdgeKind, Event, EventKind, ExternalRef
 from .._enum_schema import EDGE_KIND_VALUES, EVENT_KIND_VALUES
+from ..graph_fold import Graph, fold_graph
+from ..graph_ops import (
+    EdgeDelete,
+    EdgeUpsert,
+    GraphOp,
+    NodeDelete,
+    NodeUpsert,
+)
 from .witness import witness_data, witness_ref
 
 
@@ -96,6 +104,53 @@ class ExtractionState:
     _edges_pending: list[Edge] = field(default_factory=list)
     _external_refs_pending: dict[int, list[ExternalRef]] = field(default_factory=dict)
     _dropped_pending: list[dict[str, Any]] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Event-sourcing op log (2026-05-22 refactor).
+    #
+    # ``pending_ops`` is the authoritative record of every edit this
+    # firing applied to the persistent graph; finalize hands the list
+    # to the adapter, which persists each entry as an ``AUDIT_GRAPH_OP``
+    # session entry. ``pending_graph`` caches the fold of
+    # (recent_graph + recent_edges) + pending_ops so each ``apply_*``
+    # call can validate against the *current* view (the LLM may edit
+    # nodes that were emitted by prior firings, not just this firing's
+    # work).
+    #
+    # ``recent_graph_dict`` / ``recent_edges_dict`` carry the prior-
+    # firings view; the adapter populates them in branch order from the
+    # scanned op log. Defaults are empty for first-firing tests and the
+    # legacy ``commit`` / ``commit_batch`` callers that never had a
+    # cumulative graph to start from.
+    recent_graph_dict: dict[int, Event] = field(default_factory=dict)
+    recent_edges_dict: dict[tuple[int, int, str], Edge] = field(
+        default_factory=dict
+    )
+    pending_ops: list[GraphOp] = field(default_factory=list)
+    pending_graph: Graph = field(default_factory=Graph)
+
+    def __post_init__(self) -> None:
+        # Seed ``recent_graph_dict`` from the legacy ``recent_graph``
+        # tuple when callers passed only the tuple (every existing test
+        # does this; the adapter populates the dict directly). Keeps
+        # the two views consistent so the new ``apply_*`` surface sees
+        # the same nodes the legacy ``commit`` path does.
+        if self.recent_graph and not self.recent_graph_dict:
+            self.recent_graph_dict = {ev.id: ev for ev in self.recent_graph}
+        # First fold: the only ops at this point are the recent prefix,
+        # so the result equals the recent graph view.
+        if (
+            self.recent_graph_dict
+            or self.recent_edges_dict
+            or self.pending_ops
+        ):
+            self._refold()
+        # ``next_event_id`` intentionally NOT auto-derived from
+        # ``recent_graph_dict``: legacy callers and tests rely on the
+        # default of 1 even when ``recent_graph`` is non-empty (the
+        # legacy validation rule didn't reject id collisions with
+        # recent). The adapter sets next_event_id explicitly for live
+        # sessions; tests can override per case.
 
     # ------------------------------------------------------------------
     # Public mutators
@@ -215,9 +270,17 @@ class ExtractionState:
         self._edges_pending = []
         self._external_refs_pending = {}
         self._dropped_pending = []
+        self.pending_ops = []
+        self._refold()
 
     def upsert_node(self, raw: dict[str, Any]) -> dict[str, Any] | str:
-        """Insert or replace one pending event node by id."""
+        """Insert or replace one pending event node by id.
+
+        Legacy in-firing-only contract: ids must occupy a fresh slice
+        starting at ``next_event_id`` — no cross-firing edits. Use
+        :meth:`apply_node_upsert` for the event-sourcing surface that
+        accepts edits targeting prior-firing nodes.
+        """
         if self.committed:
             return "upsert_node: firing already finalized"
         err, ev = _validate_event_shape(len(self._events_pending), raw)
@@ -234,8 +297,19 @@ class ExtractionState:
             if ev.id < min_id:
                 return f"upsert_node: node id {ev.id} must be >= {min_id}"
             self._events_pending.append(ev)
-            return self._edit_digest("upsert_node")
-        self._events_pending[idx] = ev
+        else:
+            self._events_pending[idx] = ev
+        # Mirror into the op log so commit() can emit AUDIT_GRAPH_OP
+        # entries for the firing.
+        self.pending_ops.append(
+            NodeUpsert(
+                id=ev.id,
+                kind=ev.kind.value,
+                summary=ev.summary,
+                source_turns=tuple(ev.source_turns),
+            )
+        )
+        self._refold()
         return self._edit_digest("upsert_node")
 
     def delete_node(self, node_id: int) -> dict[str, Any] | str:
@@ -250,6 +324,8 @@ class ExtractionState:
             e for e in self._edges_pending if e.src != node_id and e.dst != node_id
         ]
         self._external_refs_pending.pop(node_id, None)
+        self.pending_ops.append(NodeDelete(id=node_id))
+        self._refold()
         return self._edit_digest("delete_node")
 
     def upsert_edge(self, raw: dict[str, Any]) -> dict[str, Any] | str:
@@ -266,17 +342,317 @@ class ExtractionState:
             self._edges_pending.append(edge)
         else:
             self._edges_pending[idx] = edge
+        self.pending_ops.append(
+            EdgeUpsert(
+                src=edge.src,
+                dst=edge.dst,
+                kind=edge.kind.value,
+                reason=edge.reason,
+                cited_entities=edge.cited_entities,
+                cited_quote=edge.cited_quote,
+                src_turns=edge.src_turns,
+                dst_turns=edge.dst_turns,
+            )
+        )
+        self._refold()
         return self._edit_digest("upsert_edge")
 
     def delete_edge(self, selector: dict[str, Any]) -> dict[str, Any] | str:
-        """Delete one pending edge selected by src/dst and optional kind."""
+        """Delete one pending edge selected by src/dst and optional kind.
+
+        Op-log policy: the persisted ``EdgeDelete`` carries the full
+        ``(src, dst, kind)`` triple even when the caller omitted ``kind``,
+        so the replayable log remains unambiguous. When the selector
+        omits ``kind`` and several edges match, this matches the first
+        in pending order — preserving the legacy (pre-event-sourcing)
+        behaviour while still emitting a well-formed op.
+        """
         if self.committed:
             return "delete_edge: firing already finalized"
         idx = self._pending_edge_index(selector)
         if idx is None:
             return "delete_edge: edge not found"
+        edge = self._edges_pending[idx]
         del self._edges_pending[idx]
+        self.pending_ops.append(
+            EdgeDelete(src=edge.src, dst=edge.dst, kind=edge.kind.value)
+        )
+        self._refold()
         return self._edit_digest("delete_edge")
+
+    # ------------------------------------------------------------------
+    # Event-sourcing apply_* surface (2026-05-22 refactor).
+    #
+    # Each ``apply_*`` validates against the folded view
+    # ``recent (union pending_graph)``, appends a :class:`GraphOp` to
+    # ``pending_ops``, refolds ``pending_graph``, and returns a digest
+    # dict on success or a string error on rejection. Unlike the legacy
+    # ``upsert_node`` / ``delete_node`` / ``upsert_edge`` / ``delete_edge``
+    # methods, these accept edits that target nodes from prior firings
+    # (anything in ``recent_graph_dict``) — that is the whole point of
+    # the event-sourcing refactor: the graph maintainer can revise
+    # stale nodes and merge duplicates across firings.
+
+    def _refold(self) -> None:
+        """Recompute ``pending_graph`` from recent + pending_ops.
+
+        Recent state is materialised as a synthetic op prefix so the
+        same :func:`fold_graph` semantics apply uniformly (insertion
+        order, NodeDelete cascade, etc.). Building the prefix is O(R+E)
+        where R is recent_graph_dict size and E is recent_edges_dict
+        size; ``pending_ops`` is typically small per firing so the
+        refold cost is dominated by recent.
+        """
+        prefix: list[GraphOp] = []
+        for nid, ev in self.recent_graph_dict.items():
+            prefix.append(
+                NodeUpsert(
+                    id=nid,
+                    kind=ev.kind.value,
+                    summary=ev.summary,
+                    source_turns=tuple(ev.source_turns),
+                )
+            )
+        for (src, dst, kind), ed in self.recent_edges_dict.items():
+            prefix.append(
+                EdgeUpsert(
+                    src=src,
+                    dst=dst,
+                    kind=kind,
+                    reason=ed.reason,
+                    cited_entities=ed.cited_entities,
+                    cited_quote=ed.cited_quote,
+                    src_turns=ed.src_turns,
+                    dst_turns=ed.dst_turns,
+                )
+            )
+        self.pending_graph = fold_graph(prefix + self.pending_ops)
+
+    def _ops_digest(self, op: str) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "op": op,
+            "pending_ops": len(self.pending_ops),
+            "graph_nodes": len(self.pending_graph.nodes),
+            "graph_edges": len(self.pending_graph.edges),
+        }
+
+    def _folded_view(self) -> tuple[dict[int, Event], dict[tuple[int, int, str], Edge]]:
+        """Convenience: return ``(nodes, edges)`` of the current folded graph.
+
+        Always reflects ``recent union pending_ops`` because ``pending_graph``
+        is kept in sync via :meth:`_refold` after every accepted op.
+        """
+        return self.pending_graph.nodes, self.pending_graph.edges
+
+    def _witness_in_turn_texts(
+        self, quote: str, turn_indices: tuple[int, ...] | list[int]
+    ) -> bool:
+        """Substring-check ``quote`` against concatenated ``turn_texts``.
+
+        Uses the same case+whitespace normalisation as :mod:`witness` so
+        the gate here is identical to the one applied to in-firing refs
+        in :meth:`_validate_and_append`. Missing turn texts contribute
+        the empty string — the check then naturally fails.
+        """
+        from .witness import normalize as _normalize
+
+        concat = " ".join(self.turn_texts.get(t, "") for t in turn_indices)
+        return _normalize(quote) in _normalize(concat)
+
+    def apply_node_upsert(self, raw: dict[str, Any]) -> dict[str, Any] | str:
+        """Validate + apply one ``NodeUpsert`` against the folded view.
+
+        Accepts ids that are (a) already present in the folded graph
+        (edit), (b) the next free id ``= max(folded_ids) + 1`` (append),
+        or (c) any id previously removed in this firing via
+        ``apply_node_delete`` — re-use after delete is allowed because
+        the op log preserves the deletion order. The constraint is
+        enforced against ``(folded union deleted-in-this-firing)``.
+        """
+        if self.committed:
+            return "apply_node_upsert: firing already finalized"
+        err, ev = _validate_event_shape(0, raw)
+        if err is not None:
+            return err.replace("submit_events", "apply_node_upsert", 1)
+        assert ev is not None
+
+        nodes, _edges = self._folded_view()
+        deleted_in_firing = {
+            op.id for op in self.pending_ops if isinstance(op, NodeDelete)
+        }
+        # Largest seen id includes recent_graph_dict (which seeded
+        # pending_graph via _refold), pending NodeUpsert ids, and the
+        # explicitly-deleted ids — so the LLM cannot "skip" over a
+        # deleted slot to make the validator forget about it.
+        max_seen = max(
+            [0]
+            + list(nodes.keys())
+            + [op.id for op in self.pending_ops if isinstance(op, NodeUpsert)]
+            + list(deleted_in_firing)
+            + [self.next_event_id - 1]
+        )
+        allowed_ids = set(nodes.keys()) | deleted_in_firing | {max_seen + 1}
+        if ev.id not in allowed_ids:
+            return (
+                f"apply_node_upsert: id={ev.id} is neither an existing node "
+                f"in the folded graph (recent + pending), a node deleted in "
+                f"this firing, nor the next available id ({max_seen + 1}). "
+                "Pick one: edit an existing id, re-use a just-deleted id, or "
+                "append at the next free slot."
+            )
+
+        op = NodeUpsert(
+            id=ev.id,
+            kind=ev.kind.value,
+            summary=ev.summary,
+            source_turns=tuple(ev.source_turns),
+        )
+        self.pending_ops.append(op)
+        self._refold()
+        return self._ops_digest("node_upsert")
+
+    def apply_node_delete(self, node_id: int) -> dict[str, Any] | str:
+        """Validate + apply one ``NodeDelete`` against the folded view.
+
+        The node must exist in the current folded graph (recent +
+        pending); deleting a node not present is a programmer error
+        from the LLM's perspective. Edge cascade happens at fold time.
+        """
+        if self.committed:
+            return "apply_node_delete: firing already finalized"
+        nodes, _edges = self._folded_view()
+        if node_id not in nodes:
+            return (
+                f"apply_node_delete: unknown node_id {node_id}. "
+                f"Existing ids in the folded graph: {sorted(nodes.keys())}"
+            )
+        self.pending_ops.append(NodeDelete(id=node_id))
+        self._refold()
+        return self._ops_digest("node_delete")
+
+    def apply_edge_upsert(self, raw: dict[str, Any]) -> dict[str, Any] | str:
+        """Validate + apply one ``EdgeUpsert`` against the folded view.
+
+        Endpoint nodes are looked up in the folded view (recent +
+        pending). Kind-specific witness rules:
+
+        - ``kind='data'``: ``cited_entities`` is non-empty (validator
+          rejects empty list; the witness pipeline at edge-construction
+          time has historically been lax for this case because the
+          downstream auditor still has the entities to work with).
+        - ``kind='ref'``: ``cited_quote`` must appear (case+ws
+          normalised) as a substring of the src node's source_turns
+          text. This was missing from the original ``upsert_edge``
+          path — the LLM could fabricate quotes; the v18 batch path
+          enforced the same rule but the atomic edit path did not.
+        """
+        if self.committed:
+            return "apply_edge_upsert: firing already finalized"
+
+        src = _coerce_int(raw.get("src"))
+        dst = _coerce_int(raw.get("dst"))
+        kind_raw = raw.get("kind")
+        if src is None or dst is None:
+            return "apply_edge_upsert: 'src' and 'dst' must be integers"
+        try:
+            kind = EdgeKind(kind_raw)
+        except ValueError:
+            return f"apply_edge_upsert: kind {kind_raw!r} not in {EDGE_KIND_VALUES}"
+
+        nodes, _edges = self._folded_view()
+        if src not in nodes or dst not in nodes:
+            return (
+                f"apply_edge_upsert: src={src} and dst={dst} must both exist "
+                f"in the folded graph. Existing ids: {sorted(nodes.keys())}"
+            )
+        src_event = nodes[src]
+        dst_event = nodes[dst]
+
+        cited_entities_raw = raw.get("cited_entities", [])
+        cited_quote = str(raw.get("cited_quote", "") or "")
+        if kind is EdgeKind.DATA:
+            if not isinstance(cited_entities_raw, list) or not cited_entities_raw:
+                return (
+                    "apply_edge_upsert: kind='data' requires non-empty "
+                    "cited_entities"
+                )
+            if any(not isinstance(e, str) or not e for e in cited_entities_raw):
+                return (
+                    "apply_edge_upsert: cited_entities must be non-empty strings"
+                )
+            cited_entities = tuple(str(e) for e in cited_entities_raw)
+        else:
+            if not cited_quote:
+                return (
+                    "apply_edge_upsert: kind='ref' requires non-empty cited_quote"
+                )
+            # Witness validation for ref: the verbatim quote must appear in
+            # the src node's source_turns text. This was missing from the
+            # original atomic upsert_edge — a gap the event-sourcing
+            # refactor closes.
+            if not self._witness_in_turn_texts(
+                cited_quote, tuple(src_event.source_turns)
+            ):
+                return (
+                    "apply_edge_upsert: cited_quote not found in src node's "
+                    "source_turns text. Quote tokens must literally appear "
+                    "(after case+whitespace normalization) in the source "
+                    "event's turn text — paraphrasing is rejected."
+                )
+            cited_entities = tuple(
+                str(e) for e in (cited_entities_raw or [])
+            )
+
+        reason = raw.get("reason", "")
+        if not isinstance(reason, str):
+            return "apply_edge_upsert: reason must be a string"
+
+        op = EdgeUpsert(
+            src=src,
+            dst=dst,
+            kind=kind.value,
+            reason=reason,
+            cited_entities=cited_entities,
+            cited_quote=cited_quote,
+            src_turns=tuple(src_event.source_turns),
+            dst_turns=tuple(dst_event.source_turns),
+        )
+        self.pending_ops.append(op)
+        self._refold()
+        return self._ops_digest("edge_upsert")
+
+    def apply_edge_delete(self, selector: dict[str, Any]) -> dict[str, Any] | str:
+        """Validate + apply one ``EdgeDelete`` against the folded view.
+
+        Selector MUST carry src, dst, and kind — the op-log contract
+        requires the full key because ``(src, dst)`` alone is ambiguous
+        across ``kind=data`` / ``kind=ref``.
+        """
+        if self.committed:
+            return "apply_edge_delete: firing already finalized"
+
+        src = _coerce_int(selector.get("src"))
+        dst = _coerce_int(selector.get("dst"))
+        kind_raw = selector.get("kind")
+        if src is None or dst is None:
+            return "apply_edge_delete: 'src' and 'dst' must be integers"
+        if not isinstance(kind_raw, str) or not kind_raw:
+            return "apply_edge_delete: 'kind' is required and must be a string"
+        try:
+            EdgeKind(kind_raw)
+        except ValueError:
+            return f"apply_edge_delete: kind {kind_raw!r} not in {EDGE_KIND_VALUES}"
+
+        _nodes, edges = self._folded_view()
+        if (src, dst, kind_raw) not in edges:
+            return (
+                f"apply_edge_delete: edge ({src}, {dst}, {kind_raw}) not "
+                "found in the folded graph"
+            )
+        self.pending_ops.append(EdgeDelete(src=src, dst=dst, kind=kind_raw))
+        self._refold()
+        return self._ops_digest("edge_delete")
 
     # ------------------------------------------------------------------
     # Legacy single-shot API (kept for v17 tests and direct callers).
@@ -520,6 +896,32 @@ class ExtractionState:
         for eid, refs in accepted_external.items():
             self._external_refs_pending.setdefault(eid, []).extend(refs)
         self._dropped_pending.extend(dropped)
+        # Mirror the batch into the op log so commit() can persist
+        # AUDIT_GRAPH_OP entries even when the LLM used the legacy
+        # ``submit_events_batch`` flow.
+        for ev in working:
+            self.pending_ops.append(
+                NodeUpsert(
+                    id=ev.id,
+                    kind=ev.kind.value,
+                    summary=ev.summary,
+                    source_turns=tuple(ev.source_turns),
+                )
+            )
+        for ed in accepted_edges:
+            self.pending_ops.append(
+                EdgeUpsert(
+                    src=ed.src,
+                    dst=ed.dst,
+                    kind=ed.kind.value,
+                    reason=ed.reason,
+                    cited_entities=ed.cited_entities,
+                    cited_quote=ed.cited_quote,
+                    src_turns=ed.src_turns,
+                    dst_turns=ed.dst_turns,
+                )
+            )
+        self._refold()
         return None
 
     def _concat_turn_texts(self, turn_indices: list[int] | tuple[int, ...]) -> str:

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/state.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/state.py
@@ -329,13 +329,26 @@ class ExtractionState:
         return self._edit_digest("delete_node")
 
     def upsert_edge(self, raw: dict[str, Any]) -> dict[str, Any] | str:
-        """Insert or replace one pending edge by (src, dst, kind)."""
+        """Insert or replace one pending edge by (src, dst, kind).
+
+        Witness rule: kind='ref' requires ``cited_quote`` to appear in
+        BOTH endpoints' source_turns text — same gate as the batch
+        path and :meth:`apply_edge_upsert`. The legacy path used to
+        skip this check, letting fabricated quotes through; closed
+        here so all three surfaces share one contract.
+        """
         if self.committed:
             return "upsert_edge: firing already finalized"
         err, edge = self._build_pending_edge(raw)
         if err is not None:
             return err
         assert edge is not None
+        if edge.kind is EdgeKind.REF:
+            src_text = self._concat_turn_texts(edge.src_turns)
+            dst_text = self._concat_turn_texts(edge.dst_turns)
+            werr = witness_ref(edge.cited_quote, src_text, dst_text)
+            if werr is not None:
+                return f"upsert_edge: {werr}"
         selector = {"src": edge.src, "dst": edge.dst, "kind": edge.kind.value}
         idx = self._pending_edge_index(selector)
         if idx is None:
@@ -358,17 +371,25 @@ class ExtractionState:
         return self._edit_digest("upsert_edge")
 
     def delete_edge(self, selector: dict[str, Any]) -> dict[str, Any] | str:
-        """Delete one pending edge selected by src/dst and optional kind.
+        """Delete one pending edge selected by ``(src, dst, kind)``.
 
-        Op-log policy: the persisted ``EdgeDelete`` carries the full
-        ``(src, dst, kind)`` triple even when the caller omitted ``kind``,
-        so the replayable log remains unambiguous. When the selector
-        omits ``kind`` and several edges match, this matches the first
-        in pending order — preserving the legacy (pre-event-sourcing)
-        behaviour while still emitting a well-formed op.
+        ``kind`` is **mandatory** — the op-log contract requires the
+        full triple because the same ``(src, dst)`` pair may carry
+        both a ``data`` and a ``ref`` edge. The original kind-less
+        behaviour (first-match-in-pending-order) lost replay
+        determinism: which edge got the EdgeDelete depended on
+        insertion order, not on the selector.
         """
         if self.committed:
             return "delete_edge: firing already finalized"
+        kind_raw = selector.get("kind")
+        if not isinstance(kind_raw, str) or not kind_raw:
+            return (
+                "delete_edge: 'kind' is required. The op-log selector "
+                "needs the full (src, dst, kind) triple — (src, dst) "
+                "alone is ambiguous when both 'data' and 'ref' edges "
+                "exist between the same pair."
+            )
         idx = self._pending_edge_index(selector)
         if idx is None:
             return "delete_edge: edge not found"
@@ -411,6 +432,7 @@ class ExtractionState:
                     kind=ev.kind.value,
                     summary=ev.summary,
                     source_turns=tuple(ev.source_turns),
+                    external_refs=ev.external_refs,
                 )
             )
         for (src, dst, kind), ed in self.recent_edges_dict.items():
@@ -542,10 +564,12 @@ class ExtractionState:
           time has historically been lax for this case because the
           downstream auditor still has the entities to work with).
         - ``kind='ref'``: ``cited_quote`` must appear (case+ws
-          normalised) as a substring of the src node's source_turns
-          text. This was missing from the original ``upsert_edge``
-          path — the LLM could fabricate quotes; the v18 batch path
-          enforced the same rule but the atomic edit path did not.
+          normalised) as a substring of BOTH the src node's source-
+          turns text AND the dst node's source-turns text — same rule
+          as the batch path (:func:`witness_ref`). The atomic path
+          originally checked src only, letting a quote that exists
+          only in src text slip through; that divergence was a hole
+          the batch contract closed and we close here too.
         """
         if self.committed:
             return "apply_edge_upsert: firing already finalized"
@@ -587,19 +611,16 @@ class ExtractionState:
                 return (
                     "apply_edge_upsert: kind='ref' requires non-empty cited_quote"
                 )
-            # Witness validation for ref: the verbatim quote must appear in
-            # the src node's source_turns text. This was missing from the
-            # original atomic upsert_edge — a gap the event-sourcing
-            # refactor closes.
-            if not self._witness_in_turn_texts(
-                cited_quote, tuple(src_event.source_turns)
-            ):
-                return (
-                    "apply_edge_upsert: cited_quote not found in src node's "
-                    "source_turns text. Quote tokens must literally appear "
-                    "(after case+whitespace normalization) in the source "
-                    "event's turn text — paraphrasing is rejected."
-                )
+            # Witness validation for ref: the verbatim quote must appear
+            # in BOTH the src and dst nodes' source_turns text (same
+            # rule as :func:`witness_ref` in the batch path). Routing
+            # through that helper keeps the two contracts byte-identical
+            # so a quote accepted by one path is accepted by the other.
+            src_text = self._concat_turn_texts(src_event.source_turns)
+            dst_text = self._concat_turn_texts(dst_event.source_turns)
+            werr = witness_ref(cited_quote, src_text, dst_text)
+            if werr is not None:
+                return f"apply_edge_upsert: {werr}"
             cited_entities = tuple(
                 str(e) for e in (cited_entities_raw or [])
             )
@@ -898,7 +919,11 @@ class ExtractionState:
         self._dropped_pending.extend(dropped)
         # Mirror the batch into the op log so commit() can persist
         # AUDIT_GRAPH_OP entries even when the LLM used the legacy
-        # ``submit_events_batch`` flow.
+        # ``submit_events_batch`` flow. external_refs are folded onto
+        # each event's NodeUpsert so the op-log round-trip preserves
+        # cross-firing connectivity — matches the eventual
+        # ``finalize()`` Event(...) construction (line ~273 in this
+        # file) that attaches them as event-level fields.
         for ev in working:
             self.pending_ops.append(
                 NodeUpsert(
@@ -906,6 +931,7 @@ class ExtractionState:
                     kind=ev.kind.value,
                     summary=ev.summary,
                     source_turns=tuple(ev.source_turns),
+                    external_refs=tuple(accepted_external.get(ev.id, [])),
                 )
             )
         for ed in accepted_edges:

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/tools.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/tools.py
@@ -353,6 +353,71 @@ _SUBMIT_EVENTS_BATCH_PARAMETERS: dict[str, Any] = {
 _RESET_EXTRACTION_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+# Dedicated parameters schema for the atomic ``upsert_node`` tool.
+#
+# Sharing ``_EVENT_SCHEMA`` (the v18 ``submit_events_batch.events[]``
+# item shape) misleads the LLM in two ways: its ``id`` description
+# talks about ``events[0]`` / ``events[1]`` (no plural here — one node
+# per call), and it lists ``refs`` as required, which is undefined for
+# single-node upserts and outright wrong for editing a prior-firing
+# node. The persistent-graph contract is: id resolves against the
+# *current folded graph* (this firing or any prior firing); refs are
+# only carried by ``submit_events_batch`` events, never as a field on
+# the node itself.
+_UPSERT_NODE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "integer",
+            "description": (
+                "Node id. If this id already exists in the current graph "
+                "(this firing or any prior firing), the node is updated "
+                "in place. Otherwise the id must equal the next available "
+                "id (max existing id + 1) or a node id you deleted earlier "
+                "in this firing (re-use after delete is the merge-duplicate "
+                "path). Gaps over still-live ids are rejected."
+            ),
+        },
+        "kind": {
+            "type": "string",
+            "enum": list(EVENT_KIND_VALUES),
+            "description": (
+                "Closed-set event kind classified by ACTION SIGNATURE, "
+                "not by what the agent says it is doing."
+            ),
+        },
+        "summary": {
+            "type": "string",
+            "description": (
+                "Natural-language paragraph describing this event, with "
+                "LENGTH PROPORTIONAL TO source_turns COUNT. A "
+                "single-turn branch event (task / hyp / dec / concl) is "
+                "one focused sentence with the concrete claim. A linear "
+                "act or evid that COALESCES N consecutive turns must be "
+                "a paragraph that walks through what happened across "
+                "those N turns: roughly one short sentence per covered "
+                "turn. Name every distinct tool_call's concrete "
+                "parameters verbatim (services, time windows, query "
+                "filters, file paths, error codes, span/log/metric "
+                "names) and quote the key numbers each result returned."
+            ),
+        },
+        "source_turns": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": (
+                "Trajectory indices this event was extracted from. "
+                "Non-empty and contiguous ([first, first+1, ..., last] "
+                "with no gaps)."
+            ),
+        },
+    },
+    "required": ["id", "kind", "summary", "source_turns"],
     "additionalProperties": False,
 }
 
@@ -381,12 +446,53 @@ _EDGE_SELECTOR_SCHEMA: dict[str, Any] = {
 _GRAPH_EDGE_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "src": {"type": "integer"},
-        "dst": {"type": "integer"},
-        "kind": {"type": "string", "enum": list(EDGE_KIND_VALUES)},
-        "reason": {"type": "string"},
-        "cited_entities": {"type": "array", "items": {"type": "string"}},
-        "cited_quote": {"type": "string"},
+        "src": {
+            "type": "integer",
+            "description": (
+                "Source node id — must exist in the current graph (this "
+                "firing or any prior firing)."
+            ),
+        },
+        "dst": {
+            "type": "integer",
+            "description": (
+                "Destination node id — must exist in the current graph "
+                "(this firing or any prior firing)."
+            ),
+        },
+        "kind": {
+            "type": "string",
+            "enum": list(EDGE_KIND_VALUES),
+            "description": (
+                "Edge kind. 'ref' for textual-witness edges (cited_quote); "
+                "'data' for entity-witness edges (cited_entities)."
+            ),
+        },
+        "reason": {
+            "type": "string",
+            "description": "One short sentence explaining the causal connection.",
+        },
+        "cited_entities": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Concrete identifiers (service names, span ids, file "
+                "paths, error codes, etc.) shared by src and dst. "
+                "Required non-empty when kind='data'; each entity must "
+                "appear (case+whitespace normalized substring) in at "
+                "least one of the src or dst node's source_turns text."
+            ),
+        },
+        "cited_quote": {
+            "type": "string",
+            "description": (
+                "Verbatim substring of BOTH the src node's source_turns "
+                "text AND the dst node's source_turns text "
+                "(case+whitespace normalized). Required when kind='ref'. "
+                "Paraphrasing or reformatting is rejected at op-build "
+                "time."
+            ),
+        },
     },
     "required": ["src", "dst", "kind", "reason"],
     "additionalProperties": False,
@@ -396,7 +502,14 @@ _GRAPH_EDGE_SCHEMA: dict[str, Any] = {
 _DELETE_NODE_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "id": {"type": "integer", "description": "Pending event node id to delete."},
+        "id": {
+            "type": "integer",
+            "description": (
+                "Event node id to delete. May reference a node from this "
+                "firing or from any prior firing — the resulting "
+                "NodeDelete cascades to all incident edges at fold time."
+            ),
+        },
     },
     "required": ["id"],
     "additionalProperties": False,
@@ -585,17 +698,20 @@ def build_extractor_tools(
         FunctionTool(
             name=UPSERT_NODE_TOOL_NAME,
             description=(
-                "Insert or replace one pending event node by id. Fields match "
-                "submit_events_batch events: id, kind, summary, source_turns."
+                "Insert or replace one event node in the current graph. "
+                "Editing a prior-firing node is supported — the id "
+                "resolves against the folded view (this firing + every "
+                "prior firing). Recorded as a NodeUpsert op."
             ),
-            parameters=_EVENT_SCHEMA,
+            parameters=_UPSERT_NODE_PARAMETERS,
             fn=_upsert_node,
         ),
         FunctionTool(
             name=DELETE_NODE_TOOL_NAME,
             description=(
-                "Delete one pending event node by id. Any pending edge touching "
-                "that node is removed automatically."
+                "Delete one event node from the current graph (this firing "
+                "or any prior firing). Every edge incident to that node "
+                "is removed automatically at fold time."
             ),
             parameters=_DELETE_NODE_PARAMETERS,
             fn=_delete_node,
@@ -603,8 +719,10 @@ def build_extractor_tools(
         FunctionTool(
             name=UPSERT_EDGE_TOOL_NAME,
             description=(
-                "Insert or replace one pending witness-bearing edge, keyed by "
-                "(src, dst, kind). Both endpoint nodes must already be pending."
+                "Insert or replace one witness-bearing edge keyed by "
+                "(src, dst, kind). Both endpoint nodes must already exist "
+                "in the current graph (this firing or any prior firing). "
+                "Recorded as an EdgeUpsert op."
             ),
             parameters=_GRAPH_EDGE_SCHEMA,
             fn=_upsert_edge,
@@ -612,7 +730,9 @@ def build_extractor_tools(
         FunctionTool(
             name=DELETE_EDGE_TOOL_NAME,
             description=(
-                "Delete one pending edge selected by src/dst and optional kind."
+                "Delete one edge identified by (src, dst, kind). 'kind' "
+                "is mandatory because the same (src, dst) pair may carry "
+                "both a 'data' and a 'ref' edge."
             ),
             parameters=_EDGE_SELECTOR_SCHEMA,
             fn=_delete_edge,

--- a/contrib/extensions/llmharness/src/llmharness/audit/extractor/tools.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/extractor/tools.py
@@ -17,6 +17,7 @@ the submission is accepted.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from agentm.core.abi import FunctionTool, TextContent, ToolResult, ToolTerminate
@@ -361,8 +362,18 @@ _EDGE_SELECTOR_SCHEMA: dict[str, Any] = {
     "properties": {
         "src": {"type": "integer"},
         "dst": {"type": "integer"},
-        "kind": {"type": "string", "enum": list(EDGE_KIND_VALUES)},
+        "kind": {
+            "type": "string",
+            "enum": list(EDGE_KIND_VALUES),
+            "description": (
+                "Required: the edge kind to delete. Without this the "
+                "selector is ambiguous — the same (src, dst) pair may "
+                "carry both a 'data' and a 'ref' edge in the persistent "
+                "op log."
+            ),
+        },
     },
+    "required": ["src", "dst", "kind"],
     "additionalProperties": False,
 }
 
@@ -456,6 +467,7 @@ def build_extractor_tools(
         done = bool(args.get("done", False))
 
         prev_dropped = len(state._dropped_pending)
+        prev_ops_len = len(state.pending_ops)
         err = state.commit_batch(events_payload)
         if err is not None:
             return _err(err)
@@ -481,6 +493,10 @@ def build_extractor_tools(
                 if eid in accepted_ids:
                     state._external_refs_pending.pop(eid, None)
             state._dropped_pending = state._dropped_pending[:prev_dropped]
+            # Truncate the op log to match — the just-appended NodeUpsert
+            # / EdgeUpsert ops for this batch get rolled off.
+            state.pending_ops = state.pending_ops[:prev_ops_len]
+            state._refold()
             attempts_used += 1
             return _err(_format_witness_feedback(list(new_drops)))
 
@@ -513,38 +529,30 @@ def build_extractor_tools(
         )
 
     async def _upsert_node(args: dict[str, Any]) -> ToolResult:
-        result = state.upsert_node(args)
+        result = state.apply_node_upsert(args)
         if isinstance(result, str):
             return _err(result)
-        import json
-
         return _ok(json.dumps(result, ensure_ascii=False))
 
     async def _delete_node(args: dict[str, Any]) -> ToolResult:
         node_id = args.get("id")
         if isinstance(node_id, bool) or not isinstance(node_id, int):
             return _err("delete_node: 'id' must be an integer")
-        result = state.delete_node(node_id)
+        result = state.apply_node_delete(node_id)
         if isinstance(result, str):
             return _err(result)
-        import json
-
         return _ok(json.dumps(result, ensure_ascii=False))
 
     async def _upsert_edge(args: dict[str, Any]) -> ToolResult:
-        result = state.upsert_edge(args)
+        result = state.apply_edge_upsert(args)
         if isinstance(result, str):
             return _err(result)
-        import json
-
         return _ok(json.dumps(result, ensure_ascii=False))
 
     async def _delete_edge(args: dict[str, Any]) -> ToolResult:
-        result = state.delete_edge(args)
+        result = state.apply_edge_delete(args)
         if isinstance(result, str):
             return _err(result)
-        import json
-
         return _ok(json.dumps(result, ensure_ascii=False))
 
     async def _reset_extraction(args: dict[str, Any]) -> ToolResult:

--- a/contrib/extensions/llmharness/src/llmharness/audit/graph_fold.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/graph_fold.py
@@ -65,6 +65,7 @@ def fold_graph(ops: Iterable[GraphOp]) -> Graph:
                 kind=EventKind(op.kind),
                 summary=op.summary,
                 source_turns=list(op.source_turns),
+                external_refs=op.external_refs,
             )
         elif isinstance(op, NodeDelete):
             nodes.pop(op.id, None)

--- a/contrib/extensions/llmharness/src/llmharness/audit/graph_fold.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/graph_fold.py
@@ -1,0 +1,93 @@
+"""Pure :func:`fold_graph` — collapse an op log into a live :class:`Graph`.
+
+The persistent audit graph is the **fold** of an ordered op list. Given
+the initial empty graph plus a list of :mod:`graph_ops`-typed ops,
+:func:`fold_graph` returns the current view. Replayable by construction:
+the op list is the source of truth and the graph is a cached projection.
+
+Semantics:
+
+- ``NodeUpsert`` — ``nodes[op.id] = Event(...)``.
+- ``NodeDelete`` — drop ``nodes[op.id]`` and every incident edge (cascade).
+- ``EdgeUpsert`` — ``edges[(src, dst, kind)] = Edge(...)``.
+- ``EdgeDelete`` — drop ``edges[(src, dst, kind)]``.
+
+The fold uses insertion-ordered :class:`dict` so iteration order matches
+op order. Downstream consumers (auditor compose, replay sidecar) expect
+stable ordering; helpers :meth:`Graph.nodes_list` / :meth:`Graph.edges_list`
+expose that as sequences.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from ..schema import Edge, EdgeKind, Event, EventKind
+from .graph_ops import (
+    EdgeDelete,
+    EdgeUpsert,
+    GraphOp,
+    NodeDelete,
+    NodeUpsert,
+)
+
+
+@dataclass(frozen=True)
+class Graph:
+    """Folded view of an op log.
+
+    ``nodes`` is keyed by event id; ``edges`` by the ``(src, dst, kind)``
+    triple (kind as the string value — the same string the op carries).
+    Both are insertion-ordered.
+    """
+
+    nodes: dict[int, Event] = field(default_factory=dict)
+    edges: dict[tuple[int, int, str], Edge] = field(default_factory=dict)
+
+    def nodes_list(self) -> list[Event]:
+        """Events in insertion order — what most downstream code wants."""
+        return list(self.nodes.values())
+
+    def edges_list(self) -> list[Edge]:
+        """Edges in insertion order — what most downstream code wants."""
+        return list(self.edges.values())
+
+
+def fold_graph(ops: Iterable[GraphOp]) -> Graph:
+    """Fold an op iterable into a :class:`Graph`. Pure, no I/O."""
+    nodes: dict[int, Event] = {}
+    edges: dict[tuple[int, int, str], Edge] = {}
+    for op in ops:
+        if isinstance(op, NodeUpsert):
+            nodes[op.id] = Event(
+                id=op.id,
+                kind=EventKind(op.kind),
+                summary=op.summary,
+                source_turns=list(op.source_turns),
+            )
+        elif isinstance(op, NodeDelete):
+            nodes.pop(op.id, None)
+            # Cascade: drop every edge whose src or dst is op.id.
+            for key in [k for k in edges if k[0] == op.id or k[1] == op.id]:
+                del edges[key]
+        elif isinstance(op, EdgeUpsert):
+            key = (op.src, op.dst, op.kind)
+            edges[key] = Edge(
+                src=op.src,
+                dst=op.dst,
+                kind=EdgeKind(op.kind),
+                reason=op.reason,
+                src_turns=op.src_turns,
+                dst_turns=op.dst_turns,
+                cited_entities=op.cited_entities,
+                cited_quote=op.cited_quote,
+            )
+        elif isinstance(op, EdgeDelete):
+            edges.pop((op.src, op.dst, op.kind), None)
+        else:  # pragma: no cover - exhaustiveness guard
+            raise TypeError(f"unknown graph op type: {type(op).__name__}")
+    return Graph(nodes=nodes, edges=edges)
+
+
+__all__ = ["Graph", "fold_graph"]

--- a/contrib/extensions/llmharness/src/llmharness/audit/graph_ops.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/graph_ops.py
@@ -1,0 +1,214 @@
+"""Event-sourcing graph ops: the persistent extractor graph as an op log.
+
+The audit graph survives across firings. Each firing's extractor child
+emits a sequence of ops which the substrate folds onto the prior graph
+to produce the current view. Given an initial graph (empty) plus the
+ordered op log, any historical state is reproducible.
+
+Four op kinds, all frozen and dict-serializable:
+
+- :class:`NodeUpsert` — insert or replace an event node by id.
+- :class:`NodeDelete` — remove an event node; cascades to incident edges.
+- :class:`EdgeUpsert` — insert or replace an edge keyed by ``(src, dst, kind)``.
+- :class:`EdgeDelete` — remove an edge by ``(src, dst, kind)``. ``kind`` is
+  MANDATORY so the selector is unambiguous; per the original audit-graph
+  contract, multiple edges may share the same ``(src, dst)`` pair across
+  ``kind=data`` / ``kind=ref``.
+
+Every dict carries an ``"op"`` discriminator field so :func:`parse_op`
+can dispatch without ambiguity. The discriminator values are:
+``"node_upsert"`` / ``"node_delete"`` / ``"edge_upsert"`` /
+``"edge_delete"``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..schema import EdgeKind, EventKind
+
+
+@dataclass(frozen=True)
+class NodeUpsert:
+    """Insert or replace an event node by ``id``.
+
+    ``kind`` is the :class:`~llmharness.schema.EventKind` value (str);
+    validated by the caller before constructing the op. ``source_turns``
+    is a tuple of absolute trajectory turn indices.
+    """
+
+    id: int
+    kind: str
+    summary: str
+    source_turns: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "op": "node_upsert",
+            "id": self.id,
+            "kind": self.kind,
+            "summary": self.summary,
+            "source_turns": list(self.source_turns),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NodeUpsert:
+        return cls(
+            id=int(data["id"]),
+            kind=str(data["kind"]),
+            summary=str(data.get("summary", "")),
+            source_turns=tuple(int(t) for t in (data.get("source_turns") or [])),
+        )
+
+
+@dataclass(frozen=True)
+class NodeDelete:
+    """Delete an event node by id. Cascades to incident edges at fold time."""
+
+    id: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"op": "node_delete", "id": self.id}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NodeDelete:
+        return cls(id=int(data["id"]))
+
+
+@dataclass(frozen=True)
+class EdgeUpsert:
+    """Insert or replace one witness-bearing edge keyed by ``(src, dst, kind)``.
+
+    ``src_turns`` / ``dst_turns`` are populated by the op builder at the
+    time the op is constructed (lifted from the endpoint nodes' source
+    turns in the *folded* view). Keeping them on the op makes replay
+    self-contained — the fold does not need to re-read node state to
+    materialize an :class:`~llmharness.schema.Edge`.
+    """
+
+    src: int
+    dst: int
+    kind: str
+    reason: str
+    cited_entities: tuple[str, ...]
+    cited_quote: str
+    src_turns: tuple[int, ...]
+    dst_turns: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "op": "edge_upsert",
+            "src": self.src,
+            "dst": self.dst,
+            "kind": self.kind,
+            "reason": self.reason,
+            "cited_entities": list(self.cited_entities),
+            "cited_quote": self.cited_quote,
+            "src_turns": list(self.src_turns),
+            "dst_turns": list(self.dst_turns),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EdgeUpsert:
+        return cls(
+            src=int(data["src"]),
+            dst=int(data["dst"]),
+            kind=str(data["kind"]),
+            reason=str(data.get("reason", "")),
+            cited_entities=tuple(
+                str(e) for e in (data.get("cited_entities") or [])
+            ),
+            cited_quote=str(data.get("cited_quote", "")),
+            src_turns=tuple(int(t) for t in (data.get("src_turns") or [])),
+            dst_turns=tuple(int(t) for t in (data.get("dst_turns") or [])),
+        )
+
+
+@dataclass(frozen=True)
+class EdgeDelete:
+    """Delete an edge identified by ``(src, dst, kind)``.
+
+    ``kind`` is mandatory because ``(src, dst)`` alone is not unique —
+    a single pair may carry both a ``data`` and a ``ref`` edge. Forcing
+    the selector to include ``kind`` rules out the ambiguity at the
+    op-log level.
+    """
+
+    src: int
+    dst: int
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "op": "edge_delete",
+            "src": self.src,
+            "dst": self.dst,
+            "kind": self.kind,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EdgeDelete:
+        return cls(
+            src=int(data["src"]),
+            dst=int(data["dst"]),
+            kind=str(data["kind"]),
+        )
+
+
+GraphOp = NodeUpsert | NodeDelete | EdgeUpsert | EdgeDelete
+
+
+_OP_TABLE: dict[str, type] = {
+    "node_upsert": NodeUpsert,
+    "node_delete": NodeDelete,
+    "edge_upsert": EdgeUpsert,
+    "edge_delete": EdgeDelete,
+}
+
+
+def parse_op(data: dict[str, Any]) -> GraphOp:
+    """Dispatch on the ``"op"`` discriminator to build the right op.
+
+    Raises ``ValueError`` if the discriminator is missing or unknown —
+    the caller is expected to validate upstream when reading durable
+    entries, so an exception here marks a programmer error or a corrupt
+    log entry, not a runtime branch.
+    """
+    op = data.get("op")
+    if not isinstance(op, str):
+        raise ValueError(f"graph op payload missing 'op' discriminator: {data!r}")
+    cls = _OP_TABLE.get(op)
+    if cls is None:
+        raise ValueError(f"unknown graph op discriminator {op!r}")
+    return cls.from_dict(data)  # type: ignore[attr-defined,no-any-return]
+
+
+def validate_node_upsert_kind(kind: str) -> bool:
+    """True iff ``kind`` is a valid :class:`~llmharness.schema.EventKind` value."""
+    try:
+        EventKind(kind)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_edge_kind(kind: str) -> bool:
+    """True iff ``kind`` is a valid :class:`~llmharness.schema.EdgeKind` value."""
+    try:
+        EdgeKind(kind)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "EdgeDelete",
+    "EdgeUpsert",
+    "GraphOp",
+    "NodeDelete",
+    "NodeUpsert",
+    "parse_op",
+    "validate_edge_kind",
+    "validate_node_upsert_kind",
+]

--- a/contrib/extensions/llmharness/src/llmharness/audit/graph_ops.py
+++ b/contrib/extensions/llmharness/src/llmharness/audit/graph_ops.py
@@ -23,10 +23,10 @@ can dispatch without ambiguity. The discriminator values are:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-from ..schema import EdgeKind, EventKind
+from ..schema import EdgeKind, EventKind, ExternalRef
 
 
 @dataclass(frozen=True)
@@ -36,12 +36,21 @@ class NodeUpsert:
     ``kind`` is the :class:`~llmharness.schema.EventKind` value (str);
     validated by the caller before constructing the op. ``source_turns``
     is a tuple of absolute trajectory turn indices.
+
+    ``external_refs`` carries cross-firing references from this event
+    back into the cumulative graph (see :class:`ExternalRef`). It must
+    survive the op-log/fold round-trip so the legacy
+    ``AUDIT_EVENT``-to-op translation in ``_scan_branch`` does not
+    drop them when reading prior-firing entries; the auditor and the
+    next firing's ``recent_graph`` payload both depend on them being
+    present on the folded :class:`Event`.
     """
 
     id: int
     kind: str
     summary: str
     source_turns: tuple[int, ...]
+    external_refs: tuple[ExternalRef, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -50,6 +59,7 @@ class NodeUpsert:
             "kind": self.kind,
             "summary": self.summary,
             "source_turns": list(self.source_turns),
+            "external_refs": [r.to_dict() for r in self.external_refs],
         }
 
     @classmethod
@@ -59,6 +69,9 @@ class NodeUpsert:
             kind=str(data["kind"]),
             summary=str(data.get("summary", "")),
             source_turns=tuple(int(t) for t in (data.get("source_turns") or [])),
+            external_refs=tuple(
+                ExternalRef.from_dict(r) for r in (data.get("external_refs") or [])
+            ),
         )
 
 

--- a/contrib/extensions/llmharness/tests/test_extractor_state.py
+++ b/contrib/extensions/llmharness/tests/test_extractor_state.py
@@ -103,7 +103,11 @@ def test_atomic_edit_tools_upsert_and_delete_nodes_and_edges() -> None:
     assert not isinstance(updated_edge, str)
     assert state._edges_pending[0].reason == "updated reason"
 
-    deleted_edge = state.delete_edge({"src": 1, "dst": 2})
+    # ``kind`` is mandatory on the legacy delete path too — the op
+    # log selector needs the full (src, dst, kind) triple.
+    rejected = state.delete_edge({"src": 1, "dst": 2})
+    assert isinstance(rejected, str) and "kind" in rejected
+    deleted_edge = state.delete_edge({"src": 1, "dst": 2, "kind": "data"})
     assert not isinstance(deleted_edge, str)
     assert state._edges_pending == []
 

--- a/contrib/extensions/llmharness/tests/test_extractor_state.py
+++ b/contrib/extensions/llmharness/tests/test_extractor_state.py
@@ -551,6 +551,155 @@ def test_external_ref_unknown_id_rejected() -> None:
     assert "not found in recent_graph" in err
 
 
+# --- event-sourcing apply_* surface (cross-firing edits) ----------------------
+
+
+def test_apply_node_delete_targets_prior_firing_node() -> None:
+    """Cross-firing edit: the apply_* surface accepts deleting a node
+    that came from a PRIOR firing (i.e. lives in ``recent_graph_dict``
+    only, not in this firing's pending ops). The legacy ``delete_node``
+    rejects this because it only sees the in-firing pending set.
+    """
+    from llmharness.audit.graph_ops import NodeDelete
+    from llmharness.schema import Event, EventKind
+
+    prior_a = Event(id=1, kind=EventKind("task"), summary="prior a", source_turns=[1])
+    prior_b = Event(id=2, kind=EventKind("evid"), summary="prior b", source_turns=[2])
+    state = ExtractionState(
+        turn_texts={1: "alpha", 2: "bravo"},
+        recent_graph_dict={1: prior_a, 2: prior_b},
+        next_event_id=3,
+    )
+
+    result = state.apply_node_delete(1)
+    assert not isinstance(result, str), result
+    assert len(state.pending_ops) == 1
+    op = state.pending_ops[0]
+    assert isinstance(op, NodeDelete) and op.id == 1
+    # Folded view drops node 1; node 2 remains visible to subsequent
+    # apply_* calls in this firing.
+    assert set(state.pending_graph.nodes.keys()) == {2}
+
+
+def test_apply_edge_upsert_requires_existing_endpoints_in_folded_view() -> None:
+    """The apply_* surface validates endpoint nodes against the folded
+    graph (recent union pending), not just pending. Adding a node first
+    and then an edge to it must work — this proves the test described
+    in the brief: build on a prior node, then attach a new edge.
+    """
+    from llmharness.schema import Event, EventKind
+
+    prior = Event(id=2, kind=EventKind("hyp"), summary="prior hyp", source_turns=[2])
+    state = ExtractionState(
+        turn_texts={2: "bravo alpha", 3: "charlie alpha"},
+        recent_graph_dict={2: prior},
+        next_event_id=3,
+    )
+
+    # Initial: try to point at a yet-unborn dst — must reject.
+    err = state.apply_edge_upsert(
+        {
+            "src": 2,
+            "dst": 99,
+            "kind": "data",
+            "reason": "r",
+            "cited_entities": ["alpha"],
+        }
+    )
+    assert isinstance(err, str) and "99" in err
+
+    # Now create the dst, then attach the edge. Both succeed.
+    res = state.apply_node_upsert(
+        {"id": 3, "kind": "evid", "summary": "new", "source_turns": [3]}
+    )
+    assert not isinstance(res, str), res
+
+    res = state.apply_edge_upsert(
+        {
+            "src": 2,
+            "dst": 3,
+            "kind": "data",
+            "reason": "supports",
+            "cited_entities": ["alpha"],
+        }
+    )
+    assert not isinstance(res, str), res
+    assert (2, 3, "data") in state.pending_graph.edges
+
+
+def test_apply_edge_upsert_rejects_fabricated_ref_quote() -> None:
+    """Witness validation for kind='ref' edges: the cited_quote must
+    literally appear (after case+ws normalization) in the src node's
+    source_turns text. This gate was missing from the original atomic
+    upsert_edge — fabricated quotes slipped through.
+    """
+    state = ExtractionState(
+        turn_texts={
+            10: "the abnormal_traces table has rows",
+            11: "we follow up on abnormal_traces",
+        }
+    )
+    # Build two nodes in this firing first.
+    state.apply_node_upsert(
+        {"id": 1, "kind": "evid", "summary": "src", "source_turns": [10]}
+    )
+    state.apply_node_upsert(
+        {"id": 2, "kind": "act", "summary": "dst", "source_turns": [11]}
+    )
+
+    # cited_quote not present in src node's turn text -> rejected.
+    err = state.apply_edge_upsert(
+        {
+            "src": 1,
+            "dst": 2,
+            "kind": "ref",
+            "reason": "r",
+            "cited_quote": "never said xyzzy",
+        }
+    )
+    assert isinstance(err, str)
+    assert "cited_quote" in err
+
+    # A real quote from turn 10 -> accepted.
+    ok = state.apply_edge_upsert(
+        {
+            "src": 1,
+            "dst": 2,
+            "kind": "ref",
+            "reason": "r",
+            "cited_quote": "abnormal_traces",
+        }
+    )
+    assert not isinstance(ok, str), ok
+    assert (1, 2, "ref") in state.pending_graph.edges
+
+
+def test_apply_node_delete_unknown_id_is_rejected() -> None:
+    state = ExtractionState(turn_texts={1: "alpha"})
+    err = state.apply_node_delete(42)
+    assert isinstance(err, str) and "42" in err
+    assert state.pending_ops == []
+
+
+def test_apply_edge_delete_requires_kind() -> None:
+    state = ExtractionState(
+        turn_texts={1: "alpha", 2: "bravo alpha"}
+    )
+    state.apply_node_upsert({"id": 1, "kind": "evid", "summary": "s", "source_turns": [1]})
+    state.apply_node_upsert({"id": 2, "kind": "act", "summary": "d", "source_turns": [2]})
+    state.apply_edge_upsert(
+        {"src": 1, "dst": 2, "kind": "data", "reason": "r", "cited_entities": ["alpha"]}
+    )
+    # No kind in selector -> rejected; the op-log selector contract
+    # requires the full triple.
+    err = state.apply_edge_delete({"src": 1, "dst": 2})
+    assert isinstance(err, str) and "kind" in err
+    # With kind -> accepted; folded graph drops the edge.
+    ok = state.apply_edge_delete({"src": 1, "dst": 2, "kind": "data"})
+    assert not isinstance(ok, str), ok
+    assert (1, 2, "data") not in state.pending_graph.edges
+
+
 def test_external_ref_witness_failure_drops_into_dropped_edges() -> None:
     """Witness failures on external_refs DROP the ref (recorded for
     debugging) but keep the event — partial-success path symmetric with

--- a/contrib/extensions/llmharness/tests/test_graph_fold.py
+++ b/contrib/extensions/llmharness/tests/test_graph_fold.py
@@ -1,0 +1,245 @@
+"""Fail-stop tests for the event-sourcing op log + fold.
+
+The persistent audit graph is the **fold** of an ordered op list. If
+:func:`fold_graph` semantics drift or :meth:`GraphOp.to_dict` /
+``from_dict`` round-trip lose data, every replayed graph downstream
+goes wrong. These tests pin the load-bearing positions:
+
+- empty fold = empty graph
+- last-write-wins on repeated NodeUpsert
+- NodeDelete cascades to all incident edges
+- EdgeDelete keyed by (src, dst, kind) — removing data leaves ref alone
+- replay equivalence: fold(ops_a + ops_b) == fold(ops_a then ops_b)
+- to_dict / from_dict round-trips preserve every op variant
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmharness.audit.graph_fold import fold_graph
+from llmharness.audit.graph_ops import (
+    EdgeDelete,
+    EdgeUpsert,
+    NodeDelete,
+    NodeUpsert,
+    parse_op,
+)
+from llmharness.schema import EdgeKind, EventKind
+
+
+def _nu(eid: int, *, kind: str = "evid", summary: str = "x", turns: tuple[int, ...] = (1,)) -> NodeUpsert:
+    return NodeUpsert(id=eid, kind=kind, summary=summary, source_turns=turns)
+
+
+def _eu(src: int, dst: int, *, kind: str = "data", reason: str = "r") -> EdgeUpsert:
+    return EdgeUpsert(
+        src=src,
+        dst=dst,
+        kind=kind,
+        reason=reason,
+        cited_entities=("ent",) if kind == "data" else (),
+        cited_quote="" if kind == "data" else "quote",
+        src_turns=(1,),
+        dst_turns=(2,),
+    )
+
+
+# --- fold semantics --------------------------------------------------------
+
+
+def test_empty_op_list_yields_empty_graph() -> None:
+    g = fold_graph([])
+    assert g.nodes == {}
+    assert g.edges == {}
+    assert g.nodes_list() == []
+    assert g.edges_list() == []
+
+
+def test_single_node_upsert_creates_node() -> None:
+    g = fold_graph([_nu(1, kind="task", summary="root", turns=(1, 2))])
+    assert list(g.nodes) == [1]
+    ev = g.nodes[1]
+    assert ev.id == 1
+    assert ev.kind is EventKind.TASK
+    assert ev.summary == "root"
+    assert ev.source_turns == [1, 2]
+
+
+def test_repeated_node_upsert_is_last_write_wins() -> None:
+    g = fold_graph(
+        [
+            _nu(1, summary="first"),
+            _nu(1, summary="revised"),
+            _nu(1, kind="concl", summary="final"),
+        ]
+    )
+    assert len(g.nodes) == 1
+    assert g.nodes[1].summary == "final"
+    assert g.nodes[1].kind is EventKind.CONCL
+
+
+def test_node_delete_cascades_to_incident_edges() -> None:
+    """A deleted node drops every edge that touches it on either side."""
+    ops = [
+        _nu(1),
+        _nu(2),
+        _nu(3),
+        _eu(1, 2, kind="data"),
+        _eu(2, 3, kind="ref"),
+        _eu(1, 3, kind="ref"),
+        NodeDelete(id=2),
+    ]
+    g = fold_graph(ops)
+    assert set(g.nodes.keys()) == {1, 3}
+    # (1,2,data) and (2,3,ref) cascade; (1,3,ref) survives.
+    assert set(g.edges.keys()) == {(1, 3, "ref")}
+
+
+def test_edge_delete_removes_only_the_keyed_edge() -> None:
+    """Two edges between the same nodes differ by kind; delete is keyed."""
+    ops = [
+        _nu(1),
+        _nu(2),
+        _eu(1, 2, kind="data"),
+        _eu(1, 2, kind="ref"),
+        EdgeDelete(src=1, dst=2, kind="data"),
+    ]
+    g = fold_graph(ops)
+    assert set(g.edges.keys()) == {(1, 2, "ref")}
+
+
+def test_edge_delete_of_missing_edge_is_noop() -> None:
+    g = fold_graph(
+        [
+            _nu(1),
+            _nu(2),
+            EdgeDelete(src=1, dst=2, kind="data"),  # never existed
+        ]
+    )
+    assert g.edges == {}
+
+
+def test_node_delete_of_missing_node_is_noop() -> None:
+    g = fold_graph([NodeDelete(id=42)])
+    assert g.nodes == {}
+
+
+def test_fold_is_associative_against_concatenation() -> None:
+    """``fold(a + b) == fold(fold(a) then b)`` is the property the
+    cross-firing op log relies on: each firing's ops can be applied on
+    top of any prior fold and yield the same final state as folding
+    the whole concatenated log from scratch.
+    """
+    ops_a = [_nu(1), _nu(2), _eu(1, 2, kind="data")]
+    ops_b = [_nu(3), _eu(2, 3, kind="ref"), NodeDelete(id=1)]
+
+    direct = fold_graph(ops_a + ops_b)
+
+    fold_a = fold_graph(ops_a)
+    # Materialise fold_a back as ops to apply ops_b on top.
+    replay_prefix = [
+        NodeUpsert(
+            id=ev.id,
+            kind=ev.kind.value,
+            summary=ev.summary,
+            source_turns=tuple(ev.source_turns),
+        )
+        for ev in fold_a.nodes_list()
+    ] + [
+        EdgeUpsert(
+            src=ed.src,
+            dst=ed.dst,
+            kind=ed.kind.value,
+            reason=ed.reason,
+            cited_entities=ed.cited_entities,
+            cited_quote=ed.cited_quote,
+            src_turns=ed.src_turns,
+            dst_turns=ed.dst_turns,
+        )
+        for ed in fold_a.edges_list()
+    ]
+    indirect = fold_graph(replay_prefix + ops_b)
+
+    assert set(direct.nodes.keys()) == set(indirect.nodes.keys())
+    assert set(direct.edges.keys()) == set(indirect.edges.keys())
+
+
+def test_nodes_and_edges_iterate_in_insertion_order() -> None:
+    """Downstream consumers (auditor compose, replay sidecar) depend on
+    stable ordering. The fold MUST preserve op order in the materialised
+    node / edge lists.
+    """
+    g = fold_graph([_nu(3), _nu(1), _nu(2), _eu(3, 1, kind="data"), _eu(1, 2, kind="ref")])
+    assert [ev.id for ev in g.nodes_list()] == [3, 1, 2]
+    assert [(e.src, e.dst, e.kind.value) for e in g.edges_list()] == [
+        (3, 1, "data"),
+        (1, 2, "ref"),
+    ]
+
+
+# --- round-trip ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        NodeUpsert(id=7, kind="hyp", summary="bet", source_turns=(3, 4, 5)),
+        NodeDelete(id=12),
+        EdgeUpsert(
+            src=1,
+            dst=2,
+            kind="data",
+            reason="evidence supports",
+            cited_entities=("table_a", "service_b"),
+            cited_quote="",
+            src_turns=(1, 2),
+            dst_turns=(3,),
+        ),
+        EdgeUpsert(
+            src=1,
+            dst=2,
+            kind="ref",
+            reason="references earlier turn",
+            cited_entities=(),
+            cited_quote="latency spike",
+            src_turns=(1,),
+            dst_turns=(3,),
+        ),
+        EdgeDelete(src=1, dst=2, kind="ref"),
+    ],
+)
+def test_to_dict_from_dict_round_trip(op: object) -> None:
+    """Every op variant must round-trip through ``to_dict`` /
+    :func:`parse_op` losslessly — replay reads the dict form back from
+    durable session entries."""
+    d = op.to_dict()  # type: ignore[attr-defined]
+    parsed = parse_op(d)
+    assert parsed == op
+
+
+def test_parse_op_rejects_unknown_discriminator() -> None:
+    with pytest.raises(ValueError):
+        parse_op({"op": "not_a_real_op", "id": 1})
+
+
+def test_parse_op_rejects_missing_discriminator() -> None:
+    with pytest.raises(ValueError):
+        parse_op({"id": 1, "kind": "evid"})
+
+
+def test_edge_kind_round_trip_against_schema_enum() -> None:
+    """The folded :class:`Edge` carries an :class:`EdgeKind` enum even
+    though ops store kind as a string — proves the fold materialises
+    the schema-level type correctly.
+    """
+    g = fold_graph(
+        [
+            _nu(1),
+            _nu(2),
+            _eu(1, 2, kind="data"),
+            _eu(1, 2, kind="ref"),
+        ]
+    )
+    kinds = {e.kind for e in g.edges_list()}
+    assert kinds == {EdgeKind.DATA, EdgeKind.REF}

--- a/contrib/extensions/llmharness/tests/test_graph_fold.py
+++ b/contrib/extensions/llmharness/tests/test_graph_fold.py
@@ -25,7 +25,7 @@ from llmharness.audit.graph_ops import (
     NodeUpsert,
     parse_op,
 )
-from llmharness.schema import EdgeKind, EventKind
+from llmharness.schema import EdgeKind, EventKind, ExternalRef
 
 
 def _nu(eid: int, *, kind: str = "evid", summary: str = "x", turns: tuple[int, ...] = (1,)) -> NodeUpsert:
@@ -185,6 +185,25 @@ def test_nodes_and_edges_iterate_in_insertion_order() -> None:
     "op",
     [
         NodeUpsert(id=7, kind="hyp", summary="bet", source_turns=(3, 4, 5)),
+        # Round-trip for the external_refs payload — this is the B2
+        # fix: NodeUpsert must carry the cross-firing edge tuple
+        # through to_dict / from_dict so legacy AUDIT_EVENT translation
+        # and live op-log writes preserve cumulative connectivity.
+        NodeUpsert(
+            id=8,
+            kind="evid",
+            summary="evidence",
+            source_turns=(10,),
+            external_refs=(
+                ExternalRef(
+                    to_recent_event_id=3,
+                    kind=EdgeKind.DATA,
+                    reason="follows from prior table",
+                    cited_entities=("abnormal_traces",),
+                    cited_quote="",
+                ),
+            ),
+        ),
         NodeDelete(id=12),
         EdgeUpsert(
             src=1,
@@ -226,6 +245,35 @@ def test_parse_op_rejects_unknown_discriminator() -> None:
 def test_parse_op_rejects_missing_discriminator() -> None:
     with pytest.raises(ValueError):
         parse_op({"id": 1, "kind": "evid"})
+
+
+def test_node_upsert_carries_external_refs_through_fold() -> None:
+    """The fold must materialise ``Event.external_refs`` from the op,
+    not synthesize ``()`` defaults. Regression for B2: prior code
+    used ``Event(...)`` without the field, so legacy AUDIT_EVENT
+    translation silently dropped cross-firing connectivity that the
+    auditor + next firing's ``recent_graph`` payload both depend on.
+    """
+    ext = ExternalRef(
+        to_recent_event_id=5,
+        kind=EdgeKind.REF,
+        reason="cites earlier turn",
+        cited_entities=(),
+        cited_quote="latency spike",
+    )
+    g = fold_graph(
+        [
+            NodeUpsert(
+                id=8,
+                kind="concl",
+                summary="root cause",
+                source_turns=(20,),
+                external_refs=(ext,),
+            ),
+        ]
+    )
+    ev = g.nodes[8]
+    assert ev.external_refs == (ext,)
 
 
 def test_edge_kind_round_trip_against_schema_enum() -> None:

--- a/contrib/extensions/llmharness/tests/test_scan_branch_regressions.py
+++ b/contrib/extensions/llmharness/tests/test_scan_branch_regressions.py
@@ -1,0 +1,301 @@
+"""Scanner / persistence regressions covered by the 2026-05-22 review.
+
+Three fail-stop positions:
+
+- **B1**: ``_scan_branch`` must fold ``AUDIT_GRAPH_OP`` entries that
+  carry only a ``node_delete`` — proving the maintainer's
+  prior-firing-only edits survive the round trip. The companion
+  unit-level check on the gating logic uses a vanilla
+  :class:`ExtractionState` to assert ``pending_ops`` is the
+  authoritative signal for "did this firing do something?".
+
+- **B2**: a legacy ``AUDIT_EVENT`` entry carrying ``external_refs``
+  in its payload must surface those external_refs on the folded
+  ``Event`` — the prior translation dropped them silently.
+
+- **M4**: the persisted ``firing_id`` per AUDIT_GRAPH_OP entry must
+  be a stable session-scoped counter (0, 1, 2, ...) — not derived
+  from "count of op_index==0 entries on the branch" which collapses
+  if any future op-log change emits a firing whose first op has a
+  non-zero index.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from agentm.core.abi.session import SessionEntry
+
+from llmharness.adapters.agentm import _scan_branch
+from llmharness.audit.entry_types import (
+    AUDIT_EDGE,
+    AUDIT_EVENT,
+    AUDIT_GRAPH_OP,
+    EXTRACTOR_CURSOR,
+)
+from llmharness.audit.extractor.state import ExtractionState
+from llmharness.audit.graph_ops import NodeDelete, NodeUpsert
+from llmharness.schema import EdgeKind, Event, EventKind
+
+
+def _entry(etype: str, payload: dict[str, Any]) -> SessionEntry:
+    return SessionEntry(
+        type=etype,
+        id=uuid.uuid4().hex,
+        parent_id=None,
+        timestamp=0.0,
+        payload=payload,
+    )
+
+
+# --- B1: pure-op firing -----------------------------------------------------
+
+
+def test_scan_branch_folds_pure_node_delete_op() -> None:
+    """A firing that emits only a NodeDelete must roll forward through
+    the scanner: the prior node is gone from the folded graph. This
+    is the maintainer use case (merge duplicates from prior firings
+    via a single delete with no new events).
+    """
+    branch = [
+        # Prior firing emitted one event the legacy way.
+        _entry(
+            AUDIT_EVENT,
+            {
+                "id": 1,
+                "kind": "evid",
+                "summary": "stale",
+                "source_turns": [1],
+                "external_refs": [],
+            },
+        ),
+        # Maintainer firing emits one AUDIT_GRAPH_OP deleting it.
+        _entry(
+            AUDIT_GRAPH_OP,
+            {
+                "op": "node_delete",
+                "id": 1,
+                "firing_id": 1,
+                "op_index": 0,
+                "caused_by_turn_window": [2, 3],
+            },
+        ),
+    ]
+    state = _scan_branch(branch, recent_verdicts_n=0)
+    assert state.graph == []
+    assert state.edges == []
+
+
+def test_state_pending_ops_is_truthy_for_pure_node_delete() -> None:
+    """B1 gating: a firing that called only ``apply_node_delete`` (no
+    new events) must report ``pending_ops`` as truthy so the adapter
+    persists AUDIT_GRAPH_OP entries instead of misclassifying the
+    firing as ``EXTRACTOR_EMPTY``. Verified at the state level — the
+    adapter's gating logic reads ``state.pending_ops`` directly.
+    """
+    prior = Event(id=1, kind=EventKind("evid"), summary="stale", source_turns=[1])
+    state = ExtractionState(
+        turn_texts={1: "alpha"},
+        recent_graph_dict={1: prior},
+        next_event_id=2,
+    )
+    # The maintainer's single edit: drop the prior node.
+    result = state.apply_node_delete(1)
+    assert not isinstance(result, str), result
+
+    # Legacy snapshot view is empty (commit_batch / finalize never ran).
+    assert state.events == ()
+    assert state.edges == ()
+    assert state.dropped_edges == ()
+    # But the op log is non-empty — the gating signal for the adapter.
+    assert len(state.pending_ops) == 1
+    assert isinstance(state.pending_ops[0], NodeDelete)
+
+
+# --- B2: legacy AUDIT_EVENT external_refs round-trip ------------------------
+
+
+def test_scan_branch_legacy_audit_event_preserves_external_refs() -> None:
+    """Legacy ``AUDIT_EVENT`` translation must thread ``external_refs``
+    onto the synthesized ``NodeUpsert`` so the folded ``Event``
+    carries them. Without this, the auditor and the next firing's
+    ``recent_graph`` payload regress to per-firing islands — the very
+    failure mode the cumulative graph is designed to avoid.
+    """
+    branch = [
+        _entry(
+            AUDIT_EVENT,
+            {
+                "id": 5,
+                "kind": "concl",
+                "summary": "root cause",
+                "source_turns": [20],
+                "external_refs": [
+                    {
+                        "to_recent_event_id": 3,
+                        "kind": "ref",
+                        "reason": "restates earlier hyp",
+                        "cited_entities": [],
+                        "cited_quote": "latency spike",
+                    }
+                ],
+            },
+        ),
+    ]
+    state = _scan_branch(branch, recent_verdicts_n=0)
+    assert len(state.graph) == 1
+    ev = state.graph[0]
+    assert ev.id == 5
+    assert len(ev.external_refs) == 1
+    er = ev.external_refs[0]
+    assert er.to_recent_event_id == 3
+    assert er.kind is EdgeKind.REF
+    assert er.cited_quote == "latency spike"
+
+
+# --- M4: firing_id invariant ------------------------------------------------
+
+
+def test_firing_id_invariant_across_three_firings() -> None:
+    """The persisted ``firing_id`` is a stable session-scoped counter.
+
+    Simulates the install-level closure: a 1-element box starts at 0
+    and is incremented by ``_drain_extractor`` after each ops-bearing
+    firing. Across three firings the persisted ops carry firing_id 0,
+    1, 2 — independent of the within-firing ``op_index`` values.
+
+    The prior heuristic (count branch entries with ``op_index==0``)
+    collapses if any future change emits a firing whose first op has
+    a non-zero index (op-log compaction, partial-recovery retry).
+    """
+    firing_counter: list[int] = [0]
+    persisted: list[dict[str, Any]] = []
+
+    def _persist_firing(ops: list[NodeUpsert | NodeDelete]) -> None:
+        """Mirror the adapter's persistence loop in _drain_extractor."""
+        firing_id = firing_counter[0]
+        for op_index, op in enumerate(ops):
+            payload = op.to_dict()
+            payload["firing_id"] = firing_id
+            payload["op_index"] = op_index
+            payload["caused_by_turn_window"] = [0, 0]
+            persisted.append(payload)
+        if ops:
+            firing_counter[0] += 1
+
+    _persist_firing(
+        [NodeUpsert(id=1, kind="task", summary="t", source_turns=(0,))]
+    )
+    _persist_firing(
+        [
+            # firing 2 starts at op_index 0 with a NodeDelete (not the
+            # typical "first op is the new task" shape) — the prior
+            # heuristic would still count it because op_index==0, but
+            # the test verifies the right answer holds regardless.
+            NodeDelete(id=1),
+            NodeUpsert(id=2, kind="hyp", summary="h", source_turns=(1,)),
+        ]
+    )
+    _persist_firing(
+        [NodeUpsert(id=3, kind="concl", summary="c", source_turns=(2,))]
+    )
+
+    firing_ids_seen = [p["firing_id"] for p in persisted]
+    # Within each firing, all ops share one firing_id; across firings
+    # the counter strictly increases.
+    assert firing_ids_seen == [0, 1, 1, 2]
+    assert firing_counter[0] == 3
+
+
+def test_firing_id_counter_does_not_advance_on_empty_firing() -> None:
+    """An ops-less firing must NOT burn a firing_id — the counter
+    only ticks when persistence actually happens. This keeps the
+    per-session sequence contiguous and aligned with on-disk entries.
+    """
+    firing_counter: list[int] = [0]
+    persisted: list[dict[str, Any]] = []
+
+    def _persist_firing(ops: list[NodeUpsert | NodeDelete]) -> None:
+        firing_id = firing_counter[0]
+        for op_index, op in enumerate(ops):
+            payload = op.to_dict()
+            payload["firing_id"] = firing_id
+            payload["op_index"] = op_index
+            persisted.append(payload)
+        if ops:
+            firing_counter[0] += 1
+
+    _persist_firing([NodeUpsert(id=1, kind="task", summary="t", source_turns=(0,))])
+    _persist_firing([])  # trivial / empty — no advance
+    _persist_firing([NodeUpsert(id=2, kind="hyp", summary="h", source_turns=(1,))])
+
+    assert [p["firing_id"] for p in persisted] == [0, 1]
+    assert firing_counter[0] == 2
+
+
+# --- B1 + B2 combined: extractor-cursor advance on pure op firing -----------
+
+
+def test_scan_branch_cursor_survives_audit_graph_op_only_branch() -> None:
+    """When a firing's only output is AUDIT_GRAPH_OP + EXTRACTOR_CURSOR
+    (no legacy AUDIT_EVENT/AUDIT_EDGE), the scanner must still report
+    the cursor — proving the maintainer path doesn't break the
+    "have we caught up?" gate that drives window slicing.
+    """
+    branch = [
+        _entry(
+            AUDIT_GRAPH_OP,
+            {
+                "op": "node_delete",
+                "id": 7,
+                "firing_id": 0,
+                "op_index": 0,
+                "caused_by_turn_window": [4, 5],
+            },
+        ),
+        _entry(EXTRACTOR_CURSOR, {"last_turn_index": 5, "extraction_run_id": "x"}),
+    ]
+    state = _scan_branch(branch, recent_verdicts_n=0)
+    assert state.cursor_last_turn_index == 5
+
+
+# --- legacy AUDIT_EDGE translation parity ----------------------------------
+
+
+def test_scan_branch_legacy_audit_edge_translation_preserves_witness_fields() -> None:
+    """Cross-check on the legacy AUDIT_EDGE → EdgeUpsert path: the
+    cited_entities / cited_quote / src_turns / dst_turns must round-
+    trip so the auditor's witness display doesn't lose anchors.
+    Pinned because the witness fields are exactly the bit the auditor
+    needs to drill back to the trace.
+    """
+    branch = [
+        _entry(
+            AUDIT_EVENT,
+            {"id": 1, "kind": "evid", "summary": "s", "source_turns": [1], "external_refs": []},
+        ),
+        _entry(
+            AUDIT_EVENT,
+            {"id": 2, "kind": "act", "summary": "d", "source_turns": [2], "external_refs": []},
+        ),
+        _entry(
+            AUDIT_EDGE,
+            {
+                "src": 1,
+                "dst": 2,
+                "kind": "data",
+                "reason": "supports",
+                "src_turns": [1],
+                "dst_turns": [2],
+                "cited_entities": ["abnormal_traces"],
+                "cited_quote": "",
+            },
+        ),
+    ]
+    state = _scan_branch(branch, recent_verdicts_n=0)
+    assert len(state.edges) == 1
+    ed = state.edges[0]
+    assert ed.cited_entities == ("abnormal_traces",)
+    assert ed.src_turns == (1,)
+    assert ed.dst_turns == (2,)

--- a/contrib/extensions/llmharness/tests/test_two_phase_audit_integration.py
+++ b/contrib/extensions/llmharness/tests/test_two_phase_audit_integration.py
@@ -49,6 +49,7 @@ from agentm.core.abi.extension import ProviderConfig
 from agentm.core.abi.session_config import AgentSessionConfig
 from agentm.core.runtime.session import AgentSession
 
+from llmharness.audit.auditor import SUBMIT_VERDICT_TOOL_NAME
 from llmharness.audit.entry_types import (
     AUDIT_EDGE,
     AUDIT_EVENT,
@@ -58,7 +59,6 @@ from llmharness.audit.entry_types import (
     EXTRACTOR_PARTIAL,
     VERDICT,
 )
-from llmharness.audit.auditor import SUBMIT_VERDICT_TOOL_NAME
 from llmharness.audit.extractor import SUBMIT_EVENTS_TOOL_NAME
 
 # --- shared constants -------------------------------------------------------


### PR DESCRIPTION
## Summary

Turn the extractor from an append-only graph builder into a **maintainer** of one persistent graph across firings. The graph is now the fold of an ordered list of typed graph ops; the extractor emits ops, the substrate folds them.

Given an initial graph + an ordered op list, anyone can reproduce any historical state — replay is intrinsic.

## What changed

- **New** `audit/graph_ops.py` — four frozen op dataclasses (`NodeUpsert` / `NodeDelete` / `EdgeUpsert` / `EdgeDelete`) + `parse_op` dispatcher
- **New** `audit/graph_fold.py` — pure `fold_graph(ops) -> Graph` with NodeDelete cascade
- **New** `AUDIT_GRAPH_OP` entry type — persistent op log on the session entry tree
- `_scan_branch` folds AUDIT_GRAPH_OP entries + translated legacy AUDIT_EVENT/AUDIT_EDGE entries in branch order — **mixed sessions work**
- New `apply_node_upsert` / `apply_node_delete` / `apply_edge_upsert` / `apply_edge_delete` surface validates against the folded view (`recent ∪ pending`) so cross-firing edits Just Work
- Ref witness check now mirrors the batch path: `cited_quote` must substring BOTH src and dst source_turns text
- Legacy AUDIT_EVENT / AUDIT_EDGE entries are still emitted for back-compat — no migration required

## Validation

- `pytest contrib/extensions/llmharness/tests/` → **221 passed** (+31 new tests covering fold semantics, scan-branch regressions, cross-firing edits, firing_id invariants)
- `ruff check` → clean
- `mypy src/llmharness` → 0 errors across 64 files

## Review trail

Two iterations of code-reviewer found and closed 2 blockers + 4 majors + 6 schema gaps. Notable resolutions:

- **B1**: emit gate switched from `output.events/edges/dropped_edges` to `has_legacy_output or has_ops` — pure event-sourcing firings no longer drop their op log
- **B2**: `NodeUpsert.external_refs` round-trips through fold; legacy AUDIT_EVENT translation preserves the field
- **M4**: `firing_id` is now adapter-level closure state, not derived from branch scan — O(1) and robust to op-log changes
- **S2**: `upsert_node` no longer reuses `_EVENT_SCHEMA` (which had `submit_events_batch`-specific descriptions); has its own schema

## Deferred (not in this PR)

- Op-log squashing / compaction
- Dropping legacy AUDIT_EVENT/AUDIT_EDGE emit (kept for back-compat; can drop in a follow-up once a few firings have run on the new path)
- Auditor / web viewer / aggregate haven't changed — they still read events/edges from the same in-memory `_BranchState.graph`/`.edges` which are now folded views

## Test plan

- [x] All existing tests pass
- [x] New cross-firing scenarios covered: scanner folds pure-NodeDelete branch, ExtractionState reports pending_ops truthy on pure delete, cursor survives AUDIT_GRAPH_OP-only branch
- [x] Legacy AUDIT_EVENT external_refs preserved through fold
- [x] firing_id sequences 0/1/2 across three firings; doesn't advance on empty firings
- [x] kind-less delete_edge rejected (op-log determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)