### PR TITLE
feat: live-inspector WebSocket atom + ChildSessionExtendingEvent

### DIFF
--- a/contrib/extensions/live_inspector/__init__.py
+++ b/contrib/extensions/live_inspector/__init__.py
@@ -1,90 +1,80 @@
-"""Live-inspector atom — broadcast a session's events over a TCP socket so
-an external UI can render the agent tree in real time.
+"""Live-inspector atom — broadcast a session's events over a WebSocket so
+an external UI (aegis-ui) can render the agent tree in real time.
 
-This is the substrate for live audit visualization. UI / aegis-ui work is
-out of scope; this atom defines the wire protocol and gets the events flowing.
+This is the substrate for live audit visualization. UI work is out of scope;
+this atom defines the wire protocol and gets the events flowing.
 
-Why raw asyncio TCP (no ``websockets`` / ``aiohttp``)
----------------------------------------------------
+Why WebSocket (not raw TCP)
+---------------------------
 
-The AgentM tree currently does not depend on either library and the §11
-single-file atom contract restricts atoms to standard-library + ABI imports.
-Rather than pull in a new runtime dependency just for the first cut, we ship
-a newline-delimited-JSON over raw TCP server. The protocol is trivial enough
-that a thin browser-side shim can adapt it to WebSocket later; for current
-internal tooling a plain ``nc`` / Python client suffices.
+Browsers cannot speak raw TCP, so the UI's backend would otherwise need to
+run a TCP-to-WS bridge — defeating the "scenario atom → UI direct connect"
+design. ``websockets>=12.0`` is pure-Python, ~70 KB, no transitive deps;
+listed in the top-level ``[project] dependencies`` so it ships with every
+install.
 
 Wire protocol (v1)
 ------------------
 
-Transport: TCP, newline-delimited UTF-8 JSON. One JSON object per line in
-each direction. The server URL is logged to stderr at startup as
-``LIVE INSPECT: tcp://<host>:<port>/inspect?root=<root_session_id>``.
+Transport: WebSocket text frames; one JSON object per frame. The server URL
+is logged to stderr at startup as
+``LIVE INSPECT: ws://<host>:<port>/inspect?root=<root_session_id>``.
 
-Client → server (first line, optional):
+Client → server (first frame, optional):
     ``{"type": "subscribe", "root_session_id": "<id>"}``
-    If omitted, the client subscribes to whichever root this server is
-    bound to (one server == one root in v1, so this is informational).
+    Informational in v1 (one server per root). Sent or omitted, the
+    connection is bound to whichever root this server serves.
 
 Server → client (every connection, in order):
     1. Hello:
        ``{"type": "hello", "root_session_id": "<id>", "schema_version": 1}``
-    2. For every session in the tree (root + children) as they start:
+    2. For every session in the tree (root + spawned children) as they start:
        ``{"type": "session_started", "session_id", "parent_session_id",
            "purpose", "cwd", "ts"}``
     3. For every EventBus dispatch in any session:
        ``{"type": "event", "session_id", "ts", "kind": "<event class name>",
            "channel": "<bus channel>", "payload": {...}}``
-    4. For every entry appended to a session's entry tree (messages,
-       ``llmharness.audit_event``, ``llmharness.verdict``, …):
+    4. For every entry appended to a session's entry tree (assistant
+       messages, ``llmharness.audit_event``, ``llmharness.verdict``,
+       ``llmharness.audit_graph_op``, plan submissions, …):
        ``{"type": "entry", "session_id", "ts", "entry_type": "<type>",
-           "entry_id", "payload": {...}}``
+           "entry_id", "parent_id", "payload": {...}}``
     5. When a session ends:
        ``{"type": "session_ended", "session_id", "ts"}``
+    6. After initial backlog replay:
+       ``{"type": "backlog_done"}``
 
 Backpressure
 ------------
 
-Each connection has a bounded outbound queue (``_QUEUE_HIGHWATER``). When the
-queue is full the NEWEST message is dropped and a warning logged — slow
-clients never deadlock the broadcasting hot path.
+Each connection has a bounded outbound queue (cap ``_QUEUE_HIGHWATER`` =
+256). When the queue is full the NEWEST message is dropped and a warning
+logged — slow clients cannot deadlock the broadcaster.
 
-Open design question: ``entry`` broadcasting
---------------------------------------------
+Child sessions
+--------------
 
-There is no ABI event today for ``ReadonlySession.append_entry``. For this
-first cut we POLL ``api.session.get_branch()`` after every bus dispatch and
-broadcast newly-appended entries. The boundary stays clean (ABI-only — no
-``core.runtime.*`` import, no file tail) and it captures every entry source
-(message bodies, llmharness audit entries, plan submissions). The cost is
-one branch-length comparison per bus emit, which is O(1) amortised.
+In ``install()`` we wrap ``api.spawn_child_session`` so every child config
+gets the inspector appended to its ``extensions`` list (root host:port + the
+parent's ``root_session_id`` baked in). The child's ``install()`` then
+finds the existing server via the process-level ``_SERVERS`` registry keyed
+by ``root_session_id`` and registers its own bus instead of starting a
+second server. Net effect: one WebSocket socket, the whole agent tree.
 
-The cleaner long-term fix is option (c) in the design call: an
-``EntryAppendedEvent`` fired by ``SessionView.append_entry`` so atoms can
-subscribe directly. That requires a small core/ABI change and is logged as
-a follow-up. Option (b) — tail the on-disk JSONL — was rejected: the file
-is rewritten (``_rewrite_file``) on session creation and forks, which
-breaks naive tailers.
+Entry broadcasting
+------------------
 
-Child sessions (extractor / auditor / tool_eval_run)
-----------------------------------------------------
+Subscribes to :class:`EntryAppendedEvent` on each session's bus. Replaced
+the v0 polling approach the moment we added the core ABI event — no more
+O(branch_length) walk per bus emit.
 
-``ChildSessionStartEvent`` fires on the parent bus with the child's
-``session_id`` and ``purpose`` — we broadcast that as a ``session_started``
-event so the UI can render the child node. However the inspector atom does
-NOT receive the child's internal events unless it is also installed in the
-child session's extension set. ``llmharness`` currently builds its child
-``AgentSessionConfig`` with a fixed extension list and does not propagate
-the parent's scenario. Full child-tree visibility requires either:
+Auth (v2)
+---------
 
-  * a follow-up to ``llmharness.adapters.agentm`` to append
-    ``contrib.extensions.live_inspector`` to ``extractor_extensions`` /
-    ``auditor_extensions`` when the parent has the inspector loaded, or
-  * a core mechanism for "session-tree-wide observers" that the substrate
-    auto-installs in spawned children.
-
-This first cut documents the gap; child lifecycle is visible, child internal
-events are not.
+This first cut is unauthenticated and binds ``127.0.0.1`` by default. v2
+will add ``?token=`` to the connect URL, validated against
+``AGENTM_LIVE_INSPECT_TOKEN``. Operators who flip the bind to ``0.0.0.0``
+today do so at their own risk.
 """
 
 from __future__ import annotations
@@ -94,16 +84,22 @@ import contextlib
 import json
 import logging
 import os
-import socket
 import sys
 import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
+# WebSocket transport. ``websockets`` ships in the top-level ``[project]
+# dependencies`` so this import is guaranteed to resolve in any AgentM
+# install — no try/except fallback needed.
+import websockets
+from websockets.asyncio.server import ServerConnection, serve
+
 from agentm.core.abi.events import (
     ChildSessionEndEvent,
     ChildSessionStartEvent,
+    EntryAppendedEvent,
     EventBusObserver,
     SessionShutdownEvent,
 )
@@ -118,12 +114,13 @@ MANIFEST = ExtensionManifest(
     name="live_inspector",
     description=(
         "Stream session events (bus dispatches + entry-tree appends + "
-        "child-session lifecycle) over a TCP newline-JSON socket so an "
-        "external UI can render the agent tree live."
+        "child-session lifecycle) over a WebSocket so an external UI "
+        "can render the agent tree live."
     ),
     registers=(
         f"event:{ChildSessionStartEvent.CHANNEL}",
         f"event:{ChildSessionEndEvent.CHANNEL}",
+        f"event:{EntryAppendedEvent.CHANNEL}",
         f"event:{SessionShutdownEvent.CHANNEL}",
     ),
     config_schema={
@@ -132,26 +129,33 @@ MANIFEST = ExtensionManifest(
             "bind": {"type": "string"},
             "port": {"type": "integer"},
             "url_file": {"type": ["string", "null"]},
+            # Set internally by the spawn-wrap when this atom is auto-
+            # attached to a child session. Tells ``install()`` to skip
+            # the URL stderr/file announcement (the root already did it)
+            # and to look up the existing server by ``parent_root``
+            # rather than create a new one.
+            "role": {"type": "string"},
+            "parent_root": {"type": ["string", "null"]},
+            "parent_port": {"type": ["integer", "null"]},
         },
         "additionalProperties": False,
     },
 )
 
 
-# Channels whose payloads we skip from the broadcast — these are pure
-# per-token noise (``stream_delta``) or handler-internal signals that add no
-# value to a UI viewer and would otherwise dominate the wire.
+# Channels whose payloads we skip from the broadcast — pure per-token noise
+# (``stream_delta``) that would otherwise dominate the wire.
 _NOISY_CHANNELS: frozenset[str] = frozenset({"stream_delta"})
 
 
 # Per-connection outbound queue cap. Exceeding this drops the NEWEST message
-# (so a slow client never starves the broadcaster).
+# so a slow client never starves the broadcaster.
 _QUEUE_HIGHWATER: int = 256
 
 
 # Process-level registry: one server per root_session_id. Child sessions in
-# the same process share the parent's server (when the atom is loaded in
-# them, which it isn't by default — see module docstring).
+# the same process share the parent's server by looking up their root id
+# here in their own ``install()``.
 _SERVERS: dict[str, _Server] = {}
 _SERVERS_LOCK = threading.Lock()
 
@@ -160,10 +164,12 @@ def _now() -> float:
     return time.time()
 
 
-# Sentinel pushed onto a client's queue to signal "drain and close".
-# Identity-checked (``msg is _CLOSE_SENTINEL``); a real broadcast payload
-# is always at least ``b"{...}\n"`` so there's no collision risk.
-_CLOSE_SENTINEL: bytes = b"\x00__close__\x00"
+# Sentinel pushed onto a client's outbound queue to signal "drain & close".
+class _CloseSentinel:
+    __slots__ = ()
+
+
+_CLOSE: _CloseSentinel = _CloseSentinel()
 
 
 @dataclass(eq=False)
@@ -171,18 +177,17 @@ class _Client:
     # ``eq=False`` so instances stay hashable by identity — they live in
     # ``_Server.clients`` (a set). The default dataclass ``__eq__`` would
     # make the class unhashable and ``set.add`` would raise.
-    writer: asyncio.StreamWriter
-    queue: asyncio.Queue[bytes]
+    queue: asyncio.Queue[Any]
     dropped: int = 0
 
 
 @dataclass
 class _Server:
-    """One TCP server bound to one root session.
+    """One WebSocket server bound to one root session.
 
     Owns its own asyncio event loop in a background thread so the AgentM
-    runtime (which may or may not be inside an asyncio context at install
-    time, depending on caller) stays out of its way.
+    runtime stays out of its way (atoms install synchronously, may or may
+    not be inside an asyncio context).
     """
 
     root_session_id: str
@@ -191,7 +196,7 @@ class _Server:
     refcount: int = 0  # number of sessions in this root tree that hold us
     loop: asyncio.AbstractEventLoop | None = None
     thread: threading.Thread | None = None
-    server: asyncio.base_events.Server | None = None
+    server: Any = None  # websockets.asyncio.server.Server
     actual_port: int = 0
     clients: set[_Client] = field(default_factory=set)
     _backlog: list[dict[str, Any]] = field(default_factory=list)
@@ -203,17 +208,35 @@ class _Server:
         ready = threading.Event()
         bind_error: list[BaseException] = []
 
+        async def _bootstrap() -> Any:
+            # ``serve(...)`` constructs a ``Server`` object whose __init__
+            # calls ``asyncio.get_running_loop()`` — so it must be invoked
+            # inside a coroutine, not from ``run_until_complete(serve(...))``.
+            srv = serve(
+                self._handle_client,
+                host=self.bind,
+                port=self.port,
+                # Only serve ``/inspect``; everything else gets a 404.
+                process_request=_only_inspect_path,
+            )
+            # ``srv`` is an async context manager. Start it; entering the
+            # ctx binds the listening socket. We hold the entered ctx for
+            # the lifetime of the server and rely on ``shutdown()`` to
+            # call ``.close()`` explicitly.
+            await srv.__aenter__()
+            return srv
+
         def runner() -> None:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
             try:
-                self.server = self.loop.run_until_complete(
-                    asyncio.start_server(
-                        self._handle_client, host=self.bind, port=self.port
-                    )
-                )
-                # Resolve actual port (in case port=0).
-                sockets = self.server.sockets or ()
+                # ``self.server`` holds the ``websockets.asyncio.server.serve``
+                # context-manager wrapper; the live ``asyncio.Server`` is at
+                # ``self.server.server`` (Server.sockets is the listening
+                # socket tuple).
+                self.server = self.loop.run_until_complete(_bootstrap())
+                asyncio_server = getattr(self.server, "server", None)
+                sockets = (asyncio_server.sockets if asyncio_server else None) or ()
                 if sockets:
                     sockname = sockets[0].getsockname()
                     self.actual_port = (
@@ -225,11 +248,6 @@ class _Server:
                 bind_error.append(exc)
                 ready.set()
             finally:
-                try:
-                    if self.server is not None:
-                        self.server.close()
-                except Exception:
-                    pass
                 try:
                     if self.loop is not None and not self.loop.is_closed():
                         self.loop.close()
@@ -246,12 +264,11 @@ class _Server:
         if bind_error:
             raise bind_error[0]
 
-    async def _handle_client(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        client = _Client(writer=writer, queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
+    async def _handle_client(self, ws: ServerConnection) -> None:
+        client = _Client(queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
         self.clients.add(client)
-        # Send hello + backlog.
+
+        # Send hello + replay backlog + backlog_done.
         await self._enqueue_one(
             client,
             {
@@ -264,46 +281,36 @@ class _Server:
             await self._enqueue_one(client, record)
         await self._enqueue_one(client, {"type": "backlog_done"})
 
-        # Drain client subscribe line (optional, ignored content) so the
-        # socket buffer doesn't fill on chatty clients.
+        # Drain client subscribe frame(s) so the socket doesn't stall on
+        # chatty clients. We don't act on subscribe content in v1.
         async def drain_reads() -> None:
             try:
-                while True:
-                    line = await reader.readline()
-                    if not line:
-                        return
-                    # Best-effort decode; ignore malformed.
-                    try:
-                        json.loads(line.decode("utf-8"))
-                    except Exception:
-                        pass
-            except (ConnectionResetError, asyncio.IncompleteReadError):
+                async for message in ws:
+                    with contextlib.suppress(Exception):
+                        json.loads(message)
+            except websockets.ConnectionClosed:
                 return
 
         reader_task = asyncio.create_task(drain_reads())
 
         try:
             while True:
-                payload = await client.queue.get()
-                if payload is _CLOSE_SENTINEL:
+                item = await client.queue.get()
+                if isinstance(item, _CloseSentinel):
                     return
                 try:
-                    writer.write(payload)
-                    await writer.drain()
-                except (ConnectionResetError, BrokenPipeError):
+                    await ws.send(item)
+                except websockets.ConnectionClosed:
                     return
         finally:
             reader_task.cancel()
             self.clients.discard(client)
             with contextlib.suppress(Exception):
-                writer.close()
-                await writer.wait_closed()
+                await ws.close()
 
     async def _enqueue_one(self, client: _Client, record: dict[str, Any]) -> None:
         try:
-            line = (json.dumps(record, default=str, ensure_ascii=False) + "\n").encode(
-                "utf-8"
-            )
+            line = json.dumps(record, default=str, ensure_ascii=False)
         except Exception:
             logger.exception("live_inspector: failed to serialize record")
             return
@@ -321,13 +328,13 @@ class _Server:
     def broadcast(self, record: dict[str, Any]) -> None:
         """Thread-safe broadcast to every connected client.
 
-        Cheap on the hot path: schedules one coroutine on the server's loop
-        and returns. The coroutine fan-outs to per-client queues; per-client
-        writes happen on the loop thread.
+        Cheap on the hot path: appends to the backlog (under the loop
+        thread's natural single-writer guarantee — we only call this from
+        the agent thread / from sync handlers) and schedules a fanout
+        coroutine on the server's loop.
         """
         if self._closed or self.loop is None:
             return
-        # Append to backlog (capped) so late connecters get state.
         if len(self._backlog) >= self._backlog_cap:
             del self._backlog[: max(1, self._backlog_cap // 4)]
         self._backlog.append(record)
@@ -356,14 +363,14 @@ class _Server:
         self._closed = True
 
         async def _close() -> None:
-            # Signal every client to drain & close.
             for client in list(self.clients):
                 with contextlib.suppress(Exception):
-                    client.queue.put_nowait(_CLOSE_SENTINEL)
+                    client.queue.put_nowait(_CLOSE)
             if self.server is not None:
-                self.server.close()
+                # Exit the async-CM the ``serve(...)`` wrapper returned;
+                # that calls ``Server.close()`` + ``wait_closed()``.
                 with contextlib.suppress(Exception):
-                    await self.server.wait_closed()
+                    await self.server.__aexit__(None, None, None)
 
         if self.loop is not None and not self.loop.is_closed():
             try:
@@ -382,10 +389,27 @@ class _Server:
                 _SERVERS.pop(self.root_session_id, None)
 
 
+async def _only_inspect_path(connection: ServerConnection, request: Any) -> Any:
+    """Reject any HTTP path that isn't ``/inspect``.
+
+    Hook into ``websockets.serve(process_request=...)``: returning ``None``
+    lets the handshake proceed; returning a Response short-circuits with
+    that response.
+    """
+    path = getattr(request, "path", "/")
+    # Strip query string before comparing.
+    base = path.split("?", 1)[0]
+    if base != "/inspect":
+        return connection.respond(404, "not found\n")
+    return None
+
+
 def _get_or_create_server(
     root_session_id: str,
     bind: str,
     port: int,
+    *,
+    announce: bool,
     url_file: str | None,
 ) -> _Server:
     with _SERVERS_LOCK:
@@ -398,19 +422,21 @@ def _get_or_create_server(
         srv.acquire()
         _SERVERS[root_session_id] = srv
 
-    # Side effects outside the lock.
-    url = f"tcp://{bind}:{srv.actual_port}/inspect?root={root_session_id}"
-    try:
-        sys.stderr.write(f"LIVE INSPECT: {url}\n")
-        sys.stderr.flush()
-    except Exception:
-        pass
-    if url_file:
+    if announce:
+        url = f"ws://{bind}:{srv.actual_port}/inspect?root={root_session_id}"
         try:
-            with open(url_file, "w", encoding="utf-8") as fh:
-                fh.write(url + "\n")
-        except OSError:
-            logger.warning("live_inspector: failed to write url_file=%s", url_file)
+            sys.stderr.write(f"LIVE INSPECT: {url}\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
+        if url_file:
+            try:
+                with open(url_file, "w", encoding="utf-8") as fh:
+                    fh.write(url + "\n")
+            except OSError:
+                logger.warning(
+                    "live_inspector: failed to write url_file=%s", url_file
+                )
     return srv
 
 
@@ -420,16 +446,8 @@ class _BusObserver(EventBusObserver):
     def __init__(self, session_id: str, server: _Server) -> None:
         self._session_id = session_id
         self._server = server
-        # Entry-tree polling state. The branch is a list of SessionEntry-like
-        # objects with stable ``.id`` (uuid4 hex); we track the set we've
-        # already broadcast so a new append yields exactly one ``entry`` msg.
-        self._seen_entry_ids: set[str] = set()
-        self._branch_getter: Any = None  # set by install()
 
-    def attach_branch_getter(self, getter: Any) -> None:
-        self._branch_getter = getter
-
-    def on_emit_start(self, channel: str, event: Any) -> None:  # noqa: D401
+    def on_emit_start(self, channel: str, event: Any) -> None:
         return None
 
     def on_handler_done(
@@ -445,49 +463,90 @@ class _BusObserver(EventBusObserver):
     def on_emit_end(
         self, channel: str, event: Any, results: list[Any]
     ) -> None:
-        if channel not in _NOISY_CHANNELS:
-            try:
-                payload = to_jsonable(event)
-            except Exception:
-                payload = {"_repr": repr(event)}
-            self._server.broadcast(
-                {
-                    "type": "event",
-                    "session_id": self._session_id,
-                    "ts": _now(),
-                    "kind": type(event).__name__,
-                    "channel": channel,
-                    "payload": payload,
-                }
-            )
-        self._poll_entries()
-
-    def _poll_entries(self) -> None:
-        if self._branch_getter is None:
+        if channel in _NOISY_CHANNELS:
+            return
+        # ``EntryAppendedEvent`` is handled on its own typed channel where
+        # the inspector emits a richer ``entry`` record; skip the generic
+        # event broadcast so we don't double-publish entry writes.
+        if channel == EntryAppendedEvent.CHANNEL:
             return
         try:
-            branch = self._branch_getter()
+            payload = to_jsonable(event)
         except Exception:
-            return
-        for entry in branch:
-            entry_id = getattr(entry, "id", None)
-            if entry_id is None or entry_id in self._seen_entry_ids:
-                continue
-            self._seen_entry_ids.add(entry_id)
-            try:
-                payload = to_jsonable(getattr(entry, "payload", None))
-            except Exception:
-                payload = {"_repr": repr(getattr(entry, "payload", None))}
-            self._server.broadcast(
-                {
-                    "type": "entry",
-                    "session_id": self._session_id,
-                    "ts": _now(),
-                    "entry_id": entry_id,
-                    "entry_type": getattr(entry, "type", "unknown"),
-                    "payload": payload,
-                }
-            )
+            payload = {"_repr": repr(event)}
+        self._server.broadcast(
+            {
+                "type": "event",
+                "session_id": self._session_id,
+                "ts": _now(),
+                "kind": type(event).__name__,
+                "channel": channel,
+                "payload": payload,
+            }
+        )
+
+
+def _wrap_spawn_child_session(
+    api: ExtensionAPI,
+    bind: str,
+    actual_port: int,
+    root_session_id: str,
+) -> None:
+    """Wrap ``api.spawn_child_session`` so children auto-load the inspector.
+
+    The wrap appends a ``contrib.extensions.live_inspector`` extension entry
+    to the child's ``AgentSessionConfig.extensions`` list with ``role:
+    "child"``, ``parent_root``, and ``parent_port`` set. The child's
+    ``install()`` reads those and joins the existing per-root server
+    instead of starting another one.
+
+    Idempotent: if the child config already lists the inspector, we leave
+    it alone (operator override wins).
+    """
+
+    original = api.spawn_child_session
+    child_entry = (
+        "contrib.extensions.live_inspector",
+        {
+            "bind": bind,
+            "port": actual_port,
+            "role": "child",
+            "parent_root": root_session_id,
+            "parent_port": actual_port,
+        },
+    )
+
+    async def wrapped(config: Any = None, **kwargs: Any) -> Any:
+        # Two call styles: positional ``AgentSessionConfig`` or kwargs.
+        # Mutating an attrs/dataclass: best-effort — if ``extensions`` is
+        # accessible we append; otherwise we fall through unchanged.
+        target = config if config is not None else kwargs
+        if target is not None:
+            extensions = _get_extensions_list(target)
+            if extensions is not None:
+                # Skip if already present (operator override).
+                if not any(
+                    isinstance(e, tuple) and e and e[0] == child_entry[0]
+                    for e in extensions
+                ):
+                    extensions.append(child_entry)
+        return await original(config, **kwargs) if config is not None else await original(**kwargs)
+
+    api.spawn_child_session = wrapped  # type: ignore[method-assign]
+
+
+def _get_extensions_list(target: Any) -> list[Any] | None:
+    """Return a mutable extensions list from an ``AgentSessionConfig`` or
+    a kwargs dict. ``None`` if the target doesn't expose one we can mutate.
+    """
+    if isinstance(target, dict):
+        ext = target.get("extensions")
+        if ext is None:
+            target["extensions"] = []
+            ext = target["extensions"]
+        return ext if isinstance(ext, list) else None
+    ext = getattr(target, "extensions", None)
+    return ext if isinstance(ext, list) else None
 
 
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
@@ -495,27 +554,41 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     port = int(config.get("port", 0))
     url_file_raw = config.get("url_file")
     url_file = str(url_file_raw) if url_file_raw else None
+    role = str(config.get("role", "root"))
+    parent_port_raw = config.get("parent_port")
 
-    # Env-var overrides so an operator can flip the bind/port without
-    # rewriting the manifest. Useful for the aegis-ui dev loop where the
-    # UI binds a known port and the agent should publish there.
-    env_bind = os.environ.get("AGENTM_LIVE_INSPECT_BIND")
-    env_port = os.environ.get("AGENTM_LIVE_INSPECT_PORT")
-    env_url_file = os.environ.get("AGENTM_LIVE_INSPECT_URL_FILE")
-    if env_bind:
-        bind = env_bind
-    if env_port:
-        try:
-            port = int(env_port)
-        except ValueError:
-            pass
-    if env_url_file:
-        url_file = env_url_file
+    # Env-var overrides for ROOT only. Children inherit the resolved
+    # bind:port from the spawn-wrap config so they cannot drift.
+    if role == "root":
+        env_bind = os.environ.get("AGENTM_LIVE_INSPECT_BIND")
+        env_port = os.environ.get("AGENTM_LIVE_INSPECT_PORT")
+        env_url_file = os.environ.get("AGENTM_LIVE_INSPECT_URL_FILE")
+        if env_bind:
+            bind = env_bind
+        if env_port:
+            try:
+                port = int(env_port)
+            except ValueError:
+                pass
+        if env_url_file:
+            url_file = env_url_file
+    else:
+        # For child role: use the parent's already-resolved port verbatim.
+        # This is the unambiguous join key — we never re-bind in a child.
+        if parent_port_raw is not None:
+            try:
+                port = int(parent_port_raw)
+            except (TypeError, ValueError):
+                pass
 
+    # For a child, the per-root server already exists in this process; the
+    # registry-keyed-by-root lookup finds it. For a root, we bind a fresh
+    # server.
     server = _get_or_create_server(
         root_session_id=api.root_session_id,
         bind=bind,
         port=port,
+        announce=(role == "root"),
         url_file=url_file,
     )
 
@@ -532,10 +605,24 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     )
 
     observer = _BusObserver(session_id=session_id, server=server)
-    # Attach the branch getter via the session view — pure ABI access, no
-    # ``core.runtime.*`` import.
-    observer.attach_branch_getter(api.session.get_branch)
     api.add_observer(observer)
+
+    def _on_entry_appended(event: EntryAppendedEvent) -> None:
+        try:
+            payload = to_jsonable(event.payload)
+        except Exception:
+            payload = {"_repr": repr(event.payload)}
+        server.broadcast(
+            {
+                "type": "entry",
+                "session_id": session_id,
+                "ts": _now(),
+                "entry_id": event.entry_id,
+                "entry_type": event.entry_type,
+                "parent_id": event.parent_id,
+                "payload": payload,
+            }
+        )
 
     def _on_child_start(event: ChildSessionStartEvent) -> None:
         server.broadcast(
@@ -544,9 +631,9 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
                 "session_id": event.child_session_id,
                 "parent_session_id": event.parent_session_id,
                 "purpose": event.purpose,
-                # ``cwd`` is unknown from the parent's perspective; the
-                # child will broadcast its own session_started with cwd if
-                # the inspector atom is loaded inside it.
+                # cwd is unknown from the parent's perspective; the child's
+                # own session_started (broadcast by its inspector install)
+                # will carry the cwd.
                 "cwd": None,
                 "ts": _now(),
             }
@@ -569,43 +656,21 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
                 "ts": _now(),
             }
         )
-        # Release our refcount. Server shuts down when the last holder
-        # releases — typically the root session at process exit.
         server.release()
 
+    api.on(EntryAppendedEvent.CHANNEL, _on_entry_appended)
     api.on(ChildSessionStartEvent.CHANNEL, _on_child_start)
     api.on(ChildSessionEndEvent.CHANNEL, _on_child_end)
     api.on(SessionShutdownEvent.CHANNEL, _on_shutdown)
 
-
-# --- Test helpers -----------------------------------------------------------
-# Exposed for unit tests in ``tests/test_live_inspector.py``. Not part of
-# the atom's runtime contract; do not import from other atoms.
-
-def _connect_and_read(host: str, port: int, n_messages: int, timeout: float = 2.0) -> list[dict[str, Any]]:
-    """Open a blocking TCP socket, read up to ``n_messages`` JSON lines.
-
-    Test-only helper; uses stdlib ``socket`` rather than asyncio to keep the
-    test harness simple.
-    """
-    sock = socket.create_connection((host, port), timeout=timeout)
-    sock.settimeout(timeout)
-    out: list[dict[str, Any]] = []
-    buf = b""
-    try:
-        while len(out) < n_messages:
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            buf += chunk
-            while b"\n" in buf:
-                line, buf = buf.split(b"\n", 1)
-                if not line.strip():
-                    continue
-                out.append(json.loads(line.decode("utf-8")))
-                if len(out) >= n_messages:
-                    break
-    finally:
-        with contextlib.suppress(Exception):
-            sock.close()
-    return out
+    # Wrap spawn_child_session so children auto-attach the inspector and
+    # share the SAME server (looked up by root_session_id in their own
+    # install()). Only wraps from the root install — children don't need
+    # to wrap further; transitive grandchildren walk back to the same root.
+    if role == "root":
+        _wrap_spawn_child_session(
+            api=api,
+            bind=bind,
+            actual_port=server.actual_port,
+            root_session_id=api.root_session_id,
+        )

--- a/contrib/extensions/live_inspector/__init__.py
+++ b/contrib/extensions/live_inspector/__init__.py
@@ -54,12 +54,16 @@ logged — slow clients cannot deadlock the broadcaster.
 Child sessions
 --------------
 
-In ``install()`` we wrap ``api.spawn_child_session`` so every child config
-gets the inspector appended to its ``extensions`` list (root host:port + the
-parent's ``root_session_id`` baked in). The child's ``install()`` then
-finds the existing server via the process-level ``_SERVERS`` registry keyed
-by ``root_session_id`` and registers its own bus instead of starting a
-second server. Net effect: one WebSocket socket, the whole agent tree.
+The root ``install()`` subscribes to :class:`ChildSessionExtendingEvent` on
+the parent bus — a typed bus channel the substrate fires synchronously
+before spawning each child. Our handler returns one
+``(module, config)`` tuple contributing the inspector to the child's load
+order with ``role: "child"`` + ``parent_root`` + ``parent_port`` baked in.
+The substrate dedupes by module path (operator override on the child
+config wins), then runs the factory. The child's own ``install()`` finds
+the existing server via the process-level ``_SERVERS`` registry keyed by
+``root_session_id`` and joins instead of binding a fresh one. Net effect:
+one WebSocket socket, the whole agent tree.
 
 Entry broadcasting
 ------------------
@@ -98,6 +102,7 @@ from websockets.asyncio.server import ServerConnection, serve
 
 from agentm.core.abi.events import (
     ChildSessionEndEvent,
+    ChildSessionExtendingEvent,
     ChildSessionStartEvent,
     EntryAppendedEvent,
     EventBusObserver,
@@ -120,6 +125,7 @@ MANIFEST = ExtensionManifest(
     registers=(
         f"event:{ChildSessionStartEvent.CHANNEL}",
         f"event:{ChildSessionEndEvent.CHANNEL}",
+        f"event:{ChildSessionExtendingEvent.CHANNEL}",
         f"event:{EntryAppendedEvent.CHANNEL}",
         f"event:{SessionShutdownEvent.CHANNEL}",
     ),
@@ -266,10 +272,22 @@ class _Server:
 
     async def _handle_client(self, ws: ServerConnection) -> None:
         client = _Client(queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
-        self.clients.add(client)
 
-        # Send hello + replay backlog + backlog_done.
-        await self._enqueue_one(
+        # Replay-ordering invariant: hello + backlog snapshot + backlog_done
+        # must reach the client BEFORE any live broadcast that fires during
+        # the handshake. We achieve this by enqueueing the prologue under a
+        # single atomic block of ``put_nowait`` calls (no awaits) and only
+        # THEN adding the client to ``self.clients``. Live broadcasts
+        # (``_fanout``) only iterate clients present in that set, so they
+        # cannot interleave with the prologue — the asyncio event loop is
+        # single-threaded and we never yield between the prologue and the
+        # set insertion. Any broadcast that fires concurrently with the
+        # handshake will land in ``_backlog`` first (the broadcaster
+        # appends to ``_backlog`` before scheduling ``_fanout``), so our
+        # backlog snapshot picks it up — and then ``_fanout`` will skip
+        # this client because it's not yet in ``self.clients``, so no
+        # duplicate delivery.
+        self._enqueue_sync(
             client,
             {
                 "type": "hello",
@@ -278,8 +296,9 @@ class _Server:
             },
         )
         for record in list(self._backlog):
-            await self._enqueue_one(client, record)
-        await self._enqueue_one(client, {"type": "backlog_done"})
+            self._enqueue_sync(client, record)
+        self._enqueue_sync(client, {"type": "backlog_done"})
+        self.clients.add(client)
 
         # Drain client subscribe frame(s) so the socket doesn't stall on
         # chatty clients. We don't act on subscribe content in v1.
@@ -304,11 +323,22 @@ class _Server:
                     return
         finally:
             reader_task.cancel()
+            # Await the cancelled reader so a stray exception surfaces in
+            # the log instead of slipping out as an unhandled-task warning
+            # when the loop tears down.
+            await asyncio.gather(reader_task, return_exceptions=True)
             self.clients.discard(client)
             with contextlib.suppress(Exception):
                 await ws.close()
 
-    async def _enqueue_one(self, client: _Client, record: dict[str, Any]) -> None:
+    def _enqueue_sync(self, client: _Client, record: dict[str, Any]) -> None:
+        """Synchronous variant — used by the connect prologue.
+
+        Identical drop-newest backpressure as :meth:`_enqueue_one`; the
+        only difference is the lack of ``async`` so callers can run a
+        batch (hello + backlog + backlog_done) atomically on the loop
+        thread without yielding control.
+        """
         try:
             line = json.dumps(record, default=str, ensure_ascii=False)
         except Exception:
@@ -325,6 +355,9 @@ class _Server:
                     self.root_session_id,
                 )
 
+    async def _enqueue_one(self, client: _Client, record: dict[str, Any]) -> None:
+        self._enqueue_sync(client, record)
+
     def broadcast(self, record: dict[str, Any]) -> None:
         """Thread-safe broadcast to every connected client.
 
@@ -335,6 +368,15 @@ class _Server:
         """
         if self._closed or self.loop is None:
             return
+        # The truncate-then-append pair runs across multiple bytecode ops
+        # and ``broadcast()`` may be called from non-loop threads (any
+        # sync event handler on the agent thread). We rely on CPython's
+        # GIL atomicity on list ops — at worst a concurrent broadcast
+        # sees one stale length-cap check and inserts an extra record;
+        # the backlog never drops below ``_backlog_cap * 3/4`` so the
+        # invariant "late-joining client gets a recent window" is safe.
+        # If this ever moves to free-threaded Python, swap in a
+        # ``threading.Lock``.
         if len(self._backlog) >= self._backlog_cap:
             del self._backlog[: max(1, self._backlog_cap // 4)]
         self._backlog.append(record)
@@ -486,69 +528,6 @@ class _BusObserver(EventBusObserver):
         )
 
 
-def _wrap_spawn_child_session(
-    api: ExtensionAPI,
-    bind: str,
-    actual_port: int,
-    root_session_id: str,
-) -> None:
-    """Wrap ``api.spawn_child_session`` so children auto-load the inspector.
-
-    The wrap appends a ``contrib.extensions.live_inspector`` extension entry
-    to the child's ``AgentSessionConfig.extensions`` list with ``role:
-    "child"``, ``parent_root``, and ``parent_port`` set. The child's
-    ``install()`` reads those and joins the existing per-root server
-    instead of starting another one.
-
-    Idempotent: if the child config already lists the inspector, we leave
-    it alone (operator override wins).
-    """
-
-    original = api.spawn_child_session
-    child_entry = (
-        "contrib.extensions.live_inspector",
-        {
-            "bind": bind,
-            "port": actual_port,
-            "role": "child",
-            "parent_root": root_session_id,
-            "parent_port": actual_port,
-        },
-    )
-
-    async def wrapped(config: Any = None, **kwargs: Any) -> Any:
-        # Two call styles: positional ``AgentSessionConfig`` or kwargs.
-        # Mutating an attrs/dataclass: best-effort — if ``extensions`` is
-        # accessible we append; otherwise we fall through unchanged.
-        target = config if config is not None else kwargs
-        if target is not None:
-            extensions = _get_extensions_list(target)
-            if extensions is not None:
-                # Skip if already present (operator override).
-                if not any(
-                    isinstance(e, tuple) and e and e[0] == child_entry[0]
-                    for e in extensions
-                ):
-                    extensions.append(child_entry)
-        return await original(config, **kwargs) if config is not None else await original(**kwargs)
-
-    api.spawn_child_session = wrapped  # type: ignore[method-assign]
-
-
-def _get_extensions_list(target: Any) -> list[Any] | None:
-    """Return a mutable extensions list from an ``AgentSessionConfig`` or
-    a kwargs dict. ``None`` if the target doesn't expose one we can mutate.
-    """
-    if isinstance(target, dict):
-        ext = target.get("extensions")
-        if ext is None:
-            target["extensions"] = []
-            ext = target["extensions"]
-        return ext if isinstance(ext, list) else None
-    ext = getattr(target, "extensions", None)
-    return ext if isinstance(ext, list) else None
-
-
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     bind = str(config.get("bind", "127.0.0.1"))
     port = int(config.get("port", 0))
@@ -612,10 +591,16 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
             payload = to_jsonable(event.payload)
         except Exception:
             payload = {"_repr": repr(event.payload)}
+        # Forward the event's session_id (the SessionManager header id
+        # under which the entry was written) verbatim, rather than the
+        # install-time-captured ``session_id`` (api.session_id, the OTel
+        # span id). They can differ — get_session_id() returns the
+        # persisted header id; the inspector should report the id the
+        # entry was actually written under.
         server.broadcast(
             {
                 "type": "entry",
-                "session_id": session_id,
+                "session_id": event.session_id,
                 "ts": _now(),
                 "entry_id": event.entry_id,
                 "entry_type": event.entry_type,
@@ -663,14 +648,37 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     api.on(ChildSessionEndEvent.CHANNEL, _on_child_end)
     api.on(SessionShutdownEvent.CHANNEL, _on_shutdown)
 
-    # Wrap spawn_child_session so children auto-attach the inspector and
-    # share the SAME server (looked up by root_session_id in their own
-    # install()). Only wraps from the root install — children don't need
-    # to wrap further; transitive grandchildren walk back to the same root.
+    # Auto-attach the inspector to every spawned child session so the
+    # whole agent tree publishes to the same WebSocket. The substrate
+    # fires ``ChildSessionExtendingEvent`` on the parent bus before
+    # spawning; our handler contributes one ``(module, config)`` tuple,
+    # the substrate dedupes by module so operator overrides on the
+    # child config win, and the child's own ``install()`` finds the
+    # per-root server via ``_SERVERS`` lookup instead of binding a new
+    # one. Only the ROOT install registers the contributor — children
+    # don't need to (transitive grandchildren walk back to the same
+    # root via the trace_id). Replaces the previous monkey-wrap of
+    # ``api.spawn_child_session``: this is a typed bus channel, no
+    # api-method overwrite, no fragility.
     if role == "root":
-        _wrap_spawn_child_session(
-            api=api,
-            bind=bind,
-            actual_port=server.actual_port,
-            root_session_id=api.root_session_id,
-        )
+        root_port = server.actual_port
+        root_bind = bind
+        root_id = api.root_session_id
+
+        def _on_child_extending(
+            _event: ChildSessionExtendingEvent,
+        ) -> list[tuple[str, dict[str, Any]]]:
+            return [
+                (
+                    "contrib.extensions.live_inspector",
+                    {
+                        "bind": root_bind,
+                        "port": root_port,
+                        "role": "child",
+                        "parent_root": root_id,
+                        "parent_port": root_port,
+                    },
+                )
+            ]
+
+        api.on(ChildSessionExtendingEvent.CHANNEL, _on_child_extending)

--- a/contrib/extensions/live_inspector/__init__.py
+++ b/contrib/extensions/live_inspector/__init__.py
@@ -1,0 +1,611 @@
+"""Live-inspector atom — broadcast a session's events over a TCP socket so
+an external UI can render the agent tree in real time.
+
+This is the substrate for live audit visualization. UI / aegis-ui work is
+out of scope; this atom defines the wire protocol and gets the events flowing.
+
+Why raw asyncio TCP (no ``websockets`` / ``aiohttp``)
+---------------------------------------------------
+
+The AgentM tree currently does not depend on either library and the §11
+single-file atom contract restricts atoms to standard-library + ABI imports.
+Rather than pull in a new runtime dependency just for the first cut, we ship
+a newline-delimited-JSON over raw TCP server. The protocol is trivial enough
+that a thin browser-side shim can adapt it to WebSocket later; for current
+internal tooling a plain ``nc`` / Python client suffices.
+
+Wire protocol (v1)
+------------------
+
+Transport: TCP, newline-delimited UTF-8 JSON. One JSON object per line in
+each direction. The server URL is logged to stderr at startup as
+``LIVE INSPECT: tcp://<host>:<port>/inspect?root=<root_session_id>``.
+
+Client → server (first line, optional):
+    ``{"type": "subscribe", "root_session_id": "<id>"}``
+    If omitted, the client subscribes to whichever root this server is
+    bound to (one server == one root in v1, so this is informational).
+
+Server → client (every connection, in order):
+    1. Hello:
+       ``{"type": "hello", "root_session_id": "<id>", "schema_version": 1}``
+    2. For every session in the tree (root + children) as they start:
+       ``{"type": "session_started", "session_id", "parent_session_id",
+           "purpose", "cwd", "ts"}``
+    3. For every EventBus dispatch in any session:
+       ``{"type": "event", "session_id", "ts", "kind": "<event class name>",
+           "channel": "<bus channel>", "payload": {...}}``
+    4. For every entry appended to a session's entry tree (messages,
+       ``llmharness.audit_event``, ``llmharness.verdict``, …):
+       ``{"type": "entry", "session_id", "ts", "entry_type": "<type>",
+           "entry_id", "payload": {...}}``
+    5. When a session ends:
+       ``{"type": "session_ended", "session_id", "ts"}``
+
+Backpressure
+------------
+
+Each connection has a bounded outbound queue (``_QUEUE_HIGHWATER``). When the
+queue is full the NEWEST message is dropped and a warning logged — slow
+clients never deadlock the broadcasting hot path.
+
+Open design question: ``entry`` broadcasting
+--------------------------------------------
+
+There is no ABI event today for ``ReadonlySession.append_entry``. For this
+first cut we POLL ``api.session.get_branch()`` after every bus dispatch and
+broadcast newly-appended entries. The boundary stays clean (ABI-only — no
+``core.runtime.*`` import, no file tail) and it captures every entry source
+(message bodies, llmharness audit entries, plan submissions). The cost is
+one branch-length comparison per bus emit, which is O(1) amortised.
+
+The cleaner long-term fix is option (c) in the design call: an
+``EntryAppendedEvent`` fired by ``SessionView.append_entry`` so atoms can
+subscribe directly. That requires a small core/ABI change and is logged as
+a follow-up. Option (b) — tail the on-disk JSONL — was rejected: the file
+is rewritten (``_rewrite_file``) on session creation and forks, which
+breaks naive tailers.
+
+Child sessions (extractor / auditor / tool_eval_run)
+----------------------------------------------------
+
+``ChildSessionStartEvent`` fires on the parent bus with the child's
+``session_id`` and ``purpose`` — we broadcast that as a ``session_started``
+event so the UI can render the child node. However the inspector atom does
+NOT receive the child's internal events unless it is also installed in the
+child session's extension set. ``llmharness`` currently builds its child
+``AgentSessionConfig`` with a fixed extension list and does not propagate
+the parent's scenario. Full child-tree visibility requires either:
+
+  * a follow-up to ``llmharness.adapters.agentm`` to append
+    ``contrib.extensions.live_inspector`` to ``extractor_extensions`` /
+    ``auditor_extensions`` when the parent has the inspector loaded, or
+  * a core mechanism for "session-tree-wide observers" that the substrate
+    auto-installs in spawned children.
+
+This first cut documents the gap; child lifecycle is visible, child internal
+events are not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentm.core.abi.events import (
+    ChildSessionEndEvent,
+    ChildSessionStartEvent,
+    EventBusObserver,
+    SessionShutdownEvent,
+)
+from agentm.core.abi.extension import ExtensionAPI, Handler
+from agentm.core.lib import to_jsonable
+from agentm.extensions import ExtensionManifest
+
+logger = logging.getLogger(__name__)
+
+
+MANIFEST = ExtensionManifest(
+    name="live_inspector",
+    description=(
+        "Stream session events (bus dispatches + entry-tree appends + "
+        "child-session lifecycle) over a TCP newline-JSON socket so an "
+        "external UI can render the agent tree live."
+    ),
+    registers=(
+        f"event:{ChildSessionStartEvent.CHANNEL}",
+        f"event:{ChildSessionEndEvent.CHANNEL}",
+        f"event:{SessionShutdownEvent.CHANNEL}",
+    ),
+    config_schema={
+        "type": "object",
+        "properties": {
+            "bind": {"type": "string"},
+            "port": {"type": "integer"},
+            "url_file": {"type": ["string", "null"]},
+        },
+        "additionalProperties": False,
+    },
+)
+
+
+# Channels whose payloads we skip from the broadcast — these are pure
+# per-token noise (``stream_delta``) or handler-internal signals that add no
+# value to a UI viewer and would otherwise dominate the wire.
+_NOISY_CHANNELS: frozenset[str] = frozenset({"stream_delta"})
+
+
+# Per-connection outbound queue cap. Exceeding this drops the NEWEST message
+# (so a slow client never starves the broadcaster).
+_QUEUE_HIGHWATER: int = 256
+
+
+# Process-level registry: one server per root_session_id. Child sessions in
+# the same process share the parent's server (when the atom is loaded in
+# them, which it isn't by default — see module docstring).
+_SERVERS: dict[str, _Server] = {}
+_SERVERS_LOCK = threading.Lock()
+
+
+def _now() -> float:
+    return time.time()
+
+
+# Sentinel pushed onto a client's queue to signal "drain and close".
+# Identity-checked (``msg is _CLOSE_SENTINEL``); a real broadcast payload
+# is always at least ``b"{...}\n"`` so there's no collision risk.
+_CLOSE_SENTINEL: bytes = b"\x00__close__\x00"
+
+
+@dataclass(eq=False)
+class _Client:
+    # ``eq=False`` so instances stay hashable by identity — they live in
+    # ``_Server.clients`` (a set). The default dataclass ``__eq__`` would
+    # make the class unhashable and ``set.add`` would raise.
+    writer: asyncio.StreamWriter
+    queue: asyncio.Queue[bytes]
+    dropped: int = 0
+
+
+@dataclass
+class _Server:
+    """One TCP server bound to one root session.
+
+    Owns its own asyncio event loop in a background thread so the AgentM
+    runtime (which may or may not be inside an asyncio context at install
+    time, depending on caller) stays out of its way.
+    """
+
+    root_session_id: str
+    bind: str
+    port: int  # 0 = OS-assigned
+    refcount: int = 0  # number of sessions in this root tree that hold us
+    loop: asyncio.AbstractEventLoop | None = None
+    thread: threading.Thread | None = None
+    server: asyncio.base_events.Server | None = None
+    actual_port: int = 0
+    clients: set[_Client] = field(default_factory=set)
+    _backlog: list[dict[str, Any]] = field(default_factory=list)
+    _backlog_cap: int = 2048
+    _closed: bool = False
+
+    def start(self) -> None:
+        """Start the loop thread and block until the server is bound."""
+        ready = threading.Event()
+        bind_error: list[BaseException] = []
+
+        def runner() -> None:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+            try:
+                self.server = self.loop.run_until_complete(
+                    asyncio.start_server(
+                        self._handle_client, host=self.bind, port=self.port
+                    )
+                )
+                # Resolve actual port (in case port=0).
+                sockets = self.server.sockets or ()
+                if sockets:
+                    sockname = sockets[0].getsockname()
+                    self.actual_port = (
+                        sockname[1] if isinstance(sockname, tuple) else self.port
+                    )
+                ready.set()
+                self.loop.run_forever()
+            except BaseException as exc:  # noqa: BLE001 — propagate to .start()
+                bind_error.append(exc)
+                ready.set()
+            finally:
+                try:
+                    if self.server is not None:
+                        self.server.close()
+                except Exception:
+                    pass
+                try:
+                    if self.loop is not None and not self.loop.is_closed():
+                        self.loop.close()
+                except Exception:
+                    pass
+
+        self.thread = threading.Thread(
+            target=runner,
+            name=f"live-inspector-{self.root_session_id[:8]}",
+            daemon=True,
+        )
+        self.thread.start()
+        ready.wait(timeout=5.0)
+        if bind_error:
+            raise bind_error[0]
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        client = _Client(writer=writer, queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
+        self.clients.add(client)
+        # Send hello + backlog.
+        await self._enqueue_one(
+            client,
+            {
+                "type": "hello",
+                "root_session_id": self.root_session_id,
+                "schema_version": 1,
+            },
+        )
+        for record in list(self._backlog):
+            await self._enqueue_one(client, record)
+        await self._enqueue_one(client, {"type": "backlog_done"})
+
+        # Drain client subscribe line (optional, ignored content) so the
+        # socket buffer doesn't fill on chatty clients.
+        async def drain_reads() -> None:
+            try:
+                while True:
+                    line = await reader.readline()
+                    if not line:
+                        return
+                    # Best-effort decode; ignore malformed.
+                    try:
+                        json.loads(line.decode("utf-8"))
+                    except Exception:
+                        pass
+            except (ConnectionResetError, asyncio.IncompleteReadError):
+                return
+
+        reader_task = asyncio.create_task(drain_reads())
+
+        try:
+            while True:
+                payload = await client.queue.get()
+                if payload is _CLOSE_SENTINEL:
+                    return
+                try:
+                    writer.write(payload)
+                    await writer.drain()
+                except (ConnectionResetError, BrokenPipeError):
+                    return
+        finally:
+            reader_task.cancel()
+            self.clients.discard(client)
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+
+    async def _enqueue_one(self, client: _Client, record: dict[str, Any]) -> None:
+        try:
+            line = (json.dumps(record, default=str, ensure_ascii=False) + "\n").encode(
+                "utf-8"
+            )
+        except Exception:
+            logger.exception("live_inspector: failed to serialize record")
+            return
+        try:
+            client.queue.put_nowait(line)
+        except asyncio.QueueFull:
+            client.dropped += 1
+            if client.dropped == 1 or client.dropped % 100 == 0:
+                logger.warning(
+                    "live_inspector: slow client dropped %d messages (root=%s)",
+                    client.dropped,
+                    self.root_session_id,
+                )
+
+    def broadcast(self, record: dict[str, Any]) -> None:
+        """Thread-safe broadcast to every connected client.
+
+        Cheap on the hot path: schedules one coroutine on the server's loop
+        and returns. The coroutine fan-outs to per-client queues; per-client
+        writes happen on the loop thread.
+        """
+        if self._closed or self.loop is None:
+            return
+        # Append to backlog (capped) so late connecters get state.
+        if len(self._backlog) >= self._backlog_cap:
+            del self._backlog[: max(1, self._backlog_cap // 4)]
+        self._backlog.append(record)
+
+        async def _fanout() -> None:
+            for client in list(self.clients):
+                await self._enqueue_one(client, record)
+
+        try:
+            asyncio.run_coroutine_threadsafe(_fanout(), self.loop)
+        except RuntimeError:
+            # Loop closed mid-broadcast — drop.
+            pass
+
+    def acquire(self) -> None:
+        self.refcount += 1
+
+    def release(self) -> None:
+        self.refcount -= 1
+        if self.refcount <= 0:
+            self.shutdown()
+
+    def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        async def _close() -> None:
+            # Signal every client to drain & close.
+            for client in list(self.clients):
+                with contextlib.suppress(Exception):
+                    client.queue.put_nowait(_CLOSE_SENTINEL)
+            if self.server is not None:
+                self.server.close()
+                with contextlib.suppress(Exception):
+                    await self.server.wait_closed()
+
+        if self.loop is not None and not self.loop.is_closed():
+            try:
+                fut = asyncio.run_coroutine_threadsafe(_close(), self.loop)
+                with contextlib.suppress(Exception):
+                    fut.result(timeout=2.0)
+                self.loop.call_soon_threadsafe(self.loop.stop)
+            except RuntimeError:
+                pass
+        if self.thread is not None:
+            self.thread.join(timeout=2.0)
+
+        with _SERVERS_LOCK:
+            existing = _SERVERS.get(self.root_session_id)
+            if existing is self:
+                _SERVERS.pop(self.root_session_id, None)
+
+
+def _get_or_create_server(
+    root_session_id: str,
+    bind: str,
+    port: int,
+    url_file: str | None,
+) -> _Server:
+    with _SERVERS_LOCK:
+        existing = _SERVERS.get(root_session_id)
+        if existing is not None:
+            existing.acquire()
+            return existing
+        srv = _Server(root_session_id=root_session_id, bind=bind, port=port)
+        srv.start()
+        srv.acquire()
+        _SERVERS[root_session_id] = srv
+
+    # Side effects outside the lock.
+    url = f"tcp://{bind}:{srv.actual_port}/inspect?root={root_session_id}"
+    try:
+        sys.stderr.write(f"LIVE INSPECT: {url}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+    if url_file:
+        try:
+            with open(url_file, "w", encoding="utf-8") as fh:
+                fh.write(url + "\n")
+        except OSError:
+            logger.warning("live_inspector: failed to write url_file=%s", url_file)
+    return srv
+
+
+class _BusObserver(EventBusObserver):
+    """Captures every ``EventBus.emit`` on this session's bus."""
+
+    def __init__(self, session_id: str, server: _Server) -> None:
+        self._session_id = session_id
+        self._server = server
+        # Entry-tree polling state. The branch is a list of SessionEntry-like
+        # objects with stable ``.id`` (uuid4 hex); we track the set we've
+        # already broadcast so a new append yields exactly one ``entry`` msg.
+        self._seen_entry_ids: set[str] = set()
+        self._branch_getter: Any = None  # set by install()
+
+    def attach_branch_getter(self, getter: Any) -> None:
+        self._branch_getter = getter
+
+    def on_emit_start(self, channel: str, event: Any) -> None:  # noqa: D401
+        return None
+
+    def on_handler_done(
+        self,
+        channel: str,
+        handler: Handler,
+        result: Any,
+        error: BaseException | None,
+        duration_ns: int,
+    ) -> None:
+        return None
+
+    def on_emit_end(
+        self, channel: str, event: Any, results: list[Any]
+    ) -> None:
+        if channel not in _NOISY_CHANNELS:
+            try:
+                payload = to_jsonable(event)
+            except Exception:
+                payload = {"_repr": repr(event)}
+            self._server.broadcast(
+                {
+                    "type": "event",
+                    "session_id": self._session_id,
+                    "ts": _now(),
+                    "kind": type(event).__name__,
+                    "channel": channel,
+                    "payload": payload,
+                }
+            )
+        self._poll_entries()
+
+    def _poll_entries(self) -> None:
+        if self._branch_getter is None:
+            return
+        try:
+            branch = self._branch_getter()
+        except Exception:
+            return
+        for entry in branch:
+            entry_id = getattr(entry, "id", None)
+            if entry_id is None or entry_id in self._seen_entry_ids:
+                continue
+            self._seen_entry_ids.add(entry_id)
+            try:
+                payload = to_jsonable(getattr(entry, "payload", None))
+            except Exception:
+                payload = {"_repr": repr(getattr(entry, "payload", None))}
+            self._server.broadcast(
+                {
+                    "type": "entry",
+                    "session_id": self._session_id,
+                    "ts": _now(),
+                    "entry_id": entry_id,
+                    "entry_type": getattr(entry, "type", "unknown"),
+                    "payload": payload,
+                }
+            )
+
+
+def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
+    bind = str(config.get("bind", "127.0.0.1"))
+    port = int(config.get("port", 0))
+    url_file_raw = config.get("url_file")
+    url_file = str(url_file_raw) if url_file_raw else None
+
+    # Env-var overrides so an operator can flip the bind/port without
+    # rewriting the manifest. Useful for the aegis-ui dev loop where the
+    # UI binds a known port and the agent should publish there.
+    env_bind = os.environ.get("AGENTM_LIVE_INSPECT_BIND")
+    env_port = os.environ.get("AGENTM_LIVE_INSPECT_PORT")
+    env_url_file = os.environ.get("AGENTM_LIVE_INSPECT_URL_FILE")
+    if env_bind:
+        bind = env_bind
+    if env_port:
+        try:
+            port = int(env_port)
+        except ValueError:
+            pass
+    if env_url_file:
+        url_file = env_url_file
+
+    server = _get_or_create_server(
+        root_session_id=api.root_session_id,
+        bind=bind,
+        port=port,
+        url_file=url_file,
+    )
+
+    session_id = api.session_id
+    server.broadcast(
+        {
+            "type": "session_started",
+            "session_id": session_id,
+            "parent_session_id": api.parent_session_id,
+            "purpose": api.purpose,
+            "cwd": api.cwd,
+            "ts": _now(),
+        }
+    )
+
+    observer = _BusObserver(session_id=session_id, server=server)
+    # Attach the branch getter via the session view — pure ABI access, no
+    # ``core.runtime.*`` import.
+    observer.attach_branch_getter(api.session.get_branch)
+    api.add_observer(observer)
+
+    def _on_child_start(event: ChildSessionStartEvent) -> None:
+        server.broadcast(
+            {
+                "type": "session_started",
+                "session_id": event.child_session_id,
+                "parent_session_id": event.parent_session_id,
+                "purpose": event.purpose,
+                # ``cwd`` is unknown from the parent's perspective; the
+                # child will broadcast its own session_started with cwd if
+                # the inspector atom is loaded inside it.
+                "cwd": None,
+                "ts": _now(),
+            }
+        )
+
+    def _on_child_end(event: ChildSessionEndEvent) -> None:
+        server.broadcast(
+            {
+                "type": "session_ended",
+                "session_id": event.child_session_id,
+                "ts": _now(),
+            }
+        )
+
+    def _on_shutdown(_: SessionShutdownEvent) -> None:
+        server.broadcast(
+            {
+                "type": "session_ended",
+                "session_id": session_id,
+                "ts": _now(),
+            }
+        )
+        # Release our refcount. Server shuts down when the last holder
+        # releases — typically the root session at process exit.
+        server.release()
+
+    api.on(ChildSessionStartEvent.CHANNEL, _on_child_start)
+    api.on(ChildSessionEndEvent.CHANNEL, _on_child_end)
+    api.on(SessionShutdownEvent.CHANNEL, _on_shutdown)
+
+
+# --- Test helpers -----------------------------------------------------------
+# Exposed for unit tests in ``tests/test_live_inspector.py``. Not part of
+# the atom's runtime contract; do not import from other atoms.
+
+def _connect_and_read(host: str, port: int, n_messages: int, timeout: float = 2.0) -> list[dict[str, Any]]:
+    """Open a blocking TCP socket, read up to ``n_messages`` JSON lines.
+
+    Test-only helper; uses stdlib ``socket`` rather than asyncio to keep the
+    test harness simple.
+    """
+    sock = socket.create_connection((host, port), timeout=timeout)
+    sock.settimeout(timeout)
+    out: list[dict[str, Any]] = []
+    buf = b""
+    try:
+        while len(out) < n_messages:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                out.append(json.loads(line.decode("utf-8")))
+                if len(out) >= n_messages:
+                    break
+    finally:
+        with contextlib.suppress(Exception):
+            sock.close()
+    return out

--- a/contrib/extensions/tests/test_live_inspector.py
+++ b/contrib/extensions/tests/test_live_inspector.py
@@ -3,28 +3,41 @@
 Scope per CLAUDE.md "Testing philosophy" — only positions where the atom's
 value proposition fails if broken:
 
-1. **Wire protocol round-trip**: server emits ``hello`` then broadcast
-   records in order with the right schema. If this breaks, every UI client
-   sees garbage.
+1. **Wire protocol round-trip over WebSocket** — server emits ``hello``,
+   replays backlog, and forwards broadcasts in order with the right schema.
+   If this breaks, every UI client sees garbage.
 
-2. **Backpressure**: a slow client does not deadlock the broadcaster. If
+2. **Backpressure** — a slow client does not deadlock the broadcaster. If
    this breaks, one stuck websocket-on-a-laptop wedges the whole agent.
 
-Happy-path-for-every-event-kind is NOT covered — payload serialization is
+3. **Child-session attach via spawn-wrap** — when the inspector wraps
+   ``api.spawn_child_session``, every spawned child's ``extensions`` list
+   acquires the inspector entry with ``role: child`` so the child joins
+   the root's server instead of starting another. This is the core
+   correctness invariant for visualising the agent tree.
+
+4. **Singleton-per-root** — two ``_get_or_create_server`` calls with the
+   same root_session_id reuse the same server. Load-bearing for child
+   sessions sharing the parent's socket.
+
+Per-event-kind happy paths are NOT covered — payload serialisation is
 delegated to :func:`agentm.core.lib.to_jsonable`, already tested upstream.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
-import socket
 import threading
+from typing import Any
 
 import pytest
+from websockets.sync.client import connect
 
 from contrib.extensions.live_inspector import (
-    _get_or_create_server,
     _SERVERS,
+    _get_or_create_server,
+    _wrap_spawn_child_session,
 )
 
 
@@ -40,42 +53,31 @@ def _clear_registry() -> None:
     _SERVERS.clear()
 
 
-def _read_n_messages(host: str, port: int, n: int, timeout: float = 3.0) -> list[dict]:
-    sock = socket.create_connection((host, port), timeout=timeout)
-    sock.settimeout(timeout)
-    out: list[dict] = []
-    buf = b""
-    try:
-        while len(out) < n:
-            chunk = sock.recv(8192)
-            if not chunk:
+def _read_n_messages(url: str, n: int, timeout: float = 5.0) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with connect(url, open_timeout=timeout, close_timeout=timeout) as ws:
+        for _ in range(n):
+            try:
+                msg = ws.recv(timeout=timeout)
+            except TimeoutError:
                 break
-            buf += chunk
-            while b"\n" in buf:
-                line, buf = buf.split(b"\n", 1)
-                if not line.strip():
-                    continue
-                out.append(json.loads(line.decode("utf-8")))
-                if len(out) >= n:
-                    break
-    finally:
-        sock.close()
+            if isinstance(msg, (bytes, bytearray)):
+                msg = msg.decode("utf-8")
+            out.append(json.loads(msg))
     return out
 
 
 def test_wire_protocol_round_trip() -> None:
-    """Connect a client; assert hello + ordered broadcast delivery."""
+    """Connect a client; assert hello + backlog replay + ordered delivery."""
 
     server = _get_or_create_server(
         root_session_id="root-abc",
         bind="127.0.0.1",
         port=0,
+        announce=False,
         url_file=None,
     )
     try:
-        # Broadcast BEFORE the client connects so we exercise the backlog
-        # replay path. The hello goes out first, then backlog, then
-        # backlog_done, then any subsequent live broadcasts.
         server.broadcast(
             {
                 "type": "session_started",
@@ -97,18 +99,15 @@ def test_wire_protocol_round_trip() -> None:
             }
         )
 
-        # Reader thread connects and reads 4 messages: hello, the two
-        # backlog items, and backlog_done.
-        result: dict[str, list[dict]] = {"messages": []}
+        url = f"ws://127.0.0.1:{server.actual_port}/inspect?root=root-abc"
+        result: dict[str, list[dict[str, Any]]] = {"messages": []}
 
         def reader() -> None:
-            result["messages"] = _read_n_messages(
-                "127.0.0.1", server.actual_port, 4
-            )
+            result["messages"] = _read_n_messages(url, 4)
 
         t = threading.Thread(target=reader)
         t.start()
-        t.join(timeout=3.0)
+        t.join(timeout=5.0)
         assert not t.is_alive(), "reader thread hung"
 
         msgs = result["messages"]
@@ -127,63 +126,155 @@ def test_wire_protocol_round_trip() -> None:
 
 
 def test_backpressure_does_not_deadlock_server() -> None:
-    """A slow client gets messages dropped, but the server keeps broadcasting.
+    """Flooding broadcasts while a slow client is connected must not stall.
 
-    Strategy: open a connection but never call ``recv``. The OS socket
-    buffer + per-client asyncio queue (cap 256) will fill. Verify that
-    a second, fast client still receives a fresh broadcast within the
-    timeout — i.e. the slow client did NOT block the broadcaster.
+    A fresh fast client connecting AFTER the flood must still see hello +
+    at least one backlog item + backlog_done within the timeout.
     """
 
     server = _get_or_create_server(
         root_session_id="root-slow",
         bind="127.0.0.1",
         port=0,
+        announce=False,
         url_file=None,
     )
     try:
-        # Slow client: connect, then sleep. Never read.
-        slow_sock = socket.create_connection(
-            ("127.0.0.1", server.actual_port), timeout=2.0
-        )
+        url = f"ws://127.0.0.1:{server.actual_port}/inspect?root=root-slow"
+
+        slow_ws = connect(url, open_timeout=5.0)
         try:
-            # Flood far more than the queue cap to force drops.
             for i in range(2000):
                 server.broadcast({"type": "event", "i": i, "session_id": "s1"})
 
-            # Fast client connects; should still get hello + backlog
-            # entries + backlog_done. The hello arrives even if the slow
-            # client is wedged.
-            messages = _read_n_messages(
-                "127.0.0.1", server.actual_port, 3, timeout=3.0
-            )
+            messages = _read_n_messages(url, 3)
+            assert messages, "fast client received nothing"
             assert messages[0]["type"] == "hello"
-            # Some flood records should have made it into the backlog.
-            kinds = {m["type"] for m in messages}
-            assert "hello" in kinds
         finally:
-            slow_sock.close()
+            slow_ws.close()
     finally:
         server.release()
 
 
 def test_server_singleton_per_root() -> None:
-    """Two ``_get_or_create_server`` calls with the same root reuse the same server.
+    """Two ``_get_or_create_server`` calls with the same root reuse one server.
 
-    This is the load-bearing invariant for child-session sharing: when the
-    inspector is loaded in both parent and a child session in the same
-    process, both must publish to the SAME socket so a UI client connecting
-    once sees the full tree.
+    Load-bearing for child-session sharing.
     """
 
-    a = _get_or_create_server("root-shared", "127.0.0.1", 0, None)
+    a = _get_or_create_server(
+        "root-shared", "127.0.0.1", 0, announce=False, url_file=None
+    )
     try:
-        b = _get_or_create_server("root-shared", "127.0.0.1", 0, None)
+        b = _get_or_create_server(
+            "root-shared", "127.0.0.1", 0, announce=False, url_file=None
+        )
         try:
             assert a is b
             assert a.refcount == 2
         finally:
             b.release()
-        assert a.refcount == 1  # b released, a still holds
+        assert a.refcount == 1
     finally:
         a.release()
+
+
+# --- Child-session spawn-wrap -----------------------------------------------
+
+
+class _FakeChildConfig:
+    """Minimal stand-in for ``AgentSessionConfig`` — only what the wrap touches."""
+
+    def __init__(self) -> None:
+        self.extensions: list[tuple[str, dict[str, Any]]] = []
+
+
+class _FakeAPI:
+    """Captures what the wrap did to ``spawn_child_session`` calls."""
+
+    def __init__(self) -> None:
+        self.spawned_configs: list[Any] = []
+
+        async def _original_spawn(config: Any = None, **kwargs: Any) -> Any:
+            self.spawned_configs.append(
+                config if config is not None else dict(kwargs)
+            )
+            return object()
+
+        self.spawn_child_session = _original_spawn
+
+
+def test_spawn_wrap_appends_inspector_to_child_extensions() -> None:
+    """The wrap must append the inspector entry with ``role: child`` and the
+    right ``parent_root`` / ``parent_port``. Without this, child sessions are
+    invisible to the UI.
+    """
+
+    api = _FakeAPI()
+    _wrap_spawn_child_session(
+        api=api,  # type: ignore[arg-type]
+        bind="127.0.0.1",
+        actual_port=4242,
+        root_session_id="root-xyz",
+    )
+
+    cfg = _FakeChildConfig()
+    asyncio.run(api.spawn_child_session(cfg))
+
+    assert len(cfg.extensions) == 1, cfg.extensions
+    module, child_config = cfg.extensions[0]
+    assert module == "contrib.extensions.live_inspector"
+    assert child_config["role"] == "child"
+    assert child_config["parent_root"] == "root-xyz"
+    assert child_config["parent_port"] == 4242
+    assert child_config["bind"] == "127.0.0.1"
+
+
+def test_spawn_wrap_is_idempotent_when_operator_already_listed_inspector() -> None:
+    """If the child config already lists ``live_inspector``, the wrap leaves
+    the list alone — operator override wins.
+    """
+
+    api = _FakeAPI()
+    _wrap_spawn_child_session(
+        api=api,  # type: ignore[arg-type]
+        bind="127.0.0.1",
+        actual_port=4242,
+        root_session_id="root-xyz",
+    )
+
+    cfg = _FakeChildConfig()
+    cfg.extensions.append(
+        (
+            "contrib.extensions.live_inspector",
+            {"bind": "127.0.0.1", "port": 9999, "role": "child"},
+        )
+    )
+
+    asyncio.run(api.spawn_child_session(cfg))
+
+    assert len(cfg.extensions) == 1
+    assert cfg.extensions[0][1]["port"] == 9999
+
+
+def test_spawn_wrap_handles_kwargs_call_style() -> None:
+    """``api.spawn_child_session(**kwargs)`` is a legal call style; the wrap
+    must mutate the kwargs dict's ``extensions`` list too.
+    """
+
+    api = _FakeAPI()
+    _wrap_spawn_child_session(
+        api=api,  # type: ignore[arg-type]
+        bind="127.0.0.1",
+        actual_port=4242,
+        root_session_id="root-kw",
+    )
+
+    asyncio.run(api.spawn_child_session(extensions=[], cwd="/tmp"))
+
+    captured = api.spawned_configs[0]
+    assert isinstance(captured, dict)
+    exts = captured["extensions"]
+    assert len(exts) == 1
+    assert exts[0][0] == "contrib.extensions.live_inspector"
+    assert exts[0][1]["parent_root"] == "root-kw"

--- a/contrib/extensions/tests/test_live_inspector.py
+++ b/contrib/extensions/tests/test_live_inspector.py
@@ -1,0 +1,189 @@
+"""Fail-stop tests for the ``live_inspector`` atom.
+
+Scope per CLAUDE.md "Testing philosophy" — only positions where the atom's
+value proposition fails if broken:
+
+1. **Wire protocol round-trip**: server emits ``hello`` then broadcast
+   records in order with the right schema. If this breaks, every UI client
+   sees garbage.
+
+2. **Backpressure**: a slow client does not deadlock the broadcaster. If
+   this breaks, one stuck websocket-on-a-laptop wedges the whole agent.
+
+Happy-path-for-every-event-kind is NOT covered — payload serialization is
+delegated to :func:`agentm.core.lib.to_jsonable`, already tested upstream.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+
+import pytest
+
+from contrib.extensions.live_inspector import (
+    _get_or_create_server,
+    _SERVERS,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> None:
+    # Each test should start from a clean slate so refcounts don't bleed.
+    for srv in list(_SERVERS.values()):
+        srv.shutdown()
+    _SERVERS.clear()
+    yield
+    for srv in list(_SERVERS.values()):
+        srv.shutdown()
+    _SERVERS.clear()
+
+
+def _read_n_messages(host: str, port: int, n: int, timeout: float = 3.0) -> list[dict]:
+    sock = socket.create_connection((host, port), timeout=timeout)
+    sock.settimeout(timeout)
+    out: list[dict] = []
+    buf = b""
+    try:
+        while len(out) < n:
+            chunk = sock.recv(8192)
+            if not chunk:
+                break
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                out.append(json.loads(line.decode("utf-8")))
+                if len(out) >= n:
+                    break
+    finally:
+        sock.close()
+    return out
+
+
+def test_wire_protocol_round_trip() -> None:
+    """Connect a client; assert hello + ordered broadcast delivery."""
+
+    server = _get_or_create_server(
+        root_session_id="root-abc",
+        bind="127.0.0.1",
+        port=0,
+        url_file=None,
+    )
+    try:
+        # Broadcast BEFORE the client connects so we exercise the backlog
+        # replay path. The hello goes out first, then backlog, then
+        # backlog_done, then any subsequent live broadcasts.
+        server.broadcast(
+            {
+                "type": "session_started",
+                "session_id": "s1",
+                "parent_session_id": None,
+                "purpose": "root",
+                "cwd": "/tmp",
+                "ts": 1.0,
+            }
+        )
+        server.broadcast(
+            {
+                "type": "event",
+                "session_id": "s1",
+                "ts": 1.1,
+                "kind": "TurnEndEvent",
+                "channel": "turn_end",
+                "payload": {"turn_index": 0},
+            }
+        )
+
+        # Reader thread connects and reads 4 messages: hello, the two
+        # backlog items, and backlog_done.
+        result: dict[str, list[dict]] = {"messages": []}
+
+        def reader() -> None:
+            result["messages"] = _read_n_messages(
+                "127.0.0.1", server.actual_port, 4
+            )
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join(timeout=3.0)
+        assert not t.is_alive(), "reader thread hung"
+
+        msgs = result["messages"]
+        assert len(msgs) == 4, msgs
+        assert msgs[0]["type"] == "hello"
+        assert msgs[0]["root_session_id"] == "root-abc"
+        assert msgs[0]["schema_version"] == 1
+        assert msgs[1]["type"] == "session_started"
+        assert msgs[1]["session_id"] == "s1"
+        assert msgs[2]["type"] == "event"
+        assert msgs[2]["channel"] == "turn_end"
+        assert msgs[2]["kind"] == "TurnEndEvent"
+        assert msgs[3]["type"] == "backlog_done"
+    finally:
+        server.release()
+
+
+def test_backpressure_does_not_deadlock_server() -> None:
+    """A slow client gets messages dropped, but the server keeps broadcasting.
+
+    Strategy: open a connection but never call ``recv``. The OS socket
+    buffer + per-client asyncio queue (cap 256) will fill. Verify that
+    a second, fast client still receives a fresh broadcast within the
+    timeout — i.e. the slow client did NOT block the broadcaster.
+    """
+
+    server = _get_or_create_server(
+        root_session_id="root-slow",
+        bind="127.0.0.1",
+        port=0,
+        url_file=None,
+    )
+    try:
+        # Slow client: connect, then sleep. Never read.
+        slow_sock = socket.create_connection(
+            ("127.0.0.1", server.actual_port), timeout=2.0
+        )
+        try:
+            # Flood far more than the queue cap to force drops.
+            for i in range(2000):
+                server.broadcast({"type": "event", "i": i, "session_id": "s1"})
+
+            # Fast client connects; should still get hello + backlog
+            # entries + backlog_done. The hello arrives even if the slow
+            # client is wedged.
+            messages = _read_n_messages(
+                "127.0.0.1", server.actual_port, 3, timeout=3.0
+            )
+            assert messages[0]["type"] == "hello"
+            # Some flood records should have made it into the backlog.
+            kinds = {m["type"] for m in messages}
+            assert "hello" in kinds
+        finally:
+            slow_sock.close()
+    finally:
+        server.release()
+
+
+def test_server_singleton_per_root() -> None:
+    """Two ``_get_or_create_server`` calls with the same root reuse the same server.
+
+    This is the load-bearing invariant for child-session sharing: when the
+    inspector is loaded in both parent and a child session in the same
+    process, both must publish to the SAME socket so a UI client connecting
+    once sees the full tree.
+    """
+
+    a = _get_or_create_server("root-shared", "127.0.0.1", 0, None)
+    try:
+        b = _get_or_create_server("root-shared", "127.0.0.1", 0, None)
+        try:
+            assert a is b
+            assert a.refcount == 2
+        finally:
+            b.release()
+        assert a.refcount == 1  # b released, a still holds
+    finally:
+        a.release()

--- a/contrib/extensions/tests/test_live_inspector.py
+++ b/contrib/extensions/tests/test_live_inspector.py
@@ -7,18 +7,26 @@ value proposition fails if broken:
    replays backlog, and forwards broadcasts in order with the right schema.
    If this breaks, every UI client sees garbage.
 
-2. **Backpressure** — a slow client does not deadlock the broadcaster. If
-   this breaks, one stuck websocket-on-a-laptop wedges the whole agent.
+2. **Replay-ordering race** — a broadcast arriving mid-handshake must NOT
+   reach the client before ``backlog_done``. This is the load-bearing
+   protocol invariant; replay-vs-live ordering drift would lie about
+   "what state existed when I connected".
 
-3. **Child-session attach via spawn-wrap** — when the inspector wraps
-   ``api.spawn_child_session``, every spawned child's ``extensions`` list
-   acquires the inspector entry with ``role: child`` so the child joins
-   the root's server instead of starting another. This is the core
-   correctness invariant for visualising the agent tree.
+3. **Backpressure** — a client whose queue is full has the NEWEST message
+   dropped (``_Client.dropped`` increments) while the broadcaster keeps
+   running. Drives the mechanism directly: pre-fills the queue and asserts
+   the drop counter. The WS layer is incidental to this check.
 
 4. **Singleton-per-root** — two ``_get_or_create_server`` calls with the
    same root_session_id reuse the same server. Load-bearing for child
    sessions sharing the parent's socket.
+
+5. **``ChildSessionExtendingEvent`` handler contract** — the inspector's
+   root install registers exactly one handler that returns the child
+   inspector entry with the right parent_root + parent_port + bind. The
+   substrate's dedupe (covered separately in
+   ``tests/unit/core/test_child_session_extending_event.py``) takes it
+   from there.
 
 Per-event-kind happy paths are NOT covered — payload serialisation is
 delegated to :func:`agentm.core.lib.to_jsonable`, already tested upstream.
@@ -35,9 +43,10 @@ import pytest
 from websockets.sync.client import connect
 
 from contrib.extensions.live_inspector import (
+    _QUEUE_HIGHWATER,
     _SERVERS,
+    _Client,
     _get_or_create_server,
-    _wrap_spawn_child_session,
 )
 
 
@@ -125,33 +134,123 @@ def test_wire_protocol_round_trip() -> None:
         server.release()
 
 
-def test_backpressure_does_not_deadlock_server() -> None:
-    """Flooding broadcasts while a slow client is connected must not stall.
+def test_replay_ordering_race_does_not_leak_live_event_into_backlog() -> None:
+    """Drive the race directly: broadcast AFTER the prologue has snapshotted
+    the backlog but BEFORE ``backlog_done`` is enqueued, then assert the
+    new broadcast appears strictly after ``backlog_done``.
 
-    A fresh fast client connecting AFTER the flood must still see hello +
-    at least one backlog item + backlog_done within the timeout.
+    Driving this through the WS layer is timing-fragile (the broadcaster
+    thread may run before or after the server-loop prologue depending on
+    OS scheduling). Instead we drive it directly:
+
+    1. Pre-fill ``_backlog`` with N records.
+    2. Construct a fake client and run the prologue's exact step sequence
+       (``_enqueue_sync`` hello, ``_enqueue_sync`` for each backlog record,
+       ``_enqueue_sync`` backlog_done, ``clients.add``).
+    3. BETWEEN the backlog loop and the ``backlog_done`` enqueue, fire a
+       ``broadcast()`` from another thread. Because the client is NOT yet
+       in ``server.clients``, ``broadcast()``'s ``_fanout`` MUST skip it —
+       the new record goes into ``_backlog`` for late-connecters but does
+       NOT race into our client's queue ahead of ``backlog_done``.
+
+    Drain the client's queue and assert: every backlog record comes
+    before ``backlog_done``, no live broadcast appears anywhere in the
+    queue (it correctly went to ``_backlog`` only).
+
+    This is the actual protocol invariant. A WS round-trip on top would
+    be downstream of this — if the prologue is correct, the WS layer
+    just relays whatever's in the queue.
     """
 
     server = _get_or_create_server(
-        root_session_id="root-slow",
+        root_session_id="root-race",
         bind="127.0.0.1",
         port=0,
         announce=False,
         url_file=None,
     )
     try:
-        url = f"ws://127.0.0.1:{server.actual_port}/inspect?root=root-slow"
+        for i in range(20):
+            server._backlog.append({"type": "event", "i": i, "phase": "backlog"})
 
-        slow_ws = connect(url, open_timeout=5.0)
-        try:
-            for i in range(2000):
-                server.broadcast({"type": "event", "i": i, "session_id": "s1"})
+        client = _Client(queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
 
-            messages = _read_n_messages(url, 3)
-            assert messages, "fast client received nothing"
-            assert messages[0]["type"] == "hello"
-        finally:
-            slow_ws.close()
+        # Step 1: hello.
+        server._enqueue_sync(
+            client,
+            {"type": "hello", "root_session_id": "root-race", "schema_version": 1},
+        )
+        # Step 2: backlog snapshot replay.
+        for record in list(server._backlog):
+            server._enqueue_sync(client, record)
+        # Step 3 — RACE WINDOW: a broadcast fires while we're still mid-prologue.
+        # The client is NOT in ``server.clients`` yet, so this broadcast
+        # must NOT land in client.queue. It DOES land in ``_backlog`` for
+        # any future connecter.
+        server.broadcast({"type": "event", "phase": "live_during_prologue"})
+        # Step 4: backlog_done.
+        server._enqueue_sync(client, {"type": "backlog_done"})
+        # Step 5: clients.add.
+        server.clients.add(client)
+
+        # Drain whatever's in the client's queue (all should be from the
+        # prologue, in order: hello, 20 backlog records, backlog_done).
+        delivered: list[dict[str, Any]] = []
+        while not client.queue.empty():
+            item = client.queue.get_nowait()
+            if isinstance(item, str):
+                delivered.append(json.loads(item))
+
+        # Find backlog_done; everything in the queue is before it (the
+        # queue terminates after backlog_done since clients.add happened
+        # last and no fanout has run on this client yet).
+        types_in_order = [m.get("type", m.get("phase")) for m in delivered]
+        assert types_in_order[0] == "hello"
+        assert types_in_order[-1] == "backlog_done"
+        # And nothing from the live broadcast leaked in.
+        phases = [m.get("phase") for m in delivered]
+        assert "live_during_prologue" not in phases, (
+            "REPLAY RACE: live broadcast leaked into prologue queue: "
+            f"{phases}"
+        )
+        # Sanity: the live broadcast DID make it into _backlog for future
+        # connecters.
+        assert any(
+            r.get("phase") == "live_during_prologue" for r in server._backlog
+        )
+    finally:
+        server.release()
+
+
+def test_backpressure_drops_newest_when_queue_full() -> None:
+    """Direct unit test of the backpressure mechanism.
+
+    Pre-fill a client's queue to capacity, then drive ``_enqueue_sync``
+    one more time and assert the drop counter increments. The WS layer
+    isn't involved — this is the actual mechanism we rely on to keep a
+    slow consumer from wedging the broadcaster.
+    """
+
+    server = _get_or_create_server(
+        root_session_id="root-bp",
+        bind="127.0.0.1",
+        port=0,
+        announce=False,
+        url_file=None,
+    )
+    try:
+        client = _Client(queue=asyncio.Queue(maxsize=_QUEUE_HIGHWATER))
+        for i in range(_QUEUE_HIGHWATER):
+            client.queue.put_nowait(f"prefill-{i}")
+        assert client.dropped == 0
+
+        server._enqueue_sync(client, {"i": "overflow-1"})
+        assert client.dropped == 1
+
+        for _ in range(50):
+            server._enqueue_sync(client, {"i": "more"})
+        assert client.dropped == 51
+        assert client.queue.qsize() == _QUEUE_HIGHWATER
     finally:
         server.release()
 
@@ -179,102 +278,133 @@ def test_server_singleton_per_root() -> None:
         a.release()
 
 
-# --- Child-session spawn-wrap -----------------------------------------------
+# --- Child-session extending hook -------------------------------------------
 
 
-class _FakeChildConfig:
-    """Minimal stand-in for ``AgentSessionConfig`` — only what the wrap touches."""
+def test_child_extending_handler_contributes_inspector_entry() -> None:
+    """The root install registers a ``ChildSessionExtendingEvent`` handler
+    that returns one ``(module, config)`` tuple with the parent's bind, port,
+    role=child, and ``parent_root`` set to the root_session_id. Without this,
+    spawned child sessions are invisible to the UI.
 
-    def __init__(self) -> None:
-        self.extensions: list[tuple[str, dict[str, Any]]] = []
-
-
-class _FakeAPI:
-    """Captures what the wrap did to ``spawn_child_session`` calls."""
-
-    def __init__(self) -> None:
-        self.spawned_configs: list[Any] = []
-
-        async def _original_spawn(config: Any = None, **kwargs: Any) -> Any:
-            self.spawned_configs.append(
-                config if config is not None else dict(kwargs)
-            )
-            return object()
-
-        self.spawn_child_session = _original_spawn
-
-
-def test_spawn_wrap_appends_inspector_to_child_extensions() -> None:
-    """The wrap must append the inspector entry with ``role: child`` and the
-    right ``parent_root`` / ``parent_port``. Without this, child sessions are
-    invisible to the UI.
+    We drive the install path against a stub ExtensionAPI that records
+    subscriptions, then invoke the registered ``child_session_extending``
+    handler and inspect its return value. The dedupe / append into the
+    child config is covered by the substrate-side test in
+    ``tests/unit/core/test_child_session_extending_event.py``.
     """
 
-    api = _FakeAPI()
-    _wrap_spawn_child_session(
-        api=api,  # type: ignore[arg-type]
+    from agentm.core.abi.events import ChildSessionExtendingEvent
+    from agentm.core.abi.session_config import AgentSessionConfig
+
+    from contrib.extensions import live_inspector
+
+    server = _get_or_create_server(
+        root_session_id="root-ext",
         bind="127.0.0.1",
-        actual_port=4242,
-        root_session_id="root-xyz",
+        port=0,
+        announce=False,
+        url_file=None,
     )
+    try:
+        captured: dict[str, Any] = {"handlers": {}, "observers": []}
 
-    cfg = _FakeChildConfig()
-    asyncio.run(api.spawn_child_session(cfg))
+        class _StubAPI:
+            root_session_id = "root-ext"
+            session_id = "sess-ext"
+            parent_session_id: str | None = None
+            purpose = "root"
+            cwd = "/tmp"
 
-    assert len(cfg.extensions) == 1, cfg.extensions
-    module, child_config = cfg.extensions[0]
-    assert module == "contrib.extensions.live_inspector"
-    assert child_config["role"] == "child"
-    assert child_config["parent_root"] == "root-xyz"
-    assert child_config["parent_port"] == 4242
-    assert child_config["bind"] == "127.0.0.1"
+            def on(self, channel: str, handler: Any) -> Any:
+                captured["handlers"].setdefault(channel, []).append(handler)
+                return lambda: None
 
+            def add_observer(self, observer: Any) -> Any:
+                captured["observers"].append(observer)
+                return lambda: None
 
-def test_spawn_wrap_is_idempotent_when_operator_already_listed_inspector() -> None:
-    """If the child config already lists ``live_inspector``, the wrap leaves
-    the list alone — operator override wins.
-    """
-
-    api = _FakeAPI()
-    _wrap_spawn_child_session(
-        api=api,  # type: ignore[arg-type]
-        bind="127.0.0.1",
-        actual_port=4242,
-        root_session_id="root-xyz",
-    )
-
-    cfg = _FakeChildConfig()
-    cfg.extensions.append(
-        (
-            "contrib.extensions.live_inspector",
-            {"bind": "127.0.0.1", "port": 9999, "role": "child"},
+        live_inspector.install(
+            _StubAPI(),  # type: ignore[arg-type]
+            {
+                "bind": "127.0.0.1",
+                "port": server.actual_port,
+                "role": "root",
+            },
         )
-    )
 
-    asyncio.run(api.spawn_child_session(cfg))
+        handlers = captured["handlers"].get(ChildSessionExtendingEvent.CHANNEL)
+        assert handlers is not None and len(handlers) == 1, (
+            f"expected exactly one extending handler, got {handlers}"
+        )
 
-    assert len(cfg.extensions) == 1
-    assert cfg.extensions[0][1]["port"] == 9999
+        child_cfg = AgentSessionConfig(cwd="/tmp", extensions=[])
+        event = ChildSessionExtendingEvent(
+            parent_session_id="sess-ext",
+            child_config=child_cfg,
+        )
+        result = handlers[0](event)
+
+        assert isinstance(result, list) and len(result) == 1
+        module, child_config = result[0]
+        assert module == "contrib.extensions.live_inspector"
+        assert child_config["role"] == "child"
+        assert child_config["parent_root"] == "root-ext"
+        assert child_config["parent_port"] == server.actual_port
+        assert child_config["bind"] == "127.0.0.1"
+        assert child_config["port"] == server.actual_port
+    finally:
+        server.release()
 
 
-def test_spawn_wrap_handles_kwargs_call_style() -> None:
-    """``api.spawn_child_session(**kwargs)`` is a legal call style; the wrap
-    must mutate the kwargs dict's ``extensions`` list too.
+def test_child_role_install_does_not_register_extending_handler() -> None:
+    """Only the root install contributes to ``child_session_extending``.
+    A child install must NOT register a handler — transitive grandchildren
+    still walk back to the same root via root_session_id, so duplicating
+    the contributor would just add work for the substrate dedupe to filter.
     """
 
-    api = _FakeAPI()
-    _wrap_spawn_child_session(
-        api=api,  # type: ignore[arg-type]
+    from agentm.core.abi.events import ChildSessionExtendingEvent
+
+    from contrib.extensions import live_inspector
+
+    server = _get_or_create_server(
+        root_session_id="root-child-skip",
         bind="127.0.0.1",
-        actual_port=4242,
-        root_session_id="root-kw",
+        port=0,
+        announce=False,
+        url_file=None,
     )
+    try:
+        captured: dict[str, Any] = {"handlers": {}}
 
-    asyncio.run(api.spawn_child_session(extensions=[], cwd="/tmp"))
+        class _StubAPI:
+            root_session_id = "root-child-skip"
+            session_id = "sess-child"
+            parent_session_id: str | None = "sess-parent"
+            purpose = "child"
+            cwd = "/tmp"
 
-    captured = api.spawned_configs[0]
-    assert isinstance(captured, dict)
-    exts = captured["extensions"]
-    assert len(exts) == 1
-    assert exts[0][0] == "contrib.extensions.live_inspector"
-    assert exts[0][1]["parent_root"] == "root-kw"
+            def on(self, channel: str, handler: Any) -> Any:
+                captured["handlers"].setdefault(channel, []).append(handler)
+                return lambda: None
+
+            def add_observer(self, observer: Any) -> Any:
+                return lambda: None
+
+        live_inspector.install(
+            _StubAPI(),  # type: ignore[arg-type]
+            {
+                "bind": "127.0.0.1",
+                "port": server.actual_port,
+                "role": "child",
+                "parent_port": server.actual_port,
+                "parent_root": "root-child-skip",
+            },
+        )
+
+        assert (
+            ChildSessionExtendingEvent.CHANNEL not in captured["handlers"]
+        ), "child install should not subscribe to child_session_extending"
+    finally:
+        server.release()

--- a/contrib/scenarios/rca/manifest.harness.live.yaml
+++ b/contrib/scenarios/rca/manifest.harness.live.yaml
@@ -3,7 +3,7 @@ description: |
   ``rca:harness.sync`` plus the live-inspector atom — for interactive
   debugging / aegis-ui dev. Identical atom set to ``manifest.harness.sync.yaml``;
   the only addition is ``contrib.extensions.live_inspector``, which opens a
-  TCP newline-JSON socket the UI can connect to and stream the agent tree.
+  WebSocket the UI can connect to and stream the agent tree.
 
   Do NOT use this for dataset-collection runs: the inspector buffers a
   backlog of events in-process for late-connecting clients (capped, but
@@ -11,7 +11,7 @@ description: |
   ``manifest.harness.sync.yaml``.
 
   The inspector publishes its URL to stderr at session start, of the form
-  ``LIVE INSPECT: tcp://127.0.0.1:<port>/inspect?root=<root_session_id>``.
+  ``LIVE INSPECT: ws://127.0.0.1:<port>/inspect?root=<root_session_id>``.
   Set ``AGENTM_LIVE_INSPECT_URL_FILE`` to also write the URL to a sidecar
   file so a UI runner can poll for it without scraping stderr.
 

--- a/contrib/scenarios/rca/manifest.harness.live.yaml
+++ b/contrib/scenarios/rca/manifest.harness.live.yaml
@@ -1,0 +1,56 @@
+name: rca:harness.live
+description: |
+  ``rca:harness.sync`` plus the live-inspector atom — for interactive
+  debugging / aegis-ui dev. Identical atom set to ``manifest.harness.sync.yaml``;
+  the only addition is ``contrib.extensions.live_inspector``, which opens a
+  TCP newline-JSON socket the UI can connect to and stream the agent tree.
+
+  Do NOT use this for dataset-collection runs: the inspector buffers a
+  backlog of events in-process for late-connecting clients (capped, but
+  still extra memory). For headless data collection use
+  ``manifest.harness.sync.yaml``.
+
+  The inspector publishes its URL to stderr at session start, of the form
+  ``LIVE INSPECT: tcp://127.0.0.1:<port>/inspect?root=<root_session_id>``.
+  Set ``AGENTM_LIVE_INSPECT_URL_FILE`` to also write the URL to a sidecar
+  file so a UI runner can poll for it without scraping stderr.
+
+# Same task_class so traces stay filter-compatible with the sync variant.
+task_class: rca_baseline
+
+extensions:
+  # --- substrate: Operations bundle is mandatory post harness-collapse
+  # (commit e062913) — the session factory fail-stops at freeze if no
+  # atom registered Operations. ThinkDepthAI tools never call FS / bash,
+  # so the bundle is unused at runtime, but the registration is required.
+  - module: agentm.extensions.builtin.operations_local
+
+  # --- baseline tool surface (verbatim from manifest.baseline.yaml) ---
+  - module: agentm_rca.tools.thinkdepth_sql
+  - module: agentm_rca.tools.finalize
+  - module: agentm.extensions.builtin.observability
+  # OTLP span export — no-op without ``uv sync --extra otel``.
+  - module: agentm.extensions.builtin.otel_tracing
+  - module: contrib.extensions.rcabench_contract
+  - module: agentm_rca.prompt_loader
+    config:
+      prompt: investigator.md
+      personas: false
+
+  # Surface AGENTM_RCA_DATA_DIR to the model (see manifest.harness.yaml).
+  - module: agentm_rca.runtime_context
+
+  # --- cognitive-audit adapter in SYNC mode ---
+  - module: llmharness.adapters.agentm
+    config:
+      mode: sync
+      extractor_interval_turns: 5
+      audit_interval_turns: 5
+
+  # --- live inspector (only addition vs manifest.harness.sync.yaml) ---
+  # Bind/port can also be overridden via AGENTM_LIVE_INSPECT_BIND /
+  # AGENTM_LIVE_INSPECT_PORT / AGENTM_LIVE_INSPECT_URL_FILE env vars.
+  - module: contrib.extensions.live_inspector
+    config:
+      bind: 127.0.0.1
+      port: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ dependencies = [
     "opentelemetry-api>=1.27.0",
     "opentelemetry-sdk>=1.27.0",
     "opentelemetry-exporter-otlp>=1.27.0",
+    # Backs the ``live_inspector`` contrib atom — a WebSocket server that
+    # streams session events to an external UI (aegis-ui). Browsers cannot
+    # speak raw TCP, so WS is the load-bearing transport choice;
+    # ``websockets`` is pure-Python, ~70KB, and has no transitive deps.
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agentm/core/abi/events.py
+++ b/src/agentm/core/abi/events.py
@@ -33,11 +33,19 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Final, Literal, Protocol, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, Protocol, overload
 
 from .messages import AgentMessage, AssistantMessage
 from .stream import Model
 from .tool import Tool, ToolOutcome, ToolResult
+
+if TYPE_CHECKING:
+    # ``AgentSessionConfig`` is imported only for type hints —
+    # ``session_config`` itself imports from ``agentm.core.abi`` (this
+    # package's ``__init__``), so a runtime import would close the cycle.
+    # All annotations on this module already use ``from __future__ import
+    # annotations`` (PEP 563), so the type-only import is sufficient.
+    from .session_config import AgentSessionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -541,6 +549,39 @@ class ChildSessionStartEvent(Event):
     child_session_id: str
     parent_session_id: str
     purpose: str  # e.g. "subagent:worker", caller-defined
+
+
+@dataclass(frozen=True, slots=True)
+class ChildSessionExtendingEvent(Event):
+    """Fires synchronously on the parent bus BEFORE the substrate spawns a
+    child session, so extensions can contribute additional atoms to the
+    child's load order.
+
+    Handlers should return either ``None`` (no opinion) or a list of
+    ``(module_path, config)`` tuples that the substrate will append to
+    the child's ``AgentSessionConfig.extensions`` before the factory
+    runs. Multiple handlers' contributions are concatenated in
+    registration order. The substrate dedupes by ``module_path``: if an
+    entry is already present in ``child_config.extensions`` (operator
+    override) OR contributed by an earlier handler, later contributions
+    of the same module are dropped — handlers don't need to dedupe
+    themselves.
+
+    The ``child_config`` is exposed read-only on the event; handlers
+    MUST NOT mutate it. The substrate clones the extensions list before
+    appending, so even if a misbehaving handler mutates the field in
+    place the live config the factory sees is the substrate-controlled
+    one.
+
+    Emitted via ``bus.emit_sync`` because the spawn path needs the
+    contributions to be settled before ``session_cls.create`` runs;
+    async handlers are skipped (matching the rest of the ``emit_sync``
+    contract).
+    """
+
+    CHANNEL: ClassVar[Literal["child_session_extending"]] = "child_session_extending"
+    parent_session_id: str
+    child_config: "AgentSessionConfig"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1282,6 +1323,7 @@ __all__ = [
     "BudgetExhausted",
     "BusPriority",
     "ChildSessionEndEvent",
+    "ChildSessionExtendingEvent",
     "ChildSessionStartEvent",
     "CommandDispatchedEvent",
     "ContextEvent",

--- a/src/agentm/core/abi/events.py
+++ b/src/agentm/core/abi/events.py
@@ -586,6 +586,39 @@ class PlanSubmittedEvent(Event):
 
 
 @dataclass(frozen=True, slots=True)
+class EntryAppendedEvent(Event):
+    """Fires after :meth:`ReadonlySession.append_entry` persists an entry.
+
+    Lets extensions observe every write to the session entry tree —
+    assistant messages, ``llmharness.audit_event`` / ``llmharness.verdict`` /
+    ``llmharness.audit_graph_op`` entries, plan submissions, etc. — without
+    polling ``get_branch()`` or tailing the on-disk JSONL.
+
+    Emitted via :meth:`EventBus.emit_sync` from inside the sync
+    ``append_entry`` codepath. Handlers must therefore be sync (an async
+    handler is skipped with a diagnostic, matching the rest of the
+    ``emit_sync`` contract). The event fires AFTER the entry has been
+    durably written so handler crashes cannot corrupt session state.
+
+    ``payload`` is the raw object passed to ``append_entry`` — observers
+    that need a JSON-serialisable view should run it through
+    :func:`agentm.core.lib.to_jsonable` themselves; we don't pre-serialise
+    on the hot path since most subscribers (e.g. ``live_inspector``) need
+    a custom shape anyway.
+    """
+
+    CHANNEL: ClassVar[Literal["entry_appended"]] = "entry_appended"
+    session_id: str
+    """The persisted session-manager header id (``ReadonlySession.get_session_id``),
+    not the OTel span id. Distinct from the bus-owning session's
+    ``api.session_id`` for embedded callers."""
+    entry_type: str
+    entry_id: str
+    parent_id: str | None
+    payload: Any
+
+
+@dataclass(frozen=True, slots=True)
 class SessionReadyEvent(Event):
     """Fires once after ``AgentSession.create`` has loaded every extension
     and the active provider has been picked, but before the first ``prompt``.
@@ -1255,6 +1288,7 @@ __all__ = [
     "CostBudgetExceededEvent",
     "DecideTurnActionEvent",
     "DiagnosticEvent",
+    "EntryAppendedEvent",
     "Event",
     "EventBus",
     "EventBusObserver",

--- a/src/agentm/core/runtime/session_factory.py
+++ b/src/agentm/core/runtime/session_factory.py
@@ -120,6 +120,7 @@ async def create_agent_session(
     session_view: ReadonlySession = SessionView(
         session_manager,
         loop_config_getter=lambda: configured_loop_config,
+        bus=bus,
     )
     from agentm.core.runtime.resource_writer import DEFAULT_PROTECTED_BRANCHES
 

--- a/src/agentm/core/runtime/session_factory.py
+++ b/src/agentm/core/runtime/session_factory.py
@@ -24,6 +24,7 @@ from agentm.core.runtime.atom_reloader import AtomReloader
 from agentm.core.runtime.atom_sandbox import apply_atom_source_overrides
 from agentm.core.runtime.command_dispatcher import HarnessCommandDispatcher
 from agentm.core.abi.events import (
+    ChildSessionExtendingEvent,
     ChildSessionStartEvent,
     ExtensionInstallEvent,
     SessionReadyEvent,
@@ -56,6 +57,50 @@ from agentm.core.runtime.session_manager import InMemorySessionManager, SessionM
 from agentm.core.runtime.session_runtime import SessionRuntime
 
 logger = logging.getLogger(__name__)
+
+
+def apply_child_session_contributions(
+    base_extensions: list[tuple[str, dict[str, Any]]],
+    handler_returns: list[Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    """Concatenate handler-contributed extension entries onto a child's load
+    order, dedupe by ``module_path``.
+
+    See :class:`agentm.core.abi.events.ChildSessionExtendingEvent`. Each
+    element of ``handler_returns`` is either ``None`` (no opinion) or an
+    iterable of ``(module_path, config)`` tuples. Order is preserved:
+    the operator-supplied entries on ``base_extensions`` come first,
+    then handler returns in registration order. The first occurrence of
+    each module wins; later duplicates are dropped silently so handlers
+    don't have to dedupe themselves.
+
+    Exposed at module top-level (not nested inside the factory) so the
+    fail-stop test in ``tests/unit/core/test_child_session_extending_event.py``
+    can drive the dedupe logic directly without standing up a real
+    session.
+    """
+    result: list[tuple[str, dict[str, Any]]] = list(base_extensions)
+    seen: set[str] = {entry[0] for entry in result if isinstance(entry, tuple) and entry}
+    for ret in handler_returns:
+        if ret is None:
+            continue
+        # Permissive: accept any iterable of (module, config) — handlers
+        # may return list, tuple, or generator.
+        try:
+            iterator = list(ret)
+        except TypeError:
+            continue
+        for entry in iterator:
+            if not (isinstance(entry, tuple) and len(entry) == 2):
+                continue
+            module, cfg = entry
+            if not isinstance(module, str) or module in seen:
+                continue
+            if not isinstance(cfg, dict):
+                continue
+            result.append((module, cfg))
+            seen.add(module)
+    return result
 
 
 async def create_agent_session(
@@ -188,6 +233,28 @@ async def create_agent_session(
                     "the parent session has no active provider to inherit."
                 )
             spec.provider = child_provider_factory(parent_provider)
+
+        # Give extensions on the parent bus a chance to contribute atoms
+        # to the child's load order. ``emit_sync`` because we need the
+        # contributions resolved BEFORE ``session_cls.create`` runs; the
+        # event is delivered on the parent bus only — child sessions don't
+        # observe their own extending pass.
+        #
+        # We clone the extensions list before emit so a misbehaving
+        # handler mutating ``ev.child_config.extensions`` in place cannot
+        # affect what the factory sees: only the substrate-controlled
+        # ``spec.extensions`` is honoured below.
+        returns = bus.emit_sync(
+            ChildSessionExtendingEvent.CHANNEL,
+            ChildSessionExtendingEvent(
+                parent_session_id=session_id,
+                child_config=spec,
+            ),
+        )
+        spec.extensions = apply_child_session_contributions(
+            list(spec.extensions), returns
+        )
+
         return await session_cls.create(spec)
 
     scope = build_extension_api_scope(

--- a/src/agentm/core/runtime/session_helpers.py
+++ b/src/agentm/core/runtime/session_helpers.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentm.core.abi import AgentMessage, EventBus, LoopConfig, TerminationCause
-from agentm.core.abi.events import DiagnosticEvent
+from agentm.core.abi.events import DiagnosticEvent, EntryAppendedEvent
 from agentm.core.runtime.extension import ExtensionLoadError, ProviderConfig, ReadonlySession
 from agentm.core.runtime.session_manager import SessionEntry, SessionManager
 
@@ -39,9 +39,15 @@ class SessionView:
         sm: SessionManager,
         *,
         loop_config_getter: Callable[[], LoopConfig],
+        bus: EventBus | None = None,
     ) -> None:
         self._sm = sm
         self._loop_config_getter = loop_config_getter
+        # Bus is optional so the embedded ``ReadonlySession`` constructed
+        # in tests / non-session contexts (e.g. session_factory pre-bus
+        # construction) keeps working. Production sessions always pass
+        # their event bus through so ``EntryAppendedEvent`` fires.
+        self._bus = bus
 
     def get_messages(self) -> list[AgentMessage]:
         return self._sm.get_messages()
@@ -78,6 +84,21 @@ class SessionView:
             payload=payload,
         )
         self._sm.append(entry)
+        # Fire AFTER the entry is durably appended — handler crashes
+        # cannot corrupt session state. ``emit_sync`` because
+        # ``append_entry`` is a sync API and we don't want to force the
+        # caller into an async context.
+        if self._bus is not None:
+            self._bus.emit_sync(
+                EntryAppendedEvent.CHANNEL,
+                EntryAppendedEvent(
+                    session_id=self._sm.get_session_id(),
+                    entry_type=type,
+                    entry_id=entry.id,
+                    parent_id=parent_id,
+                    payload=payload,
+                ),
+            )
         return entry.id
 
 

--- a/tests/unit/core/test_child_session_extending_event.py
+++ b/tests/unit/core/test_child_session_extending_event.py
@@ -1,0 +1,108 @@
+"""Fail-stop for ``ChildSessionExtendingEvent`` — locks down the
+substrate's "extensions can contribute atoms to child sessions" contract.
+
+The dedupe helper (``apply_child_session_contributions``) is the only
+substrate-side code path that touches handler return values; if its
+ordering or dedupe drifts, every atom that auto-attaches to children
+(``live_inspector`` today, more later) silently regresses. We test the
+helper directly rather than standing up a real session — handler return
+shapes are the contract surface.
+
+Coverage:
+- ``None`` returns are ignored.
+- A single handler's contribution is appended.
+- Two handlers' contributions are appended in registration order.
+- Re-contributing a ``(module, _)`` already on the base extensions list is
+  dropped (operator-override wins).
+- Re-contributing a module that an earlier handler already contributed is
+  dropped (first-contribution wins).
+- Malformed entries (non-tuple, wrong arity, non-string module, non-dict
+  config) are silently skipped — we don't want a misbehaving atom to wedge
+  spawn.
+"""
+
+from __future__ import annotations
+
+from agentm.core.runtime.session_factory import apply_child_session_contributions
+
+
+def test_no_handler_returns_leaves_base_unchanged() -> None:
+    base = [("m.a", {"x": 1})]
+    out = apply_child_session_contributions(base, [])
+    assert out == base
+    # Result is a fresh list — mutating it must not affect the caller's
+    # original (so the substrate can hand it to the factory without
+    # worrying about post-spawn mutation aliasing back).
+    out.append(("m.b", {}))
+    assert base == [("m.a", {"x": 1})]
+
+
+def test_none_returns_are_ignored() -> None:
+    out = apply_child_session_contributions([], [None, None])
+    assert out == []
+
+
+def test_single_handler_contribution_appended() -> None:
+    out = apply_child_session_contributions(
+        [], [[("contrib.extensions.live_inspector", {"role": "child"})]]
+    )
+    assert out == [("contrib.extensions.live_inspector", {"role": "child"})]
+
+
+def test_two_handlers_contributions_appended_in_order() -> None:
+    out = apply_child_session_contributions(
+        [],
+        [
+            [("m.first", {"k": 1})],
+            [("m.second", {"k": 2})],
+        ],
+    )
+    assert out == [
+        ("m.first", {"k": 1}),
+        ("m.second", {"k": 2}),
+    ]
+
+
+def test_module_already_on_base_extensions_wins_against_contribution() -> None:
+    """Operator override on the child config beats any handler contribution
+    for the same module — handlers can declare intent, but the operator's
+    explicit listing is authoritative.
+    """
+    base = [("m.x", {"operator_chosen_port": 9999})]
+    out = apply_child_session_contributions(
+        base, [[("m.x", {"port": 0})]]
+    )
+    assert out == [("m.x", {"operator_chosen_port": 9999})]
+
+
+def test_first_contribution_wins_across_handlers() -> None:
+    """If two handlers contribute the same module, the first one wins."""
+    out = apply_child_session_contributions(
+        [],
+        [
+            [("m.shared", {"from": "first"})],
+            [("m.shared", {"from": "second"})],
+        ],
+    )
+    assert out == [("m.shared", {"from": "first"})]
+
+
+def test_malformed_entries_are_skipped() -> None:
+    """A misbehaving handler must not wedge spawn."""
+    out = apply_child_session_contributions(
+        [],
+        [
+            "not iterable in a useful way at all",
+            [
+                "bare-string-not-a-tuple",
+                ("only-one-element",),
+                ("ok.module", {"role": "kept"}),
+                (123, {}),  # non-string module
+                ("bad.config", "not-a-dict"),
+            ],
+        ],
+    )
+    # Permissive: iterating "not iterable" produces single characters; each
+    # one is dropped by the tuple-arity check. Strings are iterable, so the
+    # outer ``list(ret)`` succeeds but every element fails downstream.
+    assert out == [("ok.module", {"role": "kept"})]

--- a/tests/unit/core/test_entry_appended_event.py
+++ b/tests/unit/core/test_entry_appended_event.py
@@ -1,0 +1,68 @@
+"""Fail-stop for ``EntryAppendedEvent`` — must fire exactly once per
+``SessionView.append_entry`` call and carry the persisted entry's id.
+
+Live-inspector / aegis-ui depend on this event firing on every entry write
+(assistant message, ``llmharness.audit_event``, plan submission, …). If the
+emit drifts off (e.g. a future refactor moves ``append_entry`` through a
+different code path or forgets to fire post-persist), the UI silently goes
+blind on entry-tree writes — exactly the failure mode this event was
+introduced to prevent. Lock it down at the contract level.
+"""
+
+from __future__ import annotations
+
+from agentm.core.abi import EventBus
+from agentm.core.abi.events import EntryAppendedEvent
+from agentm.core.runtime.session_helpers import SessionView
+from agentm.core.runtime.session_manager import SessionManager
+
+
+def _make_view(bus: EventBus) -> SessionView:
+    sm = SessionManager(cwd="/tmp", persist=False)
+    sm.new_session(id="sess-test")
+    return SessionView(
+        sm,
+        loop_config_getter=lambda: None,  # type: ignore[arg-type, return-value]
+        bus=bus,
+    )
+
+
+def test_entry_appended_event_fires_once_per_append() -> None:
+    bus = EventBus()
+    received: list[EntryAppendedEvent] = []
+
+    def handler(event: EntryAppendedEvent) -> None:
+        received.append(event)
+
+    bus.on(EntryAppendedEvent.CHANNEL, handler)
+
+    view = _make_view(bus)
+    entry_id = view.append_entry("custom_kind", {"hello": "world"})
+
+    assert len(received) == 1
+    event = received[0]
+    assert event.entry_id == entry_id
+    assert event.entry_type == "custom_kind"
+    assert event.parent_id is None  # first entry, no parent
+    assert event.payload == {"hello": "world"}
+    assert event.session_id == "sess-test"
+
+    # Second append: parent_id should chain to the first.
+    second_id = view.append_entry("custom_kind", {"k": 2})
+    assert len(received) == 2
+    assert received[1].entry_id == second_id
+    assert received[1].parent_id == entry_id
+
+
+def test_entry_appended_event_skipped_when_bus_absent() -> None:
+    """``SessionView`` constructed without a bus must not crash on append."""
+
+    sm = SessionManager(cwd="/tmp", persist=False)
+    sm.new_session(id="sess-nobus")
+    view = SessionView(
+        sm,
+        loop_config_getter=lambda: None,  # type: ignore[arg-type, return-value]
+        bus=None,
+    )
+    # No assertion needed beyond "doesn't raise".
+    view.append_entry("x", {})

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ dependencies = [
     { name = "python-frontmatter" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -72,6 +73,7 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.25.1" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["agent-env"]
 


### PR DESCRIPTION
## Summary

- Add `contrib/extensions/live_inspector`: a §11-clean atom that exposes a real-time WebSocket of session events (typed bus events + entries written to the session tree) so an external UI (aegis-ui llmharness-live, separate PR) can subscribe to a running agent and watch the main agent + every spawned extractor/auditor child in real time.
- Add `ChildSessionExtendingEvent` in `core.abi`: a typed bus channel that lets extensions contribute additional atoms to every spawned child session without monkey-patching `api.spawn_child_session`. live_inspector uses it to auto-attach itself to every child; the channel is generic enough for any cross-tree atom.
- Add `EntryAppendedEvent` in `core.abi`: fired after every `SessionView.append_entry`, so observers no longer have to poll `get_branch()` on every emit. live_inspector subscribes to it directly for the `entry` wire frame; existing callers without a bus are unaffected (param is `None`-defaulted).
- Add `contrib/scenarios/rca/manifest.harness.live.yaml`: copy of `harness.sync` + the inspector atom. Default `harness.sync` (used for dataset collection) stays untouched.

## Wire protocol (v1)

```
ws://<bind>:<port>/inspect?root=<root_session_id>

server → client (JSON-per-frame):
  hello { root_session_id, schema_version }
  session_started { session_id, parent_session_id, purpose, cwd, ts }
  session_ended   { session_id, ts }
  event           { session_id, ts, kind, payload }       # typed EventBus events
  entry           { session_id, ts, entry_type, payload } # AUDIT_GRAPH_OP, verdicts, messages, …
  backlog_done                                            # after initial replay
```

Bounded backlog (2048) for late-connecting clients; per-client outbound queue capped at 256 with newest-dropped on overflow. Backlog replay is atomic: connection enters `clients` set only after `backlog_done` is enqueued, so no live record can sneak in before it.

## Validation

- 285/285 tests pass (was 270 on main).
- Code review (independent agent) ran twice across three iterations: APPROVE-WITH-NITS after the WS/auto-attach round; all majors + nits resolved in the third commit.
- §11 contract validator clean on the atom.
- Mypy/ruff clean on touched files.

## Review trail

- Round 1 (e8c6061): TCP newline-JSON first cut + polling-based entry broadcast + monkey-wrap of `api.spawn_child_session`. Rejected: TCP can't reach browsers, polling is O(branch) per emit, monkey-wrap is fragile.
- Round 2 (87aca65): WS transport with `websockets>=12.0`, `EntryAppendedEvent` replaces polling, spawn-wrap auto-attaches inspector to every child.
- Round 3 (325d467, this commit): spawn-wrap replaced with `ChildSessionExtendingEvent`; backlog/replay race fixed via atomic prologue; backpressure test rewritten to actually exercise drop-newest; entry broadcast forwards `event.session_id`; `reader_task.gather` after cancel.

## Out of scope

- UI (separate PR in aegis-ui — will land `llmharness-live` sub-app consuming this WS).
- Auth / token handshake: documented as v2 in the module docstring.

## Test plan

- [x] Full unit suite green (285/285) on the worktree.
- [ ] End-to-end CLI trajectory: once aegis-ui's `llmharness-live` is in place, run `agentm --scenario rca:harness.live …` against a real RCA case and verify the UI receives the live stream across main agent + extractor + auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)