### PR TITLE
refactor(core/runtime): lazy-init GitBackedResourceWriter

### DIFF
--- a/src/agentm/core/runtime/resource_writer.py
+++ b/src/agentm/core/runtime/resource_writer.py
@@ -413,7 +413,12 @@ class GitBackedResourceWriter:
         return _manager()
 
     def current_version_for_path(self, path: str) -> str | None:
-        self._lazy_setup()
+        # Read-only by contract: must never trigger _lazy_setup() or touch
+        # disk. With no writes yet, there is no commit and therefore no
+        # version to report — return None. Observability calls this on
+        # every session entry; touching disk here would defeat lazy-init.
+        if not self._setup_done:
+            return None
         path_class = self.classify(path)
         if path_class != "managed" or self._advisory_mode:
             return None

--- a/src/agentm/core/runtime/resource_writer.py
+++ b/src/agentm/core/runtime/resource_writer.py
@@ -136,6 +136,11 @@ class GitBackedResourceWriter:
         auto_commit: bool = True,
         protected_branches: frozenset[str] = DEFAULT_PROTECTED_BRANCHES,
     ) -> None:
+        # Lazy-init contract: __init__ is a pure data-copy. No subprocess
+        # spawns, no stat calls, no mkdir. All disk probing and shadow-repo
+        # creation is deferred to `_lazy_setup()`, which fires on the first
+        # mutating operation (write/replace/delete/batch/restore). Scenarios
+        # that only read or classify pay zero filesystem cost.
         self._cwd = Path(cwd).resolve()
         self._session_id = session_id
         self._bus = bus
@@ -146,6 +151,20 @@ class GitBackedResourceWriter:
         self._advisory_mode = False
         self._warned_advisory = False
         self._initial_snapshot_needed = False
+        self._setup_done = False
+
+    def _lazy_setup(self) -> None:
+        """Perform the disk-touching init work on first mutation.
+
+        Idempotent: subsequent calls no-op via ``_setup_done``. Notes on
+        deferred semantics vs. eager init: the ``auto_commit=False`` /
+        ``git missing`` advisory-mode warnings now fire on the first write
+        attempt rather than at construction time. Same once-per-session
+        guarantee (``_warned_advisory``) still holds.
+        """
+        if self._setup_done:
+            return
+        self._setup_done = True
 
         git_bin = shutil.which("git")
         if git_bin is None:
@@ -155,7 +174,7 @@ class GitBackedResourceWriter:
         # auto_commit=False short-circuits everything below: we treat the
         # working tree as read-write-through and never call `git commit`.
         # Managed paths fall into the existing advisory-mode write-through.
-        if not auto_commit:
+        if not self._auto_commit:
             self._enter_advisory_mode("auto_commit disabled")
             return
 
@@ -207,6 +226,7 @@ class GitBackedResourceWriter:
         rationale: str,
         author: WriterAuthor = "agent",
     ) -> WriteResult:
+        await asyncio.to_thread(self._lazy_setup)
         path_class = self.classify(path)
         resolved = self._resolve_path(path)
         if path_class == "constitution":
@@ -254,6 +274,7 @@ class GitBackedResourceWriter:
         rationale: str,
         author: WriterAuthor = "agent",
     ) -> WriteResult:
+        await asyncio.to_thread(self._lazy_setup)
         path_class = self.classify(path)
         resolved = self._resolve_path(path)
         if path_class == "constitution":
@@ -319,6 +340,7 @@ class GitBackedResourceWriter:
         rationale: str,
         author: WriterAuthor = "agent",
     ) -> WriteResult:
+        await asyncio.to_thread(self._lazy_setup)
         path_class = self.classify(path)
         resolved = self._resolve_path(path)
         if path_class == "constitution":
@@ -391,6 +413,7 @@ class GitBackedResourceWriter:
         return _manager()
 
     def current_version_for_path(self, path: str) -> str | None:
+        self._lazy_setup()
         path_class = self.classify(path)
         if path_class != "managed" or self._advisory_mode:
             return None
@@ -413,6 +436,7 @@ class GitBackedResourceWriter:
         return sha or None
 
     def restore(self, path: Path, version: str) -> None:
+        self._lazy_setup()
         if self._advisory_mode or self.classify(str(path)) != "managed":
             raise NotImplementedError("git rollback requires a versioned ResourceWriter")
 
@@ -432,6 +456,8 @@ class GitBackedResourceWriter:
     ) -> None:
         if not pending:
             return
+
+        await asyncio.to_thread(self._lazy_setup)
 
         managed_ops: list[tuple[_PendingBatchOp, Path, str]] = []
         unmanaged_ops: list[tuple[_PendingBatchOp, Path]] = []

--- a/tests/unit/core/test_resource_writer_lazy_init.py
+++ b/tests/unit/core/test_resource_writer_lazy_init.py
@@ -1,0 +1,149 @@
+"""Lazy-init contract for ``GitBackedResourceWriter``.
+
+Locks down "cost-tied-to-usage": constructing a writer must not touch disk.
+Disk side effects (shadow ``.agentm/repo`` bare repo, initial snapshot,
+advisory-mode warning) only happen on the first mutating call.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentm.core.abi import EventBus
+from agentm.core.runtime.resource_writer import GitBackedResourceWriter
+
+
+@pytest.mark.asyncio
+async def test_no_writes_no_disk_footprint(tmp_path: Path) -> None:
+    """Constructing a writer against a cwd with no .git must not create any
+    files. Read-only / classify-only scenarios pay zero filesystem cost.
+    """
+    writer = GitBackedResourceWriter(
+        cwd=str(tmp_path),
+        session_id="lazy-session",
+        bus=EventBus(),
+        auto_commit=True,
+    )
+
+    # Inspection-only methods must not trigger setup.
+    writer.classify("skills/foo/SKILL.md")
+
+    assert not (tmp_path / ".agentm").exists()
+    assert not (tmp_path / ".agentm" / "repo").exists()
+    # Sanity: no leftover entries in cwd at all besides what pytest seeded.
+    assert list(tmp_path.iterdir()) == []
+    # Internal state should remain pristine — no probing happened yet.
+    assert writer._setup_done is False  # type: ignore[attr-defined]
+    assert writer._advisory_mode is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_first_write_creates_shadow_repo(tmp_path: Path) -> None:
+    """First write triggers lazy setup: shadow repo appears, content lands,
+    commit is recorded.
+    """
+    writer = GitBackedResourceWriter(
+        cwd=str(tmp_path),
+        session_id="first-write",
+        bus=EventBus(),
+        auto_commit=True,
+    )
+
+    assert not (tmp_path / ".agentm" / "repo").exists()
+
+    result = await writer.write(
+        "notes.txt",
+        b"hello\n",
+        rationale="first write",
+    )
+
+    shadow = tmp_path / ".agentm" / "repo"
+    assert shadow.is_dir(), "shadow bare repo should be created on first write"
+    assert (tmp_path / "notes.txt").read_bytes() == b"hello\n"
+    # notes.txt is unmanaged (no manifest globs match), so committed=False
+    # is the expected shape; what we care about is the shadow repo existing
+    # and the bytes being on disk.
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_lazy_setup_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_lazy_setup`` must be safe to call repeatedly: only the first call
+    runs the ``git init --bare`` subprocess.
+    """
+    real_run = subprocess.run
+    init_call_count = {"n": 0}
+
+    def counting_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "init":
+            init_call_count["n"] += 1
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "agentm.core.runtime.resource_writer.subprocess.run",
+        counting_run,
+    )
+
+    writer = GitBackedResourceWriter(
+        cwd=str(tmp_path),
+        session_id="idem-session",
+        bus=EventBus(),
+        auto_commit=True,
+    )
+
+    # Two writes in a row.
+    await writer.write("a.txt", b"a\n", rationale="one")
+    await writer.write("b.txt", b"b\n", rationale="two")
+
+    assert writer._setup_done is True  # type: ignore[attr-defined]
+    assert init_call_count["n"] == 1, (
+        f"expected exactly one `git init --bare`, saw {init_call_count['n']}"
+    )
+
+    # Direct repeat invocation must also no-op.
+    writer._lazy_setup()  # type: ignore[attr-defined]
+    writer._lazy_setup()  # type: ignore[attr-defined]
+    assert init_call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_advisory_warning_deferred_until_first_write(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With ``auto_commit=False``, the advisory-mode warning must fire on
+    first write — not at construction time — and must fire exactly once
+    across multiple writes.
+    """
+    writer = GitBackedResourceWriter(
+        cwd=str(tmp_path),
+        session_id="advisory-deferred",
+        bus=EventBus(),
+        auto_commit=False,
+    )
+
+    # No warning yet — construction must be silent under lazy init.
+    init_warnings = [
+        rec for rec in caplog.records
+        if "resource writer advisory mode enabled" in rec.message
+    ]
+    assert init_warnings == []
+    assert writer._advisory_mode is False  # type: ignore[attr-defined]
+
+    target = tmp_path / "x.txt"
+    await writer.write("x.txt", b"one\n", rationale="one")
+    await writer.write("x.txt", b"two\n", rationale="two")
+
+    warnings = [
+        rec for rec in caplog.records
+        if "resource writer advisory mode enabled" in rec.message
+    ]
+    assert len(warnings) == 1, f"expected one advisory warning, saw {len(warnings)}"
+    assert writer._advisory_mode is True  # type: ignore[attr-defined]
+    assert target.read_bytes() == b"two\n"

--- a/tests/unit/core/test_resource_writer_lazy_init.py
+++ b/tests/unit/core/test_resource_writer_lazy_init.py
@@ -30,6 +30,10 @@ async def test_no_writes_no_disk_footprint(tmp_path: Path) -> None:
 
     # Inspection-only methods must not trigger setup.
     writer.classify("skills/foo/SKILL.md")
+    # current_version_for_path is on the observability hot path — it fires
+    # on every session entry and must stay read-only.
+    assert writer.current_version_for_path("skills/foo/SKILL.md") is None
+    assert writer.current_version_for_path("anything.txt") is None
 
     assert not (tmp_path / ".agentm").exists()
     assert not (tmp_path / ".agentm" / "repo").exists()
@@ -147,3 +151,49 @@ async def test_advisory_warning_deferred_until_first_write(
     assert len(warnings) == 1, f"expected one advisory warning, saw {len(warnings)}"
     assert writer._advisory_mode is True  # type: ignore[attr-defined]
     assert target.read_bytes() == b"two\n"
+
+
+@pytest.mark.asyncio
+async def test_observability_hot_path_does_not_trigger_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate the observability fingerprint hook: it calls
+    ``current_version_for_path`` many times per session entry. None of
+    those calls may spawn a subprocess or create the shadow repo.
+
+    Regression guard — the unit canary alone is insufficient because real
+    sessions call this hook before any tool fires a write.
+    """
+    real_run = subprocess.run
+    subprocess_calls: list[list[str]] = []
+
+    def tracking_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(cmd, list):
+            subprocess_calls.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "agentm.core.runtime.resource_writer.subprocess.run",
+        tracking_run,
+    )
+
+    writer = GitBackedResourceWriter(
+        cwd=str(tmp_path),
+        session_id="observability-loop",
+        bus=EventBus(),
+        auto_commit=True,
+    )
+
+    # Observability iterates over every loaded builtin source file.
+    fake_atom_paths = [f"src/agentm/extensions/builtin/atom_{i}.py" for i in range(50)]
+    for path in fake_atom_paths:
+        result = writer.current_version_for_path(path)
+        assert result is None
+
+    assert subprocess_calls == [], (
+        f"current_version_for_path must not spawn subprocesses pre-write; "
+        f"saw {len(subprocess_calls)} call(s): {subprocess_calls[:3]!r}"
+    )
+    assert not (tmp_path / ".agentm").exists()
+    assert writer._setup_done is False  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Make `GitBackedResourceWriter` truly lazy: no `git init --bare`, no `.agentm/repo/` shadow directory, no subprocess calls, no protected-branch check until a real write request lands.

Before this change, even read-only / query-only scenarios (RCA harness, chat) dropped a permanent `.agentm/repo/` bare git repo in cwd because the writer's `__init__` eagerly probed git state and the observability atom called `current_version_for_path()` on every session entry — both triggering shadow-repo creation despite zero writes.

After this change:
- `__init__` is a pure data copy (no I/O, no subprocess, no advisory warning).
- `_lazy_setup()` runs idempotently on first mutating call (`write`, `replace`, `delete`, `_apply_batch`, `restore`).
- `current_version_for_path()` returns `None` short-circuit when `_setup_done is False` (no commits yet → no version to report) — no longer triggers setup.
- `read()` and `classify()` remain pure inspection paths (unchanged).
- Public API surface unchanged (`auto_commit: bool` stays; default still True).
- Existing write scenarios (sub_agent, format_fix, atom_reloader) behave identically — init just runs on the first write instead of at construction.

## Why

Substrate cost should track usage. Forcing query-only scenarios to either build throwaway git repos or remember `--no-auto-commit` was a leaky abstraction. Lazy init makes the default cost-free for non-writing sessions while preserving every behavior for writing sessions.

## Validation

- Full suite: **290/290 green** (was 289; +1 for the lazy-init test file).
- New `tests/unit/core/test_resource_writer_lazy_init.py`:
  - `test_no_writes_no_disk_footprint` — construction + 2× `current_version_for_path` lookups leave no `.agentm/repo`
  - `test_first_write_creates_shadow_repo` — first `write()` triggers init
  - `test_lazy_setup_is_idempotent` — repeat writes don't re-init
  - `test_advisory_warning_deferred_until_first_write` — `auto_commit=False` warning fires on first write, not construction
  - `test_observability_hot_path_does_not_trigger_setup` — 50× `current_version_for_path` in a loop with `subprocess.run` monkey-patched: zero subprocess calls, no shadow repo
- Real E2E smoke: `agentm --cwd /tmp/lazy-smoke-final "say hello"` → tail of session shows `.agentm/{catalog, observability}` only, no `.agentm/repo`. ✓

## Out of scope (acknowledged follow-ups)

- `.agentm/observability/` and `.agentm/catalog/` are still created unconditionally by their respective atoms. If the goal escalates to "no-op session leaves cwd byte-identical," those atoms need similar lazy treatment. Not bundled here — different atoms, different design call.

## Test plan
- [x] Unit + integration tests pass
- [x] Real CLI smoke confirms no shadow repo
- [x] Mypy + ruff clean on touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)