### PR TITLE
docs: clarify nested-session acceptance wording (output- not source-identical)

### DIFF
--- a/.claude/designs/nested-session-task.md
+++ b/.claude/designs/nested-session-task.md
@@ -175,7 +175,8 @@ interactive driver. The shared seam it already uses is the right one:
   sibling `child_collect`, never `core.runtime`.
 - No duplication: `flatten_assistant_blocks`, `serialize_block`, and
   terminal-arg scraping exist in exactly one place (`llmharness.child_collect`).
-- Behaviour: llmharness sidecar `ReplayRecord` shape and the extractor
-  directive are byte-identical; `sub_agent` is untouched.
+- Behaviour: the relocated scrapers' output is byte-identical (only source
+  formatting moved), so the llmharness sidecar `ReplayRecord` block shape and
+  the extractor directive are unchanged; `sub_agent` is untouched.
 - Core stays minimal: zero speculative generic child-task modules in the
   core tree; the seam (`spawn_child_session`) is the only core surface.


### PR DESCRIPTION
Boundary-review nit follow-up to #171 (0 block / 0 major / 2 nit).

The §6 acceptance bullet in `nested-session-task.md` claimed the relocated
scrapers were "byte-identical". A ruff signature reflow on
`terminal_tool_arguments` means the *source* changed while the *output*
contract (replay-sidecar block shape, extractor directive) is unchanged.
Reword to say so, so a future reader diffing source isn't misled.

Docs-only; no code change. The other review nit (adapter `flatten_assistant_blocks`
re-export chain) is left as-is — it is the pinned cross-repo API surface for
rca-autorl and changing it needs downstream confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)