### PR TITLE
operations_agent_env: opt-in cwd↔sandbox workspace sync (sync_cwd)

### DIFF
--- a/contrib/extensions/operations_agent_env.py
+++ b/contrib/extensions/operations_agent_env.py
@@ -42,6 +42,15 @@ required; if both are set, ``image`` wins (managed pool path):
 - ``timeout``       — Per-step timeout seconds; ``None`` means no timeout
 - ``idle_timeout_seconds`` — Sandbox idle TTL on the gateway (legacy path only;
                       ManagedSession handles idle policy server-side).
+- ``sync_cwd``      — When true (default false), seed the sandbox ``work_dir``
+                      from the host cwd's git HEAD before the run and sync the
+                      agent's diff back to the host cwd on shutdown. Lets an
+                      upstream dispatcher (e.g. workbuddy) hand the agent a real
+                      repo to edit and recover the diff for commit/push *without*
+                      putting any VCS credentials inside the sandbox. The host
+                      cwd must be a git work tree.
+- ``host_workspace`` — Host directory to seed from / sync back to (default:
+                      ``os.getcwd()``, which is the dispatcher-provided ``--cwd``).
 
 §11 single-file contract: only stdlib + ``agentm.core.abi.*`` +
 ``agentm.extensions.*`` + ``arl`` (optional 3rd-party). No atom-to-atom imports.
@@ -50,7 +59,12 @@ required; if both are set, ``image`` wins (managed pool path):
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import os
+import subprocess
+import sys
+import urllib.request
 from collections.abc import Callable
 from typing import Any
 
@@ -88,6 +102,8 @@ MANIFEST = ExtensionManifest(
             "work_dir": {"type": "string"},
             "timeout": {"type": ["number", "null"]},
             "idle_timeout_seconds": {"type": ["integer", "null"]},
+            "sync_cwd": {"type": "boolean"},
+            "host_workspace": {"type": "string"},
         },
         "additionalProperties": False,
     },
@@ -575,6 +591,178 @@ def _sh_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
+# --- cwd↔sandbox workspace sync (opt-in via ``sync_cwd``) -------------------
+#
+# Closes the dispatcher gap where an agent edits the sandbox ``work_dir`` but
+# the dispatcher publishes from a host working tree the pod never touches. The
+# pod stays credential-free: the host clones (with its creds), we seed the pod
+# from the host's committed tree, and we apply the agent's diff back to the host
+# so the dispatcher's own commit/push path ships it.
+_SEED_ARCHIVE_NAME = ".wb_seed.tar.gz"
+_BASELINE_TAG = "wb-baseline"
+_SYNC_GIT_IDENT = ("-c", "user.email=workbuddy@local", "-c", "user.name=workbuddy")
+
+
+def _exclude_host_paths(host_dir: str, patterns: tuple[str, ...]) -> None:
+    """Append ``patterns`` to the host work tree's ``.git/info/exclude``.
+
+    Local-only ignore: never committed, never touches the repo's tracked
+    ``.gitignore``. Best-effort — failures just mean the dispatcher might
+    commit a stray file; not worth aborting the run.
+    """
+    located = _run_host_git(host_dir, "rev-parse", "--git-path", "info/exclude")
+    if located.returncode != 0:
+        return
+    exclude_path = located.stdout.decode().strip()
+    if not exclude_path:
+        return
+    if not os.path.isabs(exclude_path):
+        exclude_path = os.path.join(host_dir, exclude_path)
+    try:
+        existing = ""
+        if os.path.exists(exclude_path):
+            with open(exclude_path, encoding="utf-8") as fh:
+                existing = fh.read()
+        missing = [p for p in patterns if p not in existing]
+        if not missing:
+            return
+        os.makedirs(os.path.dirname(exclude_path), exist_ok=True)
+        with open(exclude_path, "a", encoding="utf-8") as fh:
+            if existing and not existing.endswith("\n"):
+                fh.write("\n")
+            fh.write("# added by operations_agent_env sync_cwd\n")
+            fh.write("\n".join(missing) + "\n")
+    except OSError as exc:
+        print(f"WARNING: [agent_env_sync] could not update git exclude: {exc}", file=sys.stderr)
+
+
+def _run_host_git(host_dir: str, *args: str, stdin: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(  # noqa: S603,S607
+        ["git", "-C", host_dir, *args],
+        input=stdin,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _pod_exec(session: Any, cmd: str, work_dir: str) -> tuple[str, str, int]:
+    """Run ``bash -lc cmd`` in the sandbox; return (stdout, stderr, exit_code)."""
+    resp = session.execute([{"name": "wb_workspace_sync", "command": ["bash", "-lc", cmd], "work_dir": work_dir}])
+    if not getattr(resp, "results", None):
+        return "", "agent-env returned no results", 1
+    out = resp.results[0].output
+    return out.stdout, out.stderr, out.exit_code
+
+
+def _upload_to_pod(gateway_url: str, session_id: str, rel_path: str, payload: bytes) -> None:
+    """Upload bytes to ``rel_path`` (relative to work_dir) via the gateway."""
+    body = json.dumps(
+        {"path": rel_path, "content": base64.b64encode(payload).decode("ascii"), "encoding": "base64"}
+    ).encode("utf-8")
+    url = gateway_url.rstrip("/") + f"/v1/sessions/{session_id}/files"
+    req = urllib.request.Request(  # noqa: S310
+        url, data=body, method="POST", headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:  # noqa: S310
+        resp.read()
+
+
+def _seed_sandbox_from_host(session: Any, gateway_url: str, host_dir: str, work_dir: str) -> None:
+    """Seed the sandbox ``work_dir`` from ``host_dir``'s git HEAD and baseline it.
+
+    Tracked files only (``git archive`` respects ``.gitignore``); the sandbox
+    gets the code, never the remote or credentials. A baseline commit inside the
+    pod gives :func:`_sync_sandbox_to_host` a precise diff target.
+    """
+    inside = _run_host_git(host_dir, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0:
+        raise RuntimeError(
+            f"operations_agent_env: sync_cwd requires a git work tree at {host_dir!r}"
+        )
+    archive = _run_host_git(host_dir, "archive", "--format=tar.gz", "HEAD")
+    if archive.returncode != 0:
+        raise RuntimeError(
+            "operations_agent_env: sync_cwd seed failed (git archive HEAD): "
+            + archive.stderr.decode(errors="replace").strip()
+        )
+    session_id = getattr(session, "session_id", None)
+    if not session_id:
+        raise RuntimeError("operations_agent_env: sync_cwd seed failed: sandbox has no session id")
+    _upload_to_pod(gateway_url, session_id, _SEED_ARCHIVE_NAME, archive.stdout)
+    ident = " ".join(_SYNC_GIT_IDENT)
+    # Baseline as a TAG, not just HEAD: the agent is free to `git commit` inside
+    # the sandbox (and often does), which would move HEAD and make a
+    # HEAD-relative diff empty. Diffing against the immovable tag captures the
+    # agent's changes whether committed in-pod or left in the work tree.
+    seed_cmd = (
+        f"set -e; cd {work_dir}; "
+        f"tar -xzf {_SEED_ARCHIVE_NAME}; rm -f {_SEED_ARCHIVE_NAME}; "
+        "git init -q; "
+        f"git {ident} add -A; "
+        f"git {ident} commit -q -m wb-baseline --allow-empty; "
+        f"git tag -f {_BASELINE_TAG}"
+    )
+    out, err, code = _pod_exec(session, seed_cmd, work_dir)
+    if code != 0:
+        raise RuntimeError(
+            f"operations_agent_env: sync_cwd seed failed in sandbox (exit {code}): {err or out}"
+        )
+    # Keep AgentM's own host-side runtime droppings (``.agentm/`` observability,
+    # catalog) and our transient seed archive out of the dispatcher's commit:
+    # they are written into the host cwd but are not part of the repo. A local
+    # ``.git/info/exclude`` entry is non-invasive (never committed, never
+    # touches the repo's tracked ``.gitignore``).
+    _exclude_host_paths(host_dir, (".agentm/", _SEED_ARCHIVE_NAME))
+    print(
+        f"INFO: [agent_env_sync] seeded sandbox {work_dir} from {host_dir} ({len(archive.stdout)} bytes)",
+        file=sys.stderr,
+    )
+
+
+def _sync_sandbox_to_host(session: Any, host_dir: str, work_dir: str) -> None:
+    """Apply the agent's sandbox diff (vs the seed baseline) back onto ``host_dir``.
+
+    Best-effort and idempotent: an empty diff (e.g. a review agent that changed
+    nothing) is a no-op. Runs at shutdown, before the sandbox is deleted, so the
+    dispatcher's subsequent commit/push sees the changes in its work tree.
+    """
+    ident = " ".join(_SYNC_GIT_IDENT)
+    diff_cmd = (
+        f"cd {work_dir} 2>/dev/null || exit 0; "
+        "git rev-parse --git-dir >/dev/null 2>&1 || exit 0; "
+        f"git {ident} add -A; "
+        # Diff against the immovable baseline tag, not HEAD: the agent may have
+        # committed inside the sandbox, which would move HEAD and hide its work.
+        f"git diff --cached --binary {_BASELINE_TAG} | base64 -w0"
+    )
+    out, err, code = _pod_exec(session, diff_cmd, work_dir)
+    if code != 0:
+        print(f"ERROR: [agent_env_sync] sandbox diff failed (exit {code}): {err}", file=sys.stderr)
+        return
+    encoded = out.strip()
+    if not encoded:
+        return
+    try:
+        patch = base64.b64decode(encoded)
+    except ValueError as exc:  # binascii.Error is a ValueError subclass
+        print(f"ERROR: [agent_env_sync] could not decode sandbox patch: {exc}", file=sys.stderr)
+        return
+    if not patch.strip():
+        return
+    applied = _run_host_git(host_dir, "apply", "--binary", "--whitespace=nowarn", stdin=patch)
+    if applied.returncode != 0:
+        print(
+            "ERROR: [agent_env_sync] git apply failed on host work tree "
+            f"{host_dir}: {applied.stderr.decode(errors='replace').strip()}",
+            file=sys.stderr,
+        )
+        return
+    print(
+        f"INFO: [agent_env_sync] applied {len(patch)} bytes of sandbox changes to {host_dir}",
+        file=sys.stderr,
+    )
+
+
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     # Deferred import keeps the SDK truly optional — atoms that never run
     # under agent-env shouldn't fail to load just because ``arl`` is absent.
@@ -606,6 +794,9 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     timeout_value: float | None = float(timeout) if isinstance(timeout, (int, float)) else None
     idle = config.get("idle_timeout_seconds")
     idle_value: int | None = int(idle) if isinstance(idle, int) else None
+    sync_cwd = bool(config.get("sync_cwd"))
+    host_workspace = config.get("host_workspace")
+    host_dir = host_workspace if isinstance(host_workspace, str) and host_workspace else os.getcwd()
 
     session: Any
     if image:
@@ -637,6 +828,12 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
         )
     session.create_sandbox()
 
+    # Seed the sandbox from the host work tree before any tool runs. A seed
+    # failure is fatal: continuing would let the agent edit an empty workspace
+    # and silently produce an empty diff/PR.
+    if sync_cwd:
+        _seed_sandbox_from_host(session, gateway_url, host_dir, work_dir)
+
     api.register_operations(
         file=_AgentEnvFileOperations(session, default_work_dir=work_dir),
         bash=_AgentEnvBashOperations(
@@ -653,6 +850,13 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:
     )
 
     def _on_shutdown(_event: SessionShutdownEvent) -> None:
+        # Recover the agent's diff into the host work tree BEFORE tearing the
+        # sandbox down, so the dispatcher's commit/push step sees the changes.
+        if sync_cwd:
+            try:
+                _sync_sandbox_to_host(session, host_dir, work_dir)
+            except Exception as exc:  # noqa: BLE001
+                print(f"ERROR: [agent_env_sync] sync-back raised: {exc}", file=sys.stderr)
         try:
             session.delete_sandbox()
         except Exception:  # noqa: BLE001

--- a/contrib/scenarios/agent_env_repo/manifest.yaml
+++ b/contrib/scenarios/agent_env_repo/manifest.yaml
@@ -1,0 +1,38 @@
+name: agent_env_repo
+description: |
+  agent_env + host-repo workspace sync. Identical to the ``agent_env`` scenario
+  (sandboxed bash + file I/O against an ARL pod's /workspace), but with
+  ``operations_agent_env``'s ``sync_cwd`` enabled: before the run the sandbox is
+  seeded from the host cwd's git HEAD, and on shutdown the agent's diff is applied
+  back onto the host cwd.
+
+  Intended for dispatchers (e.g. workbuddy) that:
+    1. clone a repo into a host work tree with their own credentials,
+    2. hand AgentM that work tree as ``--cwd``,
+    3. want the agent's in-pod edits back in the work tree so they can
+       commit/push them — without any VCS credentials ever entering the pod.
+
+  Everything ``agent_env`` documents applies (gateway URL, image/pool_ref,
+  ``uv sync --extra agent-env``). The only delta is ``sync_cwd: true``. For
+  non-repo / RL / trajectory-collection uses, prefer the plain ``agent_env``
+  scenario — seeding does nothing useful there and requires a git work tree.
+
+extensions:
+  # Sandbox-backed Operations bundle (bash + file I/O against /workspace),
+  # with bidirectional host-repo sync turned on.
+  - module: _agentm_contrib__operations_agent_env
+    config:
+      # image / experiment_id / gateway_url / namespace fall back to env vars
+      # (AGENTM_AGENT_ENV_*) exactly as in the agent_env scenario.
+      work_dir: /workspace
+      # Seed the pod from the host cwd's git HEAD before the run, and apply the
+      # agent's diff back to the host cwd on shutdown. host_workspace defaults to
+      # the AgentM process cwd (the dispatcher-provided --cwd).
+      sync_cwd: true
+
+  # File I/O and shell tools, identical to agent_env. The Operations bundle
+  # above routes these to the sandbox.
+  - module: agentm.extensions.builtin.tool_read
+  - module: agentm.extensions.builtin.tool_edit
+  - module: agentm.extensions.builtin.tool_write
+  - module: agentm.extensions.builtin.tool_bash

--- a/tests/unit/contrib/test_operations_agent_env_sync.py
+++ b/tests/unit/contrib/test_operations_agent_env_sync.py
@@ -1,0 +1,175 @@
+"""Unit tests for ``operations_agent_env``'s opt-in cwd↔sandbox workspace sync.
+
+These pin the host-side half of the contract that lets a dispatcher (workbuddy)
+hand the agent a real repo and recover its diff WITHOUT putting VCS credentials
+in the sandbox:
+
+  - ``_seed_sandbox_from_host``: host git HEAD → tar.gz → upload → pod baseline.
+  - ``_sync_sandbox_to_host``: pod ``git diff --binary`` (base64) → ``git apply``
+    onto the host work tree; empty diff is a no-op.
+
+The ARL session and the gateway upload are faked; the real ``git archive`` /
+``git apply`` / base64 plumbing runs against throwaway repos.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "contrib"
+    / "extensions"
+    / "operations_agent_env.py"
+)
+
+
+def _load_atom():
+    spec = importlib.util.spec_from_file_location("_oae_under_test", _MOD_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+oae = _load_atom()
+
+
+class _Output:
+    def __init__(self, stdout: str = "", stderr: str = "", exit_code: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+class _Result:
+    def __init__(self, output: _Output) -> None:
+        self.output = output
+
+
+class _Response:
+    def __init__(self, results: list[_Result]) -> None:
+        self.results = results
+
+
+class _FakeSession:
+    """Records execute() calls; returns a scripted Output per call."""
+
+    def __init__(self, session_id: str = "sess-1", outputs=None) -> None:
+        self.session_id = session_id
+        self.calls: list[str] = []
+        self._outputs = list(outputs or [])
+
+    def execute(self, steps):
+        cmd = steps[0]["command"]
+        self.calls.append(" ".join(cmd))
+        out = self._outputs.pop(0) if self._outputs else _Output()
+        return _Response([_Result(out)])
+
+
+def _git(repo: Path, *args: str, stdin: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], input=stdin, capture_output=True, check=True
+    )
+
+
+def _init_repo(path: Path, files: dict[str, str]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t")
+    _git(path, "config", "user.name", "t")
+    for rel, content in files.items():
+        (path / rel).write_text(content)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "base")
+
+
+def _pod_patch_from_changes(tmp: Path, base: dict[str, str], changes: dict[str, str | None]) -> bytes:
+    """Build a realistic ``git diff --cached --binary`` patch vs an identical base.
+
+    ``changes`` maps path -> new content, or ``None`` to delete.
+    """
+    sim = tmp / "podsim"
+    _init_repo(sim, base)
+    for rel, content in changes.items():
+        if content is None:
+            (sim / rel).unlink()
+        else:
+            (sim / rel).write_text(content)
+    _git(sim, "add", "-A")
+    out = subprocess.run(
+        ["git", "-C", str(sim), "diff", "--cached", "--binary"],
+        capture_output=True, check=True,
+    )
+    return out.stdout
+
+
+def test_seed_uploads_archive_and_baselines(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    _init_repo(host, {"a.txt": "hello\n"})
+
+    uploaded: dict[str, bytes] = {}
+
+    def _fake_upload(gateway_url, session_id, rel_path, payload):
+        uploaded["url"] = gateway_url
+        uploaded["sid"] = session_id
+        uploaded["path"] = rel_path
+        uploaded["payload"] = payload
+
+    monkeypatch.setattr(oae, "_upload_to_pod", _fake_upload)
+
+    sess = _FakeSession(outputs=[_Output(exit_code=0)])
+    oae._seed_sandbox_from_host(sess, "http://gw:8080", str(host), "/workspace")
+
+    # Archive was produced (non-empty gzip) and uploaded to the seed path.
+    assert uploaded["path"] == oae._SEED_ARCHIVE_NAME
+    assert uploaded["payload"][:2] == b"\x1f\x8b"  # gzip magic
+    assert uploaded["sid"] == "sess-1"
+    # The pod baseline command was issued and tags the baseline.
+    assert any("git init" in c and "wb-baseline" in c and "tag" in c for c in sess.calls)
+    # AgentM's host-side droppings are excluded from the dispatcher's commit.
+    exclude = (host / ".git" / "info" / "exclude").read_text()
+    assert ".agentm/" in exclude
+
+
+def test_seed_requires_git_worktree(tmp_path):
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+    with pytest.raises(RuntimeError, match="git work tree"):
+        oae._seed_sandbox_from_host(_FakeSession(), "http://gw", str(not_a_repo), "/workspace")
+
+
+def test_sync_back_applies_pod_diff(tmp_path):
+    base = {"a.txt": "hello\n"}
+    host = tmp_path / "host"
+    _init_repo(host, base)
+
+    # Pod produced: modify a.txt and add b.txt.
+    patch = _pod_patch_from_changes(tmp_path, base, {"a.txt": "hello world\n", "b.txt": "new\n"})
+    encoded = base64.b64encode(patch).decode("ascii")
+    sess = _FakeSession(outputs=[_Output(stdout=encoded)])
+
+    oae._sync_sandbox_to_host(sess, str(host), "/workspace")
+
+    assert (host / "a.txt").read_text() == "hello world\n"
+    assert (host / "b.txt").read_text() == "new\n"
+
+
+def test_sync_back_empty_diff_is_noop(tmp_path):
+    host = tmp_path / "host"
+    _init_repo(host, {"a.txt": "hello\n"})
+    sess = _FakeSession(outputs=[_Output(stdout="")])  # review agent: no changes
+
+    oae._sync_sandbox_to_host(sess, str(host), "/workspace")
+
+    assert (host / "a.txt").read_text() == "hello\n"
+    # working tree clean (nothing applied)
+    status = subprocess.run(
+        ["git", "-C", str(host), "status", "--porcelain"], capture_output=True, text=True, check=True
+    )
+    assert status.stdout.strip() == ""


### PR DESCRIPTION
## What

Adds an **opt-in** `sync_cwd` mode to `operations_agent_env` (+ a new
`agent_env_repo` scenario) that seeds the sandbox `/workspace` from the host
cwd's git HEAD before a run and applies the agent's diff back onto the host cwd
on shutdown.

## Why

A dispatcher (workbuddy) clones a repo into a host work tree and hands it to
AgentM as `--cwd`, but `operations_agent_env` routes the agent's edits to the
**pod's** `/workspace`. The dispatcher then publishes from the worktree the pod
never touched → empty PRs. This closes that gap **without putting any VCS
credentials in the sandbox**: host clones → atom shuttles the diff → dispatcher
commits/pushes.

## How

- **Seed** (`install`): `git archive HEAD` → upload via gateway `/v1/sessions/{id}/files` → `git init/commit` + tag an immovable `wb-baseline` in-pod.
- **Sync back** (`SessionShutdownEvent`, before `delete_sandbox`): `git diff --cached --binary wb-baseline | base64` in-pod → `git apply` onto the host cwd. Diffing the **tag** (not HEAD) captures the agent's work even when it commits in-pod.
- AgentM's host-side `.agentm/` droppings are kept out of the dispatcher's commit via a local `.git/info/exclude` entry.
- General `agent_env` scenario is **unchanged**; `sync_cwd` defaults off.

## Tests

- `tests/unit/contrib/test_operations_agent_env_sync.py`: seed (archive→upload→baseline+tag, exclude written), seed-requires-git-worktree, sync-back apply round-trip, empty-diff no-op. (28 contrib/extensions/scenarios unit tests green.)
- **Live on kind**: a workbuddy serve loop dispatched an agentm dev agent that created `MARKER.md` *inside the pod*; the PR's sole diff was `MARKER.md` ("synced-from-pod") with no `.agentm` noise; review flipped the issue to done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)