### PR TITLE
feat(session-inbox): tag system-reminder wrapper with source attribute

### DIFF
--- a/src/agentm/core/runtime/session_inbox.py
+++ b/src/agentm/core/runtime/session_inbox.py
@@ -132,17 +132,25 @@ def render_item(item: InboxItem) -> AgentMessage:
     """Render an :class:`InboxItem` into an :class:`AgentMessage`.
 
     Handles ``source="user"`` → :class:`UserMessage` (step 1),
-    ``source="background"`` → a ``<system-reminder>``-wrapped
-    :class:`UserMessage` (step 3: auto-backgrounding completion / ticker
-    status), ``source="monitor"`` → the same ``<system-reminder>``-wrapped
-    :class:`UserMessage` shape (step 4: agent-defined wakeups + channel
-    subscriptions), and ``source="subagent"`` → the same shape (step 5:
-    child-task findings posted by ``sub_agent._finalize_state`` once it
-    rides the inbox instead of its bespoke completed-unread floor). All four
+    ``source="background"`` → a
+    ``<system-reminder source="background">``-wrapped :class:`UserMessage`
+    (step 3: auto-backgrounding completion / ticker status),
+    ``source="monitor"`` → ``<system-reminder source="monitor">`` (step 4:
+    agent-defined wakeups + channel subscriptions), and
+    ``source="subagent"`` → ``<system-reminder source="subagent">`` (step 5:
+    child-task findings posted by ``sub_agent._finalize_state``). All four
     land as new ``user`` messages so the prefix stays stable and the
     KV/prefix cache survives (no synthetic ``tool_result``, which would need
-    a live ``tool_call_id`` the inbox does not carry at drain time). Any
-    other source raises so a mis-routed item fails loudly rather than
+    a live ``tool_call_id`` the inbox does not carry at drain time).
+
+    The ``source="..."`` attribute on the wrapper tag exists so the agent
+    can distinguish producer classes textually — first surfaced as an E2E
+    finding (#176 post-merge validation): without the tag the agent has to
+    guess from payload shape whether a reminder is a bg completion vs a
+    monitor wakeup vs a sub_agent finding. Keep this attribute stable —
+    downstream prompts / extractors may key off it.
+
+    Any other source raises so a mis-routed item fails loudly rather than
     landing wrong.
     """
 
@@ -156,7 +164,7 @@ def render_item(item: InboxItem) -> AgentMessage:
 
     if item.source in ("background", "monitor", "subagent"):
         text = item.payload if isinstance(item.payload, str) else str(item.payload)
-        wrapped = f"<system-reminder>\n{text}\n</system-reminder>"
+        wrapped = f'<system-reminder source="{item.source}">\n{text}\n</system-reminder>'
         return UserMessage(
             role="user",
             content=[TextContent(type="text", text=wrapped)],

--- a/tests/integration/test_sub_agent_lifecycle.py
+++ b/tests/integration/test_sub_agent_lifecycle.py
@@ -321,7 +321,8 @@ async def test_subagent_finding_arrives_via_inbox_after_next_turn_boundary(
         if getattr(block, "type", None) == "text"
     ]
     assert any(
-        "<subagent_result" in text and "<system-reminder>" in text
+        "<subagent_result" in text
+        and '<system-reminder source="subagent">' in text
         for text in user_texts
     ), f"expected an inbox-drained subagent finding; got user_texts={user_texts!r}"
 

--- a/tests/unit/core/test_session_inbox.py
+++ b/tests/unit/core/test_session_inbox.py
@@ -96,35 +96,58 @@ def test_render_user_item_to_user_message() -> None:
 def test_render_background_item_to_system_reminder() -> None:
     # Step 3: background completion / ticker → a <system-reminder>-wrapped
     # user message (append-only, cache-stable; no synthetic tool_result).
+    # The source attribute on the wrapper lets the agent distinguish bg from
+    # monitor / subagent textually (#176 post-merge polish).
     msg = render_item(InboxItem(source="background", payload="task 7 finished"))
     assert msg.role == "user"
     assert msg.content[0].type == "text"
-    assert "<system-reminder>" in msg.content[0].text
+    assert '<system-reminder source="background">' in msg.content[0].text
     assert "task 7 finished" in msg.content[0].text
 
 
 def test_render_monitor_item_to_system_reminder() -> None:
-    # Step 4: monitor wakeups / channel fires use the same
-    # <system-reminder>-wrapped UserMessage shape as background — same
-    # cache-stability reasons.
+    # Step 4: monitor wakeups / channel fires use the same wrapper shape as
+    # background but with a different source attribute.
     msg = render_item(InboxItem(source="monitor", payload="wakeup fired"))
     assert msg.role == "user"
     assert msg.content[0].type == "text"
-    assert "<system-reminder>" in msg.content[0].text
+    assert '<system-reminder source="monitor">' in msg.content[0].text
     assert "wakeup fired" in msg.content[0].text
 
 
 def test_render_subagent_item_to_system_reminder() -> None:
-    # Step 5b: sub_agent findings posted via api.post_inbox(source="subagent")
-    # use the same <system-reminder>-wrapped UserMessage shape as background /
-    # monitor — same cache-stability reasons.
+    # Step 5b: sub_agent findings posted via api.post_inbox(source="subagent").
     msg = render_item(
         InboxItem(source="subagent", payload="<subagent_result task_id=t1 />")
     )
     assert msg.role == "user"
     assert msg.content[0].type == "text"
-    assert "<system-reminder>" in msg.content[0].text
+    assert '<system-reminder source="subagent">' in msg.content[0].text
     assert "<subagent_result" in msg.content[0].text
+
+
+def test_render_source_tag_is_per_source_distinct() -> None:
+    """Fail-stop: the ``source="..."`` attribute on the wrapper MUST distinguish
+    background / monitor / subagent — that is the whole reason the attribute
+    exists. A silent regression to a single un-attributed wrapper (or to the
+    same attribute across all three) would re-introduce the producer-ambiguity
+    that #176 post-merge E2E surfaced — the agent could no longer route a
+    reminder textually back to its producer.
+    """
+
+    tags = {
+        source: render_item(InboxItem(source=source, payload="x")).content[0].text
+        for source in ("background", "monitor", "subagent")
+    }
+    # Each render carries its own source tag verbatim.
+    for source, text in tags.items():
+        assert f'<system-reminder source="{source}">' in text, (
+            f"{source}: tag missing or wrong — got {text!r}"
+        )
+    # And the three are mutually distinguishable (no shared prefix substring
+    # that would let the agent confuse them).
+    rendered_tags = {text.split("\n", 1)[0] for text in tags.values()}
+    assert len(rendered_tags) == 3, f"sources collapsed to {rendered_tags!r}"
 
 
 def test_render_unknown_source_raises() -> None:

--- a/tests/unit/extensions/test_monitor.py
+++ b/tests/unit/extensions/test_monitor.py
@@ -474,15 +474,16 @@ async def test_install_propagates_event_summary_max_chars() -> None:
 
 
 def test_render_item_monitor_source_renders() -> None:
-    """``source="monitor"`` lands as a <system-reminder>-wrapped user message
-    (cache-stable, same shape as ``background``)."""
+    """``source="monitor"`` lands as a ``<system-reminder source="monitor">``-
+    wrapped user message (cache-stable, same shape as ``background`` /
+    ``subagent`` but distinguished by the wrapper's source attribute)."""
 
     msg = render_item(
         InboxItem(source="monitor", payload="wakeup fired", dedup_key="k")
     )
     assert msg.role == "user"
     assert msg.content[0].type == "text"
-    assert "<system-reminder>" in msg.content[0].text
+    assert '<system-reminder source="monitor">' in msg.content[0].text
     assert "wakeup fired" in msg.content[0].text
 
 


### PR DESCRIPTION
## What

`SessionInbox.render_item` now stamps the wrapper tag with the producer source:

```
<system-reminder source="background">…</system-reminder>
<system-reminder source="monitor">…</system-reminder>
<system-reminder source="subagent">…</system-reminder>
```

## Why

Surfaced during #176 post-merge E2E validation. The renderer wrapped all three producers in an identical, un-attributed `<system-reminder>` block, so the agent had to guess the producer class from payload shape. In the run I did against doubao + deepseek the agent correctly attributed each reminder anyway — but only because the payloads happened to be visually distinct. As soon as a producer's payload shape collides with another's (or a future scenario adds a 5th producer), that informal routing falls over.

The tag is the smallest possible fix that turns the routing from "guess from inner JSON" into "match on the outer wrapper".

## Trace evidence (post-fix)

```
<system-reminder source="background">
Background task 014a434e20e844b1ab4c767dc9e70275 (bash) finished.
Result: {"exit_code": 0, "stdout": "OK\n", ...}
</system-reminder>

<system-reminder source="monitor">
{'kind': 'wakeup', 'monitor_id': '702b...', 'note': 'wake up after 3 seconds', 'delay': 3.0}
</system-reminder>
```

The agent, when asked to enumerate the reminders it saw, quotes the `source="…"` attribute verbatim — confirming the tag reaches the LLM's view, not just the trace store.

## Fail-stop pin

`test_render_source_tag_is_per_source_distinct` locks down the invariant: the three sources MUST produce three distinct wrapper opening tags. A silent regression to a single un-attributed wrapper, or to the same attribute across the three sources, re-introduces the producer-ambiguity this PR exists to fix — and downstream prompts / extractors may key off the attribute, so it must stay stable AND per-source-distinct.

## Scope

- `core/runtime/session_inbox.py:159` — wrapper template + docstring
- `tests/unit/core/test_session_inbox.py` — three existing wrapper assertions updated + new fail-stop test
- `tests/unit/extensions/test_monitor.py` — wrapper assertion updated
- `tests/integration/test_sub_agent_lifecycle.py` — wrapper assertion updated

47 targeted unit + integration tests pass; ruff & mypy clean.

## Related

- Surfaced by post-merge E2E of #176
- #180 — tracks separately: tool-schema → provider compatibility (the doubao `prefixItems` issue I hit on the sub_agent E2E leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
