### PR TITLE
feat(gateway): stream the full session event surface to chat peers

### DIFF
--- a/src/agentm/extensions/builtin/wire_driver.py
+++ b/src/agentm/extensions/builtin/wire_driver.py
@@ -1,14 +1,34 @@
 """Builtin ``wire_driver`` atom — AgentSession events -> wire envelopes (§4).
 
-Installed by the single-process gateway's :class:`SessionManager` onto
-every chat session so that the session's events fan out as ``outbound``
-wire-envelope *bodies* to the originating chat client.
+Installed by the single-process gateway's :class:`SessionManager` onto every
+chat session so the session's events fan out as ``outbound`` wire-envelope
+*bodies* to the originating chat client. It is the bus→wire bridge: the TUI is
+a separate process and cannot subscribe to the session bus, so whatever it
+renders must first be projected onto the wire here (see
+``.claude/designs/textual-tui.md``).
 
-This is the only substantial new code the channels-v2 rewrite adds. It
-replaces what would have been an entire worker package: pure translation
-glue, fully expressible inside the §11 single-file atom contract — no
-``core.runtime.*`` import, no atom-to-atom import, communicating with the
-gateway only through services it gets by name.
+Design — a **declarative projector table**. ``_PROJECTORS`` maps a bus channel
+to a pure function that turns the event into a JSON-safe outbound body (or
+``None`` to skip a particular event). The *set of surfaced events and their
+wire shape lives in one reviewable place*; the table omitting a channel is the
+explicit allow-list (kernel-internal / persistence / veto / rewrite hooks are
+deliberately absent). This mirrors the per-event ``to_otel`` projection pattern
+in ``core/abi/events.py``.
+
+Async vs sync dispatch. Conversation channels (``stream_delta``, ``turn_*``,
+``tool_*``, ``child_session_*``, ``diagnostic``, ``agent_end``) are dispatched
+via async ``bus.emit``; their handlers are coroutines that ``await`` the sink,
+preserving order and backpressure on the streaming hot path. The runtime
+control channels (``extension_*``, ``api_register``, ``api_send_user_message``,
+...) are dispatched via ``bus.emit_sync`` — an **async handler there is
+silently skipped**, which would drop exactly the self-modification events the
+TUI exists to surface — so those use a *sync* handler that schedules the async
+sink via ``loop.create_task``. A sync handler is valid under both emit paths.
+
+Delivery class is the gateway sink's concern (``_DURABLE_OUTBOUND_KINDS`` in
+``agentm.gateway.cli``); this atom only stamps ``metadata.kind`` and stays
+transport-agnostic, communicating with the gateway only through services it
+gets by name (§11: no ``core.runtime.*`` import, no atom-to-atom import).
 
 Service contract (set by SessionManager before install):
 
@@ -16,44 +36,88 @@ Service contract (set by SessionManager before install):
 * ``session_key``      -> ``str`` (echoed back so the gateway routes the
   outbound to the right chat client).
 * ``turn_context``     -> mutable dict with ``channel`` / ``chat_id`` /
-  ``thread_id`` / ``sender_id`` for the current turn (used to address
-  outbound bodies and approval cards).
+  ``thread_id`` / ``sender_id`` for the current turn.
 * ``approval_manager`` -> optional object exposing ``requires(name)`` and
-  ``request(...)`` (the gateway's ApprovalManager). When present and a
-  tool needs approval, the atom blocks the tool until the user decides.
-
-The atom builds plain ``dict`` bodies (not the gateway's ``Envelope`` /
-``OutboundBody`` types) precisely so it never imports a gateway module —
-the gateway wraps the dict into an envelope on the way out.
+  ``request(...)``; when present, write-class tools are gated through it.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from typing import Any
 
 from agentm.core.abi import AssistantMessage, TextContent
 from agentm.core.abi.events import (
+    AfterCompactEvent,
+    AgentEndEvent,
+    ApiRegisterEvent,
+    ApiSendUserMessageEvent,
+    ChildSessionEndEvent,
+    ChildSessionStartEvent,
+    CommandDispatchedEvent,
+    CostBudgetExceededEvent,
     DiagnosticEvent,
+    ExtensionInstallEvent,
+    ExtensionReloadEvent,
+    ExtensionUnloadEvent,
+    PlanSubmittedEvent,
+    ResourceWriteEvent,
+    SessionReadyEvent,
+    StreamDeltaEvent,
     ToolCallEvent,
+    ToolResultEvent,
     TurnEndEvent,
+    TurnStartEvent,
 )
 from agentm.core.abi.extension import ExtensionAPI
+from agentm.core.abi.stream import TextDelta, ThinkingDelta
+from agentm.core.lib import to_jsonable
 from agentm.extensions import ExtensionManifest
+
+# A projector turns one event into an outbound body, a list of bodies, or
+# nothing. Each body MUST carry ``kind``; an optional ``content`` is the
+# primary human text, every other key rides in ``metadata``.
+ProjectorResult = dict[str, Any] | list[dict[str, Any]] | None
+Projector = Callable[[Any], ProjectorResult]
+
+_PREVIEW_LIMIT = 4000
 
 MANIFEST = ExtensionManifest(
     name="wire_driver",
     description=(
-        "Translate AgentSession events into wire outbound envelope bodies "
-        "for the single-process gateway. Installed per chat session by the "
-        "gateway's SessionManager; reads wire_outbound / session_key / "
-        "turn_context / approval_manager services. Emits assistant text on "
-        "turn_end and diagnostics on warning/error; gates write-class tools "
-        "through the approval_manager when policy requires it."
+        "Translate AgentSession bus events into wire outbound envelope bodies "
+        "for the single-process gateway, via a declarative projector table. "
+        "Installed per chat session by the gateway's SessionManager; reads "
+        "wire_outbound / session_key / turn_context / approval_manager "
+        "services. Forwards the full surfaceable event taxonomy — conversation "
+        "(stream text/thinking, tool call/result, turn, usage, child sessions) "
+        "and runtime control/observability (extension install/reload/unload, "
+        "api_register, injected user messages, resource writes, compaction, "
+        "budget, session_ready) — discriminated by metadata.kind. Gates "
+        "write-class tools through the approval_manager when policy requires."
     ),
     registers=(
+        "event:turn_start",
         "event:turn_end",
+        "event:stream_delta",
         "event:tool_call",
+        "event:tool_result",
+        "event:child_session_start",
+        "event:child_session_end",
         "event:diagnostic",
+        "event:agent_end",
+        "event:extension_install",
+        "event:extension_reload",
+        "event:extension_unload",
+        "event:api_register",
+        "event:api_send_user_message",
+        "event:resource_write",
+        "event:plan_submitted",
+        "event:after_compact",
+        "event:cost_budget_exceeded",
+        "event:session_ready",
+        "event:command_dispatched",
     ),
     config_schema={
         "type": "object",
@@ -71,6 +135,251 @@ def _assistant_text(message: AssistantMessage) -> str:
     )
 
 
+def _content_text(blocks: Any, limit: int = _PREVIEW_LIMIT) -> str:
+    """Best-effort text view of a content-block list (tool results, injected
+    messages). Duck-typed on ``.text`` so no extra ABI import is needed."""
+    if isinstance(blocks, str):
+        return blocks[:limit]
+    parts: list[str] = []
+    try:
+        for block in blocks:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text:
+                parts.append(text)
+    except TypeError:
+        return str(blocks)[:limit]
+    return "\n".join(parts)[:limit]
+
+
+# --- projectors (pure: event -> JSON-safe body) ----------------------------
+
+
+def _p_turn_start(ev: TurnStartEvent) -> ProjectorResult:
+    return {"kind": "turn_start", "turn_id": ev.turn_id, "turn_index": ev.turn_index}
+
+
+def _p_stream_delta(ev: StreamDeltaEvent) -> ProjectorResult:
+    delta = ev.delta
+    if isinstance(delta, TextDelta):
+        return (
+            {"kind": "stream_text", "content": delta.text, "turn_id": ev.turn_id}
+            if delta.text
+            else None
+        )
+    if isinstance(delta, ThinkingDelta):
+        return (
+            {"kind": "stream_thinking", "content": delta.text, "turn_id": ev.turn_id}
+            if delta.text
+            else None
+        )
+    # ToolCallStart / ArgsDelta / End / MessageEnd are surfaced via the
+    # tool_call / tool_result / turn_end channels instead.
+    return None
+
+
+def _p_tool_call(ev: ToolCallEvent) -> ProjectorResult:
+    return {
+        "kind": "tool_call",
+        "tool_call_id": ev.tool_call_id,
+        "name": ev.tool_name,
+        "args": to_jsonable(ev.args),
+    }
+
+
+def _p_tool_result(ev: ToolResultEvent) -> ProjectorResult:
+    # Covers both success and error: an errored tool still flows through
+    # ToolResultEvent with ``result.is_error=True`` (the loop emits
+    # ToolErrorEvent only to let an atom fill the result content, then emits
+    # this with the same instance), so there is no separate tool_error frame.
+    return {
+        "kind": "tool_result",
+        "tool_call_id": ev.tool_call_id,
+        "name": ev.tool_name,
+        "ok": not ev.result.is_error,
+        "content": _content_text(ev.result.content),
+    }
+
+
+def _p_turn_end(ev: TurnEndEvent) -> ProjectorResult:
+    bodies: list[dict[str, Any]] = []
+    text = _assistant_text(ev.message)
+    if text.strip():
+        bodies.append({"kind": "assistant_text", "content": text})
+    usage = ev.message.usage
+    if usage is not None:
+        bodies.append(
+            {
+                "kind": "usage",
+                "turn_id": ev.turn_id,
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "cache_read": usage.cache_read,
+                "cache_write": usage.cache_write,
+            }
+        )
+    return bodies or None
+
+
+def _p_child_start(ev: ChildSessionStartEvent) -> ProjectorResult:
+    return {
+        "kind": "child_start",
+        "child_id": ev.child_session_id,
+        "purpose": ev.purpose,
+    }
+
+
+def _p_child_end(ev: ChildSessionEndEvent) -> ProjectorResult:
+    return {
+        "kind": "child_end",
+        "child_id": ev.child_session_id,
+        "final_message_count": ev.final_message_count,
+        "error": ev.error,
+    }
+
+
+def _p_diagnostic(ev: DiagnosticEvent) -> ProjectorResult:
+    if ev.level == "warning":
+        return {"kind": "diagnostic_warning", "content": ev.message, "source": ev.source}
+    if ev.level == "error":
+        return {"kind": "diagnostic_error", "content": ev.message, "source": ev.source}
+    return None  # info is not surfaced
+
+
+def _p_agent_end(ev: AgentEndEvent) -> ProjectorResult:
+    return {"kind": "agent_end", "cause": type(ev.cause).__name__}
+
+
+def _p_extension_install(ev: ExtensionInstallEvent) -> ProjectorResult:
+    return {
+        "kind": "extension_install",
+        "module_path": ev.module_path,
+        "phase": ev.phase,
+        "trigger": ev.trigger,
+        "error": ev.error,
+    }
+
+
+def _p_extension_reload(ev: ExtensionReloadEvent) -> ProjectorResult:
+    return {
+        "kind": "extension_reload",
+        "name": ev.name,
+        "is_self_modify": ev.is_self_modify,
+        "trigger": ev.trigger,
+        "error": ev.error,
+    }
+
+
+def _p_extension_unload(ev: ExtensionUnloadEvent) -> ProjectorResult:
+    return {
+        "kind": "extension_unload",
+        "name": ev.name,
+        "trigger": ev.trigger,
+        "error": ev.error,
+    }
+
+
+def _p_api_register(ev: ApiRegisterEvent) -> ProjectorResult:
+    # ``reg_kind`` (not ``kind``) so it does not collide with the wire
+    # metadata.kind discriminator.
+    return {
+        "kind": "api_register",
+        "reg_kind": ev.kind,
+        "name": ev.name,
+        "extension": ev.extension,
+    }
+
+
+def _p_api_send_user_message(ev: ApiSendUserMessageEvent) -> ProjectorResult:
+    return {
+        "kind": "api_send_user_message",
+        "extension": ev.extension,
+        "content": _content_text(ev.content),
+    }
+
+
+def _p_resource_write(ev: ResourceWriteEvent) -> ProjectorResult:
+    return {
+        "kind": "resource_write",
+        "path": ev.path,
+        "author": ev.author,
+        "rationale": ev.rationale,
+        "post_sha": ev.post_sha,
+    }
+
+
+def _p_plan_submitted(ev: PlanSubmittedEvent) -> ProjectorResult:
+    return {"kind": "plan_submitted", "plan_id": ev.plan_id, "content": ev.plan_text}
+
+
+def _p_after_compact(ev: AfterCompactEvent) -> ProjectorResult:
+    return {
+        "kind": "after_compact",
+        "kept": ev.kept_message_count,
+        "discarded": ev.discarded_message_count,
+        "content": ev.summary,
+    }
+
+
+def _p_cost_budget(ev: CostBudgetExceededEvent) -> ProjectorResult:
+    return {
+        "kind": "cost_budget_exceeded",
+        "used": ev.used,
+        "limit": ev.limit,
+        "currency": ev.currency,
+    }
+
+
+def _p_session_ready(ev: SessionReadyEvent) -> ProjectorResult:
+    return {
+        "kind": "session_ready",
+        "tool_names": list(ev.tool_names),
+        "command_names": list(ev.command_names),
+        "model": ev.model.id if ev.model is not None else None,
+    }
+
+
+def _p_command_dispatched(ev: CommandDispatchedEvent) -> ProjectorResult:
+    return {
+        "kind": "command_dispatched",
+        "name": ev.name,
+        "args": ev.args,
+        "owner": ev.owner,
+    }
+
+
+# Channels dispatched via async ``bus.emit`` — async handlers preserve order
+# and backpressure on the streaming hot path.
+_ASYNC_PROJECTORS: tuple[tuple[str, Projector], ...] = (
+    (TurnStartEvent.CHANNEL, _p_turn_start),
+    (StreamDeltaEvent.CHANNEL, _p_stream_delta),
+    (ToolCallEvent.CHANNEL, _p_tool_call),
+    (ToolResultEvent.CHANNEL, _p_tool_result),
+    (TurnEndEvent.CHANNEL, _p_turn_end),
+    (ChildSessionStartEvent.CHANNEL, _p_child_start),
+    (ChildSessionEndEvent.CHANNEL, _p_child_end),
+    (DiagnosticEvent.CHANNEL, _p_diagnostic),
+    (AgentEndEvent.CHANNEL, _p_agent_end),
+)
+
+# Runtime control/observability channels dispatched via ``bus.emit_sync`` (or
+# whose ordering is not load-bearing). A SYNC handler is required here — an
+# async handler is silently skipped by ``emit_sync`` — so these schedule the
+# async sink on the running loop.
+_SYNC_PROJECTORS: tuple[tuple[str, Projector], ...] = (
+    (ExtensionInstallEvent.CHANNEL, _p_extension_install),
+    (ExtensionReloadEvent.CHANNEL, _p_extension_reload),
+    (ExtensionUnloadEvent.CHANNEL, _p_extension_unload),
+    (ApiRegisterEvent.CHANNEL, _p_api_register),
+    (ApiSendUserMessageEvent.CHANNEL, _p_api_send_user_message),
+    (ResourceWriteEvent.CHANNEL, _p_resource_write),
+    (PlanSubmittedEvent.CHANNEL, _p_plan_submitted),
+    (AfterCompactEvent.CHANNEL, _p_after_compact),
+    (CostBudgetExceededEvent.CHANNEL, _p_cost_budget),
+    (SessionReadyEvent.CHANNEL, _p_session_ready),
+    (CommandDispatchedEvent.CHANNEL, _p_command_dispatched),
+)
+
+
 def install(api: ExtensionAPI, config: dict[str, Any]) -> None:  # noqa: ARG001
     outbound_sink = api.get_service("wire_outbound")
     session_key = api.get_service("session_key")
@@ -84,6 +393,8 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:  # noqa: ARG001
         )
     turn_context: dict[str, Any] | None = api.get_service("turn_context")
     approval_mgr = api.get_service("approval_manager")
+    # Holds scheduled control-frame tasks so the loop does not GC them mid-flight.
+    bg_tasks: set[asyncio.Task[Any]] = set()
 
     def _addr() -> dict[str, Any]:
         ctx = turn_context or {}
@@ -93,29 +404,52 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:  # noqa: ARG001
             "thread_id": ctx.get("thread_id"),
         }
 
-    async def emit(body_kind: str, content: str) -> None:
+    async def _ship(proj: dict[str, Any]) -> None:
+        kind = proj.pop("kind")
+        content = proj.pop("content", "")
         addr = _addr()
         body: dict[str, Any] = {
             "channel": addr["channel"],
             "chat_id": addr["chat_id"],
             "content": content,
-            "metadata": {"kind": body_kind},
+            "metadata": {"kind": kind, **proj},
             # Echoed onto the envelope by the gateway sink so a multi-surface
-            # chat client can attribute this outbound to its conversation
-            # (§2.5 / §3.3). Without it the dominant outbound kinds ship
-            # session_key=None.
+            # client can attribute this outbound to its conversation (§2.5).
             "_session_key": session_key,
         }
         if addr["thread_id"] is not None:
             body["thread_id"] = addr["thread_id"]
         await outbound_sink(body)
 
-    async def on_turn_end(ev: TurnEndEvent) -> None:
-        text = _assistant_text(ev.message)
-        if text.strip():
-            await emit("assistant_text", text)
+    def _bodies(result: ProjectorResult) -> list[dict[str, Any]]:
+        if result is None:
+            return []
+        return [dict(result)] if isinstance(result, dict) else [dict(b) for b in result]
 
-    async def on_tool_call(ev: ToolCallEvent) -> dict[str, Any] | None:
+    def _make_async(projector: Projector) -> Callable[[Any], Any]:
+        async def handler(ev: Any) -> None:
+            for body in _bodies(projector(ev)):
+                await _ship(body)
+
+        return handler
+
+    def _make_sync(projector: Projector) -> Callable[[Any], Any]:
+        def handler(ev: Any) -> None:
+            bodies = _bodies(projector(ev))
+            if not bodies:
+                return
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return  # no loop — emitted outside the gateway; nothing to do
+            for body in bodies:
+                task = loop.create_task(_ship(body))
+                bg_tasks.add(task)
+                task.add_done_callback(bg_tasks.discard)
+
+        return handler
+
+    async def _approval_gate(ev: ToolCallEvent) -> dict[str, Any] | None:
         if approval_mgr is None or not approval_mgr.requires(ev.tool_name):
             return None
         ctx = turn_context or {}
@@ -131,18 +465,16 @@ def install(api: ExtensionAPI, config: dict[str, Any]) -> None:  # noqa: ARG001
         if not ok:
             return {
                 "block": True,
-                "reason": f"tool '{ev.tool_name}' was denied via the chat approval gate",
+                "reason": (
+                    f"tool '{ev.tool_name}' was denied via the chat approval gate"
+                ),
             }
         return None
 
-    async def on_diagnostic(ev: DiagnosticEvent) -> None:
-        if not ev.message:
-            return
-        if ev.level == "warning":
-            await emit("diagnostic_warning", ev.message)
-        elif ev.level == "error":
-            await emit("diagnostic_error", ev.message)
-
-    api.on(TurnEndEvent.CHANNEL, on_turn_end)
-    api.on(ToolCallEvent.CHANNEL, on_tool_call)
-    api.on(DiagnosticEvent.CHANNEL, on_diagnostic)
+    for channel, projector in _ASYNC_PROJECTORS:
+        api.on(channel, _make_async(projector))
+    for channel, projector in _SYNC_PROJECTORS:
+        api.on(channel, _make_sync(projector))
+    # Approval gate runs alongside the tool_call projector; it returns a block
+    # decision the loop acts on, independent of the outbound forwarding.
+    api.on(ToolCallEvent.CHANNEL, _approval_gate)

--- a/src/agentm/gateway/cli.py
+++ b/src/agentm/gateway/cli.py
@@ -63,10 +63,13 @@ from agentm.gateway.transport import (
     WebSocketServerTransport,
 )
 from agentm.gateway.wire import (
+    DURABLE_OUTBOUND_KINDS,
+    EPHEMERAL_OUTBOUND_KINDS,
     KIND_OUTBOUND,
     WIRE_VERSION,
     Envelope,
     InboundBody,
+    encode,
 )
 
 autoload_dotenv()
@@ -268,6 +271,27 @@ def _build_session_factory(
 # -------- gateway runtime ---------------------------------------------
 
 
+async def _ephemeral_send(peer: PeerSession, env: Envelope) -> None:
+    """Write ``env`` straight to ``peer`` best-effort, bypassing the outbox.
+
+    Holds the peer's write lock so the frame never interleaves with the
+    durable delivery worker (one wire frame == one WS message). A dead/slow
+    peer just drops the frame — ephemeral frames are live decoration, not a
+    durable record (the durable ``assistant_text`` is the fallback). See the
+    delivery-class contract in ``agentm.gateway.wire.types`` / textual-tui §4.3.
+    """
+    try:
+        async with peer.write_lock:
+            peer.transport_writer.write(encode(env))
+            await peer.transport_writer.drain()
+    except (ConnectionResetError, BrokenPipeError):
+        return
+    except Exception:  # noqa: BLE001 — a bad peer must not break the session
+        logger.debug(
+            "ephemeral outbound dropped for peer=%s", peer.peer_id, exc_info=True
+        )
+
+
 def _route_targets(
     peers: list[PeerSession],
     peer_channels: dict[str, str],
@@ -356,6 +380,8 @@ class _GatewayRuntime:
             return
         session_key = str(body.pop("_session_key", "") or "") or None
         target_channel = str(body.get("channel") or "")
+        meta = body.get("metadata")
+        kind = str((meta or {}).get("kind") or "assistant_text")
         env = Envelope(
             v=WIRE_VERSION,
             id=f"out-{uuid.uuid4().hex[:12]}",
@@ -367,8 +393,23 @@ class _GatewayRuntime:
         targets = _route_targets(
             list(self._server.registry), self._peer_channels, target_channel
         )
-        for peer in targets:
-            await asyncio.to_thread(self._outbox.enqueue, peer.peer_id, env)
+        if kind in DURABLE_OUTBOUND_KINDS:
+            for peer in targets:
+                await asyncio.to_thread(self._outbox.enqueue, peer.peer_id, env)
+        else:
+            # Ephemeral live frame: written straight to the connected peer(s),
+            # bypassing the durable outbox (delivery-class contract: wire.types
+            # / textual-tui §4.3). An unknown kind falls here too — surface it,
+            # since a typo'd DURABLE kind would otherwise silently downgrade to
+            # droppable.
+            if kind not in EPHEMERAL_OUTBOUND_KINDS:
+                logger.warning(
+                    "outbound kind %r is not in the known wire vocabulary; "
+                    "delivering as ephemeral (best-effort, droppable)",
+                    kind,
+                )
+            for peer in targets:
+                await _ephemeral_send(peer, env)
 
     # -- inbound handler ----------------------------------------------
 

--- a/src/agentm/gateway/peer.py
+++ b/src/agentm/gateway/peer.py
@@ -28,6 +28,14 @@ class PeerSession:
     # high-water mark. Cleared when drained below high_water / 2.
     backpressure: bool = False
     capabilities: dict[str, object] = field(default_factory=dict)
+    # Serialises ALL writes to ``transport_writer``. The durable delivery
+    # worker and the ephemeral-frame sink (live streaming, §4 of
+    # textual-tui.md) both write to the same writer; the WebSocket adapter
+    # coalesces buffered writes into ONE ``ws.send`` per ``drain()``, so two
+    # concurrent ``write()+drain()`` pairs would merge two wire frames into a
+    # single WS message and corrupt the stream. Every writer acquires this
+    # lock around its write+drain so each frame maps to exactly one flush.
+    write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class PeerRegistry:

--- a/src/agentm/gateway/server.py
+++ b/src/agentm/gateway/server.py
@@ -401,9 +401,13 @@ class WireServer:
         """
         writer = session.transport_writer
         try:
-            for r in records:
-                writer.write(encode(r.envelope))
-                await writer.drain()
+            # Hold the per-peer write lock across the batch so durable frames
+            # never interleave with ephemeral live frames on the same writer
+            # (one wire frame == one WS message; see PeerSession.write_lock).
+            async with session.write_lock:
+                for r in records:
+                    writer.write(encode(r.envelope))
+                    await writer.drain()
         except asyncio.CancelledError:
             await self._nack_records(records)
             raise

--- a/src/agentm/gateway/wire/__init__.py
+++ b/src/agentm/gateway/wire/__init__.py
@@ -21,7 +21,15 @@ from .kinds import (
     KIND_WELCOME,
     VALID_KINDS,
 )
-from .types import Button, ButtonStyle, InboundBody, OutboundBody, OutboundMetaKind
+from .types import (
+    DURABLE_OUTBOUND_KINDS,
+    EPHEMERAL_OUTBOUND_KINDS,
+    Button,
+    ButtonStyle,
+    InboundBody,
+    OutboundBody,
+    OutboundMetaKind,
+)
 
 __all__ = [
     "HEADER_BYTES",
@@ -36,6 +44,8 @@ __all__ = [
     "MAX_FRAME_BYTES",
     "VALID_KINDS",
     "WIRE_VERSION",
+    "DURABLE_OUTBOUND_KINDS",
+    "EPHEMERAL_OUTBOUND_KINDS",
     "Button",
     "ButtonStyle",
     "Envelope",

--- a/src/agentm/gateway/wire/types.py
+++ b/src/agentm/gateway/wire/types.py
@@ -19,13 +19,88 @@ from typing import Any, Literal
 ButtonStyle = Literal["primary", "danger", "default"]
 
 # Discriminator for how a chat client renders an outbound (§2.5).
+#
+# Two delivery classes share this one envelope kind (see
+# ``.claude/designs/textual-tui.md`` §4.3): DURABLE kinds go through the
+# per-peer outbox (at-least-once, survive reconnect); EPHEMERAL kinds are
+# written best-effort straight to the connected peer and dropped if it is
+# absent (live decoration — streaming text, tool lifecycle, runtime
+# control/observability events). The durable set is the reliability floor;
+# everything else is ephemeral.
+#
+# This module is the *single home* of the wire kind vocabulary AND its
+# delivery-class partition. The gateway sink (``agentm.gateway.cli``) imports
+# :data:`DURABLE_OUTBOUND_KINDS` to route — it does not keep its own copy — and
+# ``test_outbound_routing`` asserts the two sets partition
+# ``OutboundMetaKind`` exactly (disjoint, union == every Literal member), so a
+# new kind cannot be added to the Literal without being classified, and a
+# kind cannot drift between the two layers.
 OutboundMetaKind = Literal[
+    # -- durable (reliability floor) --
     "assistant_text",
     "approval_request",
     "approval_resolved",
     "diagnostic_warning",
     "diagnostic_error",
+    # -- ephemeral: conversation (live transcript) --
+    "turn_start",
+    "stream_text",
+    "stream_thinking",
+    "tool_call",
+    "tool_result",
+    "usage",
+    "child_start",
+    "child_end",
+    "agent_end",
+    # -- ephemeral: runtime control / observability --
+    "extension_install",
+    "extension_reload",
+    "extension_unload",
+    "api_register",
+    "api_send_user_message",
+    "resource_write",
+    "plan_submitted",
+    "after_compact",
+    "cost_budget_exceeded",
+    "session_ready",
+    "command_dispatched",
 ]
+
+# Delivery-class partition of OutboundMetaKind. DURABLE = the reliability
+# floor (outbox, at-least-once); everything else is ephemeral live decoration.
+DURABLE_OUTBOUND_KINDS: frozenset[str] = frozenset(
+    {
+        "assistant_text",
+        "approval_request",
+        "approval_resolved",
+        "diagnostic_warning",
+        "diagnostic_error",
+    }
+)
+EPHEMERAL_OUTBOUND_KINDS: frozenset[str] = frozenset(
+    {
+        "turn_start",
+        "stream_text",
+        "stream_thinking",
+        "tool_call",
+        "tool_result",
+        "usage",
+        "child_start",
+        "child_end",
+        "agent_end",
+        "extension_install",
+        "extension_reload",
+        "extension_unload",
+        "api_register",
+        "api_send_user_message",
+        "resource_write",
+        "plan_submitted",
+        "after_compact",
+        "cost_budget_exceeded",
+        "session_ready",
+        "command_dispatched",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,4 +226,12 @@ class OutboundBody:
         return out
 
 
-__all__ = ["Button", "ButtonStyle", "InboundBody", "OutboundBody", "OutboundMetaKind"]
+__all__ = [
+    "DURABLE_OUTBOUND_KINDS",
+    "EPHEMERAL_OUTBOUND_KINDS",
+    "Button",
+    "ButtonStyle",
+    "InboundBody",
+    "OutboundBody",
+    "OutboundMetaKind",
+]

--- a/tests/unit/gateway/test_outbound_routing.py
+++ b/tests/unit/gateway/test_outbound_routing.py
@@ -10,10 +10,29 @@ is the pure selection that fixes it.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, cast, get_args
 
-from agentm.gateway.cli import _route_targets
+import pytest
+
+from agentm.gateway.cli import _GatewayRuntime, _route_targets
 from agentm.gateway.peer import PeerSession
+from agentm.gateway.wire import (
+    DURABLE_OUTBOUND_KINDS,
+    EPHEMERAL_OUTBOUND_KINDS,
+    KIND_OUTBOUND,
+    OutboundMetaKind,
+    decode_stream,
+)
+
+
+def test_delivery_class_partition_matches_the_kind_literal() -> None:
+    """The durable/ephemeral sets are the single source the sink routes by;
+    they must partition OutboundMetaKind exactly — disjoint and exhaustive —
+    so a new kind cannot be added to the Literal without being classified, and
+    a kind cannot drift between the wire vocabulary and the delivery policy."""
+    literal = set(get_args(OutboundMetaKind))
+    assert DURABLE_OUTBOUND_KINDS & EPHEMERAL_OUTBOUND_KINDS == set()
+    assert DURABLE_OUTBOUND_KINDS | EPHEMERAL_OUTBOUND_KINDS == literal
 
 
 def _peer(peer_id: str) -> PeerSession:
@@ -62,3 +81,90 @@ def test_routes_to_all_same_channel_peers_mirror_case() -> None:
 
     # Two terminals on the same channel both mirror the conversation.
     assert _route_targets(peers, channels, "terminal") == [t1, t2]
+
+
+# --- delivery-class split (durable outbox vs ephemeral direct write) -------
+
+
+class _RecordingOutbox:
+    def __init__(self) -> None:
+        self.enqueued: list[tuple[str, Any]] = []
+
+    def enqueue(self, peer_id: str, env: Any) -> None:
+        self.enqueued.append((peer_id, env))
+
+
+class _RecordingWriter:
+    """Captures bytes written straight to the peer (the ephemeral path)."""
+
+    def __init__(self) -> None:
+        self.buf = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buf.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+
+class _FakeServer:
+    def __init__(self, peers: list[PeerSession]) -> None:
+        self._peers = peers
+
+    @property
+    def registry(self) -> list[PeerSession]:
+        return self._peers
+
+
+def _runtime_with(peer: PeerSession, outbox: _RecordingOutbox) -> _GatewayRuntime:
+    # Bypass the heavy __init__ (builds SqliteOutbox/SessionManager/...); we
+    # only exercise _emit_outbound, which reads _server/_outbox/_peer_channels.
+    rt = object.__new__(_GatewayRuntime)
+    rt._server = cast(Any, _FakeServer([peer]))
+    rt._outbox = cast(Any, outbox)
+    rt._peer_channels = {peer.peer_id: "terminal"}
+    return rt
+
+
+def _body(kind: str) -> dict[str, Any]:
+    return {
+        "channel": "terminal",
+        "chat_id": "t1",
+        "content": "x",
+        "metadata": {"kind": kind},
+        "_session_key": "terminal:t1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_durable_kind_enqueues_and_does_not_write_directly() -> None:
+    outbox = _RecordingOutbox()
+    writer = _RecordingWriter()
+    peer = PeerSession(peer_id="terminal-1", transport_writer=cast(Any, writer))
+    rt = _runtime_with(peer, outbox)
+
+    await rt._emit_outbound(_body("assistant_text"))
+
+    assert len(outbox.enqueued) == 1  # durable -> outbox
+    assert bytes(writer.buf) == b""  # never written straight to the peer
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_kind_writes_directly_and_skips_the_outbox() -> None:
+    outbox = _RecordingOutbox()
+    writer = _RecordingWriter()
+    peer = PeerSession(peer_id="terminal-1", transport_writer=cast(Any, writer))
+    rt = _runtime_with(peer, outbox)
+
+    await rt._emit_outbound(_body("stream_text"))
+
+    # Streaming deltas MUST bypass the durable outbox (a turn streams ~50/s;
+    # otherwise the SQLite queue explodes and replays stale frames).
+    assert outbox.enqueued == []
+    # ... and land as one valid `outbound` envelope on the live socket.
+    envelopes, rest = decode_stream(bytes(writer.buf))
+    assert rest == b""
+    assert len(envelopes) == 1
+    assert envelopes[0].kind == KIND_OUTBOUND
+    assert envelopes[0].session_key == "terminal:t1"
+    assert envelopes[0].body["metadata"]["kind"] == "stream_text"

--- a/tests/unit/gateway/test_wire_driver_atom.py
+++ b/tests/unit/gateway/test_wire_driver_atom.py
@@ -8,14 +8,24 @@ the approval manager, the gateway is mute or unsafe.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from agentm.core.abi.events import DiagnosticEvent, ToolCallEvent, TurnEndEvent
-from agentm.core.abi.messages import AssistantMessage, TextContent
+from agentm.core.abi.events import (
+    DiagnosticEvent,
+    ExtensionReloadEvent,
+    StreamDeltaEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    TurnEndEvent,
+)
+from agentm.core.abi.messages import AssistantMessage, TextContent, Usage
+from agentm.core.abi.stream import TextDelta, ThinkingDelta
+from agentm.core.abi.tool import ToolResult
 
 _WIRE_DRIVER = (
     Path(__file__).resolve().parents[3]
@@ -32,17 +42,24 @@ def _load_wire_driver() -> Any:
 
 
 class _FakeAPI:
-    """Records ``@api.on`` handlers and serves ``get_service`` lookups."""
+    """Records ``@api.on`` handlers and serves ``get_service`` lookups.
+
+    Keeps EVERY handler per channel (a channel may carry more than one — e.g.
+    ``tool_call`` has the projector then the approval gate), so a test can pick
+    the handler it means instead of depending on registration order silently
+    overwriting one. Convention: ``handlers[ch][0]`` is the projector;
+    ``handlers[ch][-1]`` is the approval gate on ``tool_call``.
+    """
 
     def __init__(self, services: dict[str, Any]) -> None:
         self._services = services
-        self.handlers: dict[str, Any] = {}
+        self.handlers: dict[str, list[Any]] = {}
 
     def get_service(self, name: str) -> Any:
         return self._services.get(name)
 
     def on(self, channel: str, handler: Any, **_kw: Any) -> None:
-        self.handlers[channel] = handler
+        self.handlers.setdefault(channel, []).append(handler)
 
 
 class _RecordingApproval:
@@ -88,7 +105,7 @@ async def test_turn_end_emits_assistant_text_outbound() -> None:
             "turn_context": {"channel": "terminal", "chat_id": "t1", "thread_id": None},
         }
     )
-    await api.handlers[TurnEndEvent.CHANNEL](
+    await api.handlers[TurnEndEvent.CHANNEL][0](
         TurnEndEvent(turn_index=0, message=_assistant("the answer is 42"))
     )
     assert len(out) == 1
@@ -117,7 +134,7 @@ async def test_empty_turn_end_emits_nothing() -> None:
             "turn_context": {"channel": "terminal", "chat_id": "t1", "thread_id": None},
         }
     )
-    await api.handlers[TurnEndEvent.CHANNEL](
+    await api.handlers[TurnEndEvent.CHANNEL][0](
         TurnEndEvent(turn_index=0, message=_assistant("   "))
     )
     assert out == []
@@ -134,7 +151,9 @@ async def test_tool_call_gated_through_approval_when_required() -> None:
             "approval_manager": approval,
         }
     )
-    result = await api.handlers[ToolCallEvent.CHANNEL](
+    # The approval gate is the LAST handler registered on tool_call (the
+    # projector is [0]); pick it explicitly rather than by overwrite luck.
+    result = await api.handlers[ToolCallEvent.CHANNEL][-1](
         ToolCallEvent(tool_call_id="tc1", tool_name="bash", args={"cmd": "ls"})
     )
     assert approval.requested == ["bash"]
@@ -156,7 +175,7 @@ async def test_tool_call_not_gated_when_policy_allows() -> None:
             "approval_manager": approval,
         }
     )
-    result = await api.handlers[ToolCallEvent.CHANNEL](
+    result = await api.handlers[ToolCallEvent.CHANNEL][-1](
         ToolCallEvent(tool_call_id="tc1", tool_name="read", args={})
     )
     assert approval.requested == []
@@ -177,7 +196,7 @@ async def test_diagnostic_error_emits_outbound() -> None:
             "turn_context": {"channel": "terminal", "chat_id": "t1", "thread_id": None},
         }
     )
-    await api.handlers[DiagnosticEvent.CHANNEL](
+    await api.handlers[DiagnosticEvent.CHANNEL][0](
         DiagnosticEvent(level="error", source="loop", message="boom")
     )
     assert out[0]["metadata"]["kind"] == "diagnostic_error"
@@ -189,3 +208,144 @@ def test_install_without_services_fails_fast() -> None:
     api = _FakeAPI({})  # no wire_outbound / session_key
     with pytest.raises(RuntimeError):
         mod.install(api, {})
+
+
+# --- projector-table forwarding (the live event surface) -------------------
+
+
+def _install_multi(sink: Any) -> _FakeAPI:
+    return _install(
+        {
+            "wire_outbound": sink,
+            "session_key": "terminal:t1",
+            "turn_context": {
+                "channel": "terminal",
+                "chat_id": "t1",
+                "thread_id": None,
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_text_delta_projected() -> None:
+    out: list[dict] = []
+
+    async def sink(body: dict) -> None:
+        out.append(body)
+
+    api = _install_multi(sink)
+    await api.handlers[StreamDeltaEvent.CHANNEL][0](
+        StreamDeltaEvent(turn_index=0, delta=TextDelta(text="hel"), turn_id=7)
+    )
+    await api.handlers[StreamDeltaEvent.CHANNEL][0](
+        StreamDeltaEvent(turn_index=0, delta=ThinkingDelta(text="hmm"), turn_id=7)
+    )
+    # Empty deltas produce no frame.
+    await api.handlers[StreamDeltaEvent.CHANNEL][0](
+        StreamDeltaEvent(turn_index=0, delta=TextDelta(text=""), turn_id=7)
+    )
+    kinds = [(b["metadata"]["kind"], b["content"], b["metadata"]["turn_id"]) for b in out]
+    assert kinds == [("stream_text", "hel", 7), ("stream_thinking", "hmm", 7)]
+
+
+@pytest.mark.asyncio
+async def test_turn_end_also_emits_usage() -> None:
+    out: list[dict] = []
+
+    async def sink(body: dict) -> None:
+        out.append(body)
+
+    api = _install_multi(sink)
+    msg = AssistantMessage(
+        role="assistant",
+        content=[TextContent(type="text", text="done")],
+        timestamp=0.0,
+        usage=Usage(input_tokens=12, output_tokens=3, cache_read=4),
+    )
+    await api.handlers[TurnEndEvent.CHANNEL][0](
+        TurnEndEvent(turn_index=0, message=msg, turn_id=5)
+    )
+    kinds = {b["metadata"]["kind"]: b for b in out}
+    assert kinds["assistant_text"]["content"] == "done"
+    usage = kinds["usage"]["metadata"]
+    assert (usage["input_tokens"], usage["output_tokens"], usage["cache_read"]) == (
+        12,
+        3,
+        4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_call_and_result_projected() -> None:
+    out: list[dict] = []
+
+    async def sink(body: dict) -> None:
+        out.append(body)
+
+    api = _install_multi(sink)
+    # handlers[tool_call] = [projector, approval_gate]; the projector is [0].
+    await api.handlers[ToolCallEvent.CHANNEL][0](
+        ToolCallEvent(tool_call_id="tc1", tool_name="bash", args={"cmd": "ls"})
+    )
+    await api.handlers[ToolResultEvent.CHANNEL][0](
+        ToolResultEvent(
+            tool_call_id="tc1",
+            tool_name="bash",
+            result=ToolResult(
+                content=[TextContent(type="text", text="file.txt")], is_error=False
+            ),
+        )
+    )
+    await api.handlers[ToolResultEvent.CHANNEL][0](
+        ToolResultEvent(
+            tool_call_id="tc2",
+            tool_name="bash",
+            result=ToolResult(
+                content=[TextContent(type="text", text="boom")], is_error=True
+            ),
+        )
+    )
+    call, ok_res, err_res = out
+    assert call["metadata"]["kind"] == "tool_call"
+    assert call["metadata"]["name"] == "bash"
+    assert call["metadata"]["args"] == {"cmd": "ls"}
+    assert ok_res["metadata"]["kind"] == "tool_result"
+    assert ok_res["metadata"]["ok"] is True
+    assert ok_res["content"] == "file.txt"
+    assert err_res["metadata"]["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_sync_emitted_control_event_is_forwarded() -> None:
+    """extension_reload is dispatched via bus.emit_sync, where an async
+    handler would be silently skipped. wire_driver registers a SYNC handler
+    that schedules the async sink on the loop — without it, self-modification
+    (the headline behavior the TUI exists to surface) would be invisible.
+    """
+    out: list[dict] = []
+
+    async def sink(body: dict) -> None:
+        out.append(body)
+
+    api = _install_multi(sink)
+    handler = api.handlers[ExtensionReloadEvent.CHANNEL][0]
+    # The handler MUST be a plain (sync) function so emit_sync runs it.
+    assert not asyncio.iscoroutinefunction(handler)
+    handler(
+        ExtensionReloadEvent(
+            name="cost_budget",
+            old_hash="a",
+            new_hash="b",
+            trigger="agent",
+            tier=2,
+            is_self_modify=True,
+        )
+    )
+    # The sink runs on a scheduled task; let it drain.
+    await asyncio.sleep(0)
+    assert len(out) == 1
+    meta = out[0]["metadata"]
+    assert meta["kind"] == "extension_reload"
+    assert meta["is_self_modify"] is True
+    assert meta["trigger"] == "agent"


### PR DESCRIPTION
## What

**Phase 1** of the terminal-TUI rebuild (design: `.claude/designs/textual-tui.md`, merged in #186). The TUI is a separate-process **wire client** of the single-process gateway — it can only render what the gateway pushes. Until now `wire_driver` forwarded only final assistant text + approvals + diagnostics, so streaming tokens, tool-call lifecycle, sub-agents, and every runtime control/observability event never crossed the process boundary. This makes the gateway stream the **full surfaceable event taxonomy**.

## How

- **`wire_driver` (builtin atom)** — rebuilt around a **declarative projector table** (`channel -> JSON-safe outbound body`, mirroring the per-event `to_otel` pattern). Forwards conversation events (`turn_start`, `stream_text`/`stream_thinking`, `tool_call`, `tool_result`, `usage` from turn_end, `child_*`) **and** runtime control/observability (`extension_install`/`reload`/`unload`, `api_register`, `api_send_user_message`, `resource_write`, `plan_submitted`, `after_compact`, `cost_budget_exceeded`, `session_ready`, `command_dispatched`, `agent_end`). The table omitting a channel is the explicit allow-list; kernel-internal / persistence / veto hooks stay off the wire. **No new envelope kind** — everything rides `outbound` via `metadata.kind`.
  - **`emit_sync` subtlety:** the `extension_*` / `api_register` / `api_send_user_message` channels are dispatched via `bus.emit_sync`, where an *async* handler is silently skipped — which would make **self-modification (the headline behavior the TUI exists to surface) invisible**. Those use a **sync** handler that schedules the async sink via `loop.create_task`; conversation channels keep async handlers (order + backpressure on the hot path).
- **Gateway sink** (`_emit_outbound`) routes by **delivery class**: durable kinds (`assistant_text`, `approval_*`, `diagnostic_*`) → per-peer outbox (at-least-once, survive reconnect); everything else → **ephemeral** best-effort write straight to the connected peer, bypassing the outbox. A turn streams ~50 deltas/s; routing those durably would explode the SQLite queue and replay stale decoration on reconnect. The partition lives **once** in `wire.types` (`DURABLE_OUTBOUND_KINDS` / `EPHEMERAL_OUTBOUND_KINDS`); a test asserts it partitions `OutboundMetaKind` exactly, and the sink warns on an unknown kind so a typo'd durable kind can't silently downgrade.
- **Write-integrity:** the ephemeral sink and the durable delivery worker share `transport_writer`, and the WS adapter coalesces buffered writes into one `ws.send` per `drain()`. Added a **per-peer `write_lock`** both paths hold around write+drain, so one wire frame == one flush (no merged frames).

## Tests (fail-stop)

- Delivery-class split: ephemeral bypasses the outbox and lands as one valid `outbound` envelope on the socket; durable enqueues and is not written directly.
- Kind-partition exhaustiveness (durable ∪ ephemeral == `OutboundMetaKind`, disjoint).
- Projector shapes (stream text/thinking, tool call/result, usage on turn_end).
- The `emit_sync` control path (`extension_reload` reaches the sink via the scheduled sync handler) — guards self-modify visibility.

64 gateway+contract tests pass; `ruff`/`mypy` clean on touched `src/`.

## Review

Ran the project `boundary-reviewer`: **0 blockers, 1 warn, 3 nits** — §11 validated zero violations, lock placement confirmed load-bearing/correct, no layering breaks. The warn (kind vocabulary drift) + two nits are addressed in this PR; the remaining nit (per-record vs per-batch lock fairness) is a noted polish, not required.

**Architectural — touches the gateway substrate + a builtin atom. Handing off for review before merge** (not self-merging). Phase 2 (TUI rewrite that renders these frames) follows once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)