### PR TITLE
feat(tui): Esc-interrupt — preempt the in-flight prompt over the wire

### DIFF
--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
@@ -51,6 +51,8 @@ class AgentMTui(App[int]):
         self._consumer: asyncio.Task[None] | None = None
         self._history: list[str] = []
         self._ctrlc_ts = 0.0
+        # True from prompt-submit until the loop's agent_end; gates Esc-interrupt.
+        self._in_flight = False
 
     def compose(self) -> ComposeResult:
         yield StatusBar(id="status-bar")
@@ -97,6 +99,11 @@ class AgentMTui(App[int]):
         self.status.phase = phase
         self.show_status()
 
+    def mark_idle(self) -> None:
+        """The loop ended (agent_end). Clear the in-flight gate + go idle."""
+        self._in_flight = False
+        self.set_phase("idle")
+
     def show_status(self) -> None:
         self.query_one("#status-bar", StatusBar).show(self.status)
 
@@ -117,6 +124,20 @@ class AgentMTui(App[int]):
             }
         )
 
+    async def send_interrupt(self) -> None:
+        """Out-of-band interrupt: preempt the in-flight prompt. ``control``
+        keeps it off the conversational path (gateway routes it to
+        AgentSession.interrupt(), not a new turn)."""
+        await self._send(
+            {
+                "channel": "terminal",
+                "sender_id": self._sender_id,
+                "chat_id": self._chat_id,
+                "content": "",
+                "control": "interrupt",
+            }
+        )
+
     # --- input ----------------------------------------------------------
 
     @on(PromptInput.Submitted)
@@ -132,6 +153,7 @@ class AgentMTui(App[int]):
         self._history.append(text)
         await self.mount_widget(UserTurn(text))
         self.scroll_end()
+        self._in_flight = True
         await self._send(
             {
                 "channel": "terminal",
@@ -166,7 +188,11 @@ class AgentMTui(App[int]):
         await self.transcript.remove_children()
         self._router = Router(self)  # drop active turn + tool/child registries
 
-    def action_cancel(self) -> None:
+    async def action_cancel(self) -> None:
+        if self._in_flight:
+            await self.send_interrupt()
+            self.toast("interrupting…")
+            return
         inp = self.query_one("#prompt-input", PromptInput)
         if inp.text.strip():
             inp.text = ""

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/router.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/router.py
@@ -144,7 +144,7 @@ class Router:
         self._app.scroll_end()
 
     async def _agent_end(self, body: dict, meta: dict) -> None:
-        self._app.set_phase("idle")
+        self._app.mark_idle()
 
     # --- approvals ------------------------------------------------------
 

--- a/contrib/gateway-peers/terminal/tests/test_tui_render.py
+++ b/contrib/gateway-peers/terminal/tests/test_tui_render.py
@@ -85,3 +85,26 @@ async def test_submit_echoes_user_turn_and_sends_inbound() -> None:
 
         assert any(b.get("content") == "hi there" for b in client.sent)
         assert len(app.query(UserTurn)) == 1
+
+
+async def test_esc_interrupts_an_in_flight_turn() -> None:
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        inp = app.query_one("#prompt-input")
+        inp.text = "long task"  # type: ignore[attr-defined]
+        inp.action_submit()  # type: ignore[attr-defined]
+        await pilot.pause(0.1)
+        # A turn is now in flight; Esc must send an out-of-band interrupt.
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert any(b.get("control") == "interrupt" for b in client.sent)
+
+        # Once the loop ends (agent_end), Esc no longer interrupts.
+        client.push(_frame("agent_end", cause="SignalAborted"))
+        await pilot.pause(0.1)
+        before = len([b for b in client.sent if b.get("control") == "interrupt"])
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        after = len([b for b in client.sent if b.get("control") == "interrupt"])
+        assert after == before  # idle Esc does not send another interrupt

--- a/src/agentm/gateway/cli.py
+++ b/src/agentm/gateway/cli.py
@@ -428,6 +428,14 @@ class _GatewayRuntime:
         # back to it instead of broadcasting to every connected client.
         if body.channel:
             self._peer_channels[peer.peer_id] = body.channel
+        if decision.action is RouterAction.INTERRUPT:
+            # Preempt the in-flight prompt inline (NOT as a detached task):
+            # it must not queue behind the very prompt it is cancelling.
+            # AgentSession.interrupt() sets the kernel abort signal -> the
+            # loop ends with SignalAborted (context preserved); a no-op when
+            # nothing is running.
+            self._interrupt_session(session_key)
+            return
         if decision.action is RouterAction.RESOLVE_APPROVAL:
             # Resolve inline: it must not sit behind a session.prompt that
             # is itself awaiting THIS approval's future (that would
@@ -460,6 +468,11 @@ class _GatewayRuntime:
         except Exception as exc:
             logger.exception("error handling inbound from %s", session_key)
             await self._send_error(session_key, body, exc)
+
+    def _interrupt_session(self, session_key: str) -> None:
+        sess = self._sessions.get(session_key)
+        if sess is not None:
+            sess.interrupt()
 
     def _resolve_approval(self, body: InboundBody) -> None:
         if body.button_value:

--- a/src/agentm/gateway/router.py
+++ b/src/agentm/gateway/router.py
@@ -1,7 +1,9 @@
 """Router — the pure dispatch decision (§3.2).
 
-Given an inbound :class:`Envelope`, decide one of three actions:
+Given an inbound :class:`Envelope`, decide one of four actions:
 
+* ``INTERRUPT`` — the inbound carries ``control="interrupt"`` (preempt the
+  in-flight prompt; not a conversational turn).
 * ``RESOLVE_APPROVAL`` — the inbound carries a ``button_value`` (an
   approval-card click).
 * ``RUN_COMMAND`` — the inbound's content is a slash command.
@@ -23,6 +25,7 @@ from .wire import Envelope, InboundBody
 class RouterAction(Enum):
     """What the gateway should do with an inbound."""
 
+    INTERRUPT = "interrupt"
     RESOLVE_APPROVAL = "resolve_approval"
     RUN_COMMAND = "run_command"
     PROMPT_SESSION = "prompt_session"
@@ -54,6 +57,8 @@ def dispatch(env: Envelope) -> RouterDecision:
     if env.kind != "inbound":
         raise ProtocolError(f"router only handles inbound; got {env.kind!r}")
     body = InboundBody.from_dict(env.body if isinstance(env.body, dict) else {})
+    if body.control == "interrupt":
+        return RouterDecision(RouterAction.INTERRUPT, body)
     if body.button_value:
         return RouterDecision(RouterAction.RESOLVE_APPROVAL, body)
     if is_slash_command(body.content):

--- a/src/agentm/gateway/wire/types.py
+++ b/src/agentm/gateway/wire/types.py
@@ -130,11 +130,17 @@ class InboundBody:
     sender_id: str = ""
     sender_name: str = ""
     button_value: str | None = None
+    # Out-of-band control verb that is NOT a conversational turn. Currently
+    # ``"interrupt"`` — preempt the in-flight prompt (the gateway routes it to
+    # AgentSession.interrupt() inline, never as a new turn). Distinct from
+    # ``content`` so an interrupt can't be mistaken for a user message.
+    control: str | None = None
     raw: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, body: dict[str, Any]) -> InboundBody:
         button = body.get("button_value")
+        control = body.get("control")
         raw = body.get("raw")
         return cls(
             channel=str(body.get("channel") or ""),
@@ -148,6 +154,7 @@ class InboundBody:
             sender_id=str(body.get("sender_id") or ""),
             sender_name=str(body.get("sender_name") or ""),
             button_value=str(button) if button is not None else None,
+            control=str(control) if control is not None else None,
             raw=raw if isinstance(raw, dict) else None,
         )
 
@@ -165,6 +172,8 @@ class InboundBody:
             out["sender_name"] = self.sender_name
         if self.button_value is not None:
             out["button_value"] = self.button_value
+        if self.control is not None:
+            out["control"] = self.control
         if self.raw is not None:
             out["raw"] = self.raw
         return out

--- a/tests/unit/gateway/test_interrupt.py
+++ b/tests/unit/gateway/test_interrupt.py
@@ -1,0 +1,65 @@
+"""Fail-stop: an interrupt inbound preempts the in-flight prompt INLINE.
+
+If the gateway dispatched ``control="interrupt"`` as a normal detached prompt
+task (or routed it through the LLM), Esc-to-interrupt would queue behind the
+very turn it is meant to cancel — the interrupt would never land. The gateway
+must call ``AgentSession.interrupt()`` directly, off the task path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agentm.gateway.cli import _GatewayRuntime
+from agentm.gateway.peer import PeerSession
+from agentm.gateway.wire import WIRE_VERSION, Envelope
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.interrupts = 0
+
+    def interrupt(self) -> None:
+        self.interrupts += 1
+
+
+class _FakeSessions:
+    def __init__(self, sess: _FakeSession) -> None:
+        self._sess = sess
+
+    def get(self, _session_key: str) -> _FakeSession:
+        return self._sess
+
+
+def _interrupt_inbound() -> Envelope:
+    return Envelope(
+        v=WIRE_VERSION,
+        id="i1",
+        kind="inbound",
+        ts=1.0,
+        session_key="terminal:t1",
+        body={
+            "channel": "terminal",
+            "chat_id": "t1",
+            "sender_id": "u1",
+            "content": "",
+            "control": "interrupt",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_interrupt_inbound_calls_session_interrupt_and_spawns_no_task() -> None:
+    sess = _FakeSession()
+    rt = object.__new__(_GatewayRuntime)
+    rt._sessions = cast(Any, _FakeSessions(sess))
+    rt._peer_channels = {}
+    rt._inflight = set()
+
+    peer = PeerSession(peer_id="p1", transport_writer=cast(Any, None))
+    await rt.handle_inbound(peer, _interrupt_inbound())
+
+    assert sess.interrupts == 1  # preempted via AgentSession.interrupt()
+    assert rt._inflight == set()  # NOT dispatched as a detached prompt task

--- a/tests/unit/gateway/test_router.py
+++ b/tests/unit/gateway/test_router.py
@@ -13,7 +13,11 @@ from agentm.gateway.router import ProtocolError, RouterAction, dispatch
 from agentm.gateway.wire import WIRE_VERSION, Envelope
 
 
-def _inbound(content: str = "", button_value: str | None = None) -> Envelope:
+def _inbound(
+    content: str = "",
+    button_value: str | None = None,
+    control: str | None = None,
+) -> Envelope:
     body: dict[str, object] = {
         "channel": "terminal",
         "chat_id": "t1",
@@ -22,6 +26,8 @@ def _inbound(content: str = "", button_value: str | None = None) -> Envelope:
     }
     if button_value is not None:
         body["button_value"] = button_value
+    if control is not None:
+        body["control"] = control
     return Envelope(
         v=WIRE_VERSION,
         id="i1",
@@ -57,6 +63,20 @@ def test_button_value_wins_over_slash_content() -> None:
     # still resolve the approval, not run a command.
     decision = dispatch(_inbound(content="/whatever", button_value="appr-x:deny"))
     assert decision.action is RouterAction.RESOLVE_APPROVAL
+
+
+def test_control_interrupt_routes_to_interrupt() -> None:
+    decision = dispatch(_inbound(control="interrupt"))
+    assert decision.action is RouterAction.INTERRUPT
+
+
+def test_interrupt_wins_over_button_and_command() -> None:
+    # An interrupt is out-of-band: it preempts the in-flight prompt even if
+    # the frame also looks like a command or carries a stale button_value.
+    decision = dispatch(
+        _inbound(content="/help", button_value="x", control="interrupt")
+    )
+    assert decision.action is RouterAction.INTERRUPT
 
 
 def test_non_inbound_kind_raises() -> None:


### PR DESCRIPTION
## What

**Phase 3** of the terminal-TUI rebuild. Esc now preempts a running turn (Claude-Code style) via an out-of-band control inbound the gateway routes straight to `AgentSession.interrupt()` — which already exists (sets the kernel abort signal → the loop ends with `SignalAborted`, conversation context preserved, no-op when idle).

## How
- **wire** (`wire/types.py`): `InboundBody` gains an optional `control` field (additive), distinct from `content` so an interrupt can't be mistaken for a user message.
- **router** (`router.py`): new `RouterAction.INTERRUPT` when `control == "interrupt"`, checked **first** (an interrupt preempts even if the frame also looks like a command or carries a stale `button_value`).
- **gateway** (`cli.py`): `handle_inbound` dispatches `INTERRUPT` **inline** (like `RESOLVE_APPROVAL`), never as a detached prompt task — otherwise the interrupt would queue behind the very turn it cancels. `_interrupt_session()` calls `sess.interrupt()`.
- **TUI** (`frontends/tui/app.py`, `router.py`): track `_in_flight` (submit → `agent_end`); Esc sends a `control=interrupt` inbound when a turn is running, else clears the draft / toasts. `mark_idle()` clears the gate on `agent_end`.

## Tests (fail-stop)
- Router: `control=interrupt` → `INTERRUPT`, and it wins over button/command.
- Gateway: the interrupt inbound calls `AgentSession.interrupt()` **inline** and spawns **no** task.
- ui Pilot: Esc on an in-flight turn emits a `control=interrupt` inbound; an idle Esc does not.

`ruff`/`mypy` clean; gateway+contract 67 pass; ui 3 pass.

Builds on #187 (gateway streaming) + #188 (TUI). Phase 4 (command palette, history, info modals) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)