### PR TITLE
feat(tui): command palette, slash commands, info modals, /copy-last

### DIFF
--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
@@ -18,10 +18,22 @@ from textual.containers import VerticalScroll
 from textual.widgets import Footer
 
 from ...client import TerminalClient
+from .modals import CommandPalette, HelpScreen, InfoModal
 from .router import Router
-from .state import StatusModel
+from .state import Catalog, StatusModel
 from .theme import CSS_PATH, Phase, resolve_theme
 from .widgets import PromptInput, StatusBar, Toast, UserTurn
+
+# Slash commands the TUI owns (handled locally, never sent to the gateway).
+_LOCAL_COMMANDS = (
+    "/help",
+    "/clear",
+    "/copy-last",
+    "/tools",
+    "/extensions",
+    "/budget",
+    "/quit",
+)
 
 
 class AgentMTui(App[int]):
@@ -30,6 +42,7 @@ class AgentMTui(App[int]):
         Binding("ctrl+c", "interrupt_or_quit", "interrupt", priority=True, show=True),
         Binding("ctrl+d", "quit_app", "quit", priority=True, show=True),
         Binding("ctrl+l", "clear_log", "clear", show=True),
+        Binding("ctrl+r", "command_palette", "commands", show=True),
         Binding("escape", "cancel", "cancel", show=False),
     ]
 
@@ -47,9 +60,11 @@ class AgentMTui(App[int]):
         self._chat_id = chat_id
         self._theme_name = resolve_theme(theme)
         self.status = StatusModel()
+        self.catalog = Catalog()
         self._router = Router(self)
         self._consumer: asyncio.Task[None] | None = None
         self._history: list[str] = []
+        self._last_text = ""  # last assistant text, for /copy-last
         self._ctrlc_ts = 0.0
         # True from prompt-submit until the loop's agent_end; gates Esc-interrupt.
         self._in_flight = False
@@ -113,6 +128,11 @@ class AgentMTui(App[int]):
     def scroll_end(self) -> None:
         self.transcript.scroll_end(animate=False)
 
+    def note_assistant_text(self, text: str) -> None:
+        """Record the latest assistant text so /copy-last can yank it."""
+        if text.strip():
+            self._last_text = text
+
     async def send_button(self, value: str) -> None:
         await self._send(
             {
@@ -147,10 +167,12 @@ class AgentMTui(App[int]):
         inp.text = ""
         if not text:
             return
-        if text in ("/quit", "/exit", "/q"):
-            self.exit(0)
-            return
         self._history.append(text)
+        # Slash commands (not ``//path``): TUI-local ones are handled here;
+        # everything else is forwarded to the gateway's command router.
+        if text.startswith("/") and not text.startswith("//"):
+            if await self._run_slash(text):
+                return
         await self.mount_widget(UserTurn(text))
         self.scroll_end()
         self._in_flight = True
@@ -162,6 +184,38 @@ class AgentMTui(App[int]):
                 "content": text,
             }
         )
+
+    async def _run_slash(self, text: str) -> bool:
+        """Handle a TUI-local slash command. Returns True if handled here,
+        False if it should be forwarded to the gateway."""
+        name = text.split(maxsplit=1)[0]
+        if name in ("/quit", "/exit", "/q"):
+            self.exit(0)
+        elif name == "/clear":
+            await self.action_clear_log()
+        elif name == "/help":
+            await self.push_screen(HelpScreen())
+        elif name == "/copy-last":
+            self._copy_last()
+        elif name == "/tools":
+            await self.push_screen(InfoModal("tools", self.catalog.tools_text()))
+        elif name == "/extensions":
+            await self.push_screen(
+                InfoModal("extensions", self.catalog.extensions_text())
+            )
+        elif name == "/budget":
+            await self.push_screen(InfoModal("budget", self.catalog.budget_text()))
+        else:
+            return False
+        return True
+
+    def _copy_last(self) -> None:
+        if not self._last_text:
+            self.toast("nothing to copy yet")
+            return
+        # OSC 52 clipboard write — works over SSH/tmux without a clipboard dep.
+        self.copy_to_clipboard(self._last_text)
+        self.toast("copied last reply")
 
     async def _send(self, body: dict[str, object]) -> None:
         try:
@@ -177,8 +231,8 @@ class AgentMTui(App[int]):
             self.exit(0)
             return
         self._ctrlc_ts = now
-        # Interrupting an in-flight turn needs a gateway cancel affordance
-        # (Phase 3). Until then Ctrl+C only escalates to quit on double-tap.
+        # Esc is the in-flight interrupt (see action_cancel); Ctrl+C is the
+        # quit affordance — double-tap within 1.5s to confirm.
         self.toast("press Ctrl+C again within 1.5s to quit")
 
     def action_quit_app(self) -> None:
@@ -187,6 +241,30 @@ class AgentMTui(App[int]):
     async def action_clear_log(self) -> None:
         await self.transcript.remove_children()
         self._router = Router(self)  # drop active turn + tool/child registries
+
+    def action_command_palette(self) -> None:
+        commands = list(_LOCAL_COMMANDS) + [
+            c for c in self.catalog.commands if c not in _LOCAL_COMMANDS
+        ]
+        self.push_screen(CommandPalette(commands), self._on_palette_pick)
+
+    async def _on_palette_pick(self, command: str | None) -> None:
+        if not command:
+            return
+        if await self._run_slash(command):
+            return
+        # A gateway/extension command picked from the palette: echo + send.
+        await self.mount_widget(UserTurn(command))
+        self.scroll_end()
+        self._in_flight = True
+        await self._send(
+            {
+                "channel": "terminal",
+                "sender_id": self._sender_id,
+                "chat_id": self._chat_id,
+                "content": command,
+            }
+        )
 
     async def action_cancel(self) -> None:
         if self._in_flight:

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.tcss
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.tcss
@@ -102,3 +102,26 @@ Toast.-selfmod {
     border: round $warning;
     background: $warning 20%;
 }
+
+/* --- modal screens (help / info snapshots / command palette) --- */
+
+HelpScreen, InfoModal, CommandPalette {
+    align: center middle;
+}
+#help-body, #info-body, #palette {
+    width: 70%;
+    max-width: 100;
+    height: auto;
+    max-height: 80%;
+    background: $surface;
+    border: round $accent;
+    padding: 1 2;
+}
+.modal-title {
+    color: $accent;
+    text-style: bold;
+}
+#palette-list {
+    height: auto;
+    max-height: 20;
+}

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/modals.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/modals.py
@@ -1,0 +1,106 @@
+"""Modal screens: help, info snapshots (/tools /extensions /budget), and the
+command palette (Ctrl+R). See ``.claude/designs/textual-tui.md`` §5.4."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList, Static
+
+_HELP = """\
+keys
+  Enter            send                  Ctrl+J / Shift+Enter  newline
+  Esc              interrupt running turn, else clear the draft
+  Ctrl+C           interrupt (twice to quit)        Ctrl+D  quit
+  Ctrl+L           clear transcript (visual only)   Ctrl+R  command palette
+  Ctrl+E           expand/collapse a focused tool block
+
+slash commands (typed or via the palette)
+  /help  /clear  /copy-last  /tools  /extensions  /budget  /quit
+  anything else is forwarded to the gateway
+"""
+
+
+class HelpScreen(ModalScreen[None]):
+    BINDINGS = [Binding("escape,enter,space,q", "close", "close")]
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static("▎ agentm-terminal", classes="modal-title"),
+            Static(_HELP, markup=False),
+            id="help-body",
+        )
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
+class InfoModal(ModalScreen[None]):
+    """Title + body snapshot (/tools, /extensions, /budget)."""
+
+    BINDINGS = [Binding("escape,enter,space,q", "close", "close")]
+
+    def __init__(self, title: str, body: str) -> None:
+        super().__init__()
+        self._title = title
+        self._body = body
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(f"▎ {self._title}", classes="modal-title"),
+            Static(self._body, markup=False),
+            id="info-body",
+        )
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
+class CommandPalette(ModalScreen[str | None]):
+    """Filterable command picker. Dismisses with the chosen command string
+    (or ``None`` on cancel)."""
+
+    BINDINGS = [Binding("escape", "close", "cancel")]
+
+    def __init__(self, commands: Iterable[str]) -> None:
+        super().__init__()
+        self._all = list(dict.fromkeys(commands))  # dedupe, preserve order
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Input(placeholder="filter commands…", id="palette-filter"),
+            OptionList(*self._all, id="palette-list"),
+            id="palette",
+        )
+
+    def on_mount(self) -> None:
+        self.query_one("#palette-filter", Input).focus()
+
+    def _matches(self, query: str) -> list[str]:
+        q = query.strip().lower()
+        return [c for c in self._all if q in c.lower()] if q else self._all
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        ol = self.query_one("#palette-list", OptionList)
+        ol.clear_options()
+        ol.add_options(self._matches(event.value))
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Enter in the filter picks the top match.
+        matches = self._matches(event.value)
+        self.dismiss(matches[0] if matches else None)
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.prompt))
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
+__all__ = ["CommandPalette", "HelpScreen", "InfoModal"]

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/router.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/router.py
@@ -138,7 +138,9 @@ class Router:
 
     async def _assistant_text(self, body: dict, meta: dict) -> None:
         turn = await self._ensure_turn()
-        await turn.set_final_text(str(body.get("content") or ""))
+        content = str(body.get("content") or "")
+        await turn.set_final_text(content)
+        self._app.note_assistant_text(content)  # for /copy-last
         self._active = None  # the turn is complete; the next turn_start opens one
         self._app.set_phase("idle")
         self._app.scroll_end()
@@ -178,18 +180,32 @@ class Router:
 
     async def _session_ready(self, body: dict, meta: dict) -> None:
         self._app.status.model = str(meta.get("model") or self._app.status.model)
-        names = meta.get("tool_names")
-        if isinstance(names, list):
-            self._app.status.tool_count = len(names)
+        tools = meta.get("tool_names")
+        if isinstance(tools, list):
+            for t in tools:
+                self._app.catalog.add_tool(str(t))
+            self._app.status.tool_count = len(self._app.catalog.tools)
+        commands = meta.get("command_names")
+        if isinstance(commands, list):
+            for c in commands:
+                self._app.catalog.add_command(_as_slash(str(c)))
         self._app.show_status()
 
     async def _api_register(self, body: dict, meta: dict) -> None:
+        name = str(meta.get("name") or "")
         if meta.get("reg_kind") == "tool":
-            self._app.status.tool_count += 1
+            self._app.catalog.add_tool(name)
+            self._app.status.tool_count = len(self._app.catalog.tools)
             self._app.show_status()
+        elif meta.get("reg_kind") == "command":
+            self._app.catalog.add_command(_as_slash(name))
 
     async def _budget(self, body: dict, meta: dict) -> None:
         self._app.status.budget_exceeded = True
+        self._app.catalog.budget = (
+            f"exceeded: {meta.get('used')}/{meta.get('limit')} "
+            f"{meta.get('currency', '')}".strip()
+        )
         self._app.show_status()
         self._app.toast(
             f"budget exceeded: {meta.get('used')}/{meta.get('limit')} "
@@ -199,12 +215,29 @@ class Router:
 
     async def _control(self, body: dict, meta: dict) -> None:
         kind = str(meta.get("kind") or "")
+        # Record extension lifecycle into the catalog (backs /extensions),
+        # for every phase — not just the ones we toast.
+        if kind == "extension_install":
+            mod = str(meta.get("module_path") or "")
+            err = meta.get("error")
+            self._app.catalog.extensions[mod] = (
+                f"{meta.get('phase')}: {err}" if err else str(meta.get("phase") or "")
+            )
+        elif kind in ("extension_reload", "extension_unload"):
+            self._app.catalog.extensions[str(meta.get("name") or "")] = kind.split(
+                "_", 1
+            )[1]
         # Skip the noisy bootstrap install start/end; surface failures + reloads.
         if kind == "extension_install" and meta.get("phase") != "error":
             return
         text, variant = _control_summary(kind, meta)
         if text:
             self._app.toast(text, variant=variant)
+
+
+def _as_slash(name: str) -> str:
+    """Normalise a command name to its ``/name`` invocation form."""
+    return name if name.startswith("/") else f"/{name}"
 
 
 def _control_summary(kind: str, meta: dict[str, Any]) -> tuple[str, str]:

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/state.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/state.py
@@ -8,7 +8,7 @@ the status vocabulary has one home (see ``.claude/designs/textual-tui.md`` §5).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .theme import PHASE_GLYPH, Phase
 
@@ -36,4 +36,36 @@ class StatusModel:
         return "  ·  ".join(parts)
 
 
-__all__ = ["StatusModel"]
+@dataclass
+class Catalog:
+    """Running snapshot of what the runtime exposes, fed from session_ready /
+    api_register / extension_install / cost_budget_exceeded frames. Backs the
+    command palette and the /tools /extensions /budget info modals."""
+
+    tools: list[str] = field(default_factory=list)
+    commands: list[str] = field(default_factory=list)
+    # module_path -> last phase seen ("start"/"end"/"error[: msg]").
+    extensions: dict[str, str] = field(default_factory=dict)
+    budget: str | None = None  # human summary once a budget is exceeded
+
+    def add_tool(self, name: str) -> None:
+        if name and name not in self.tools:
+            self.tools.append(name)
+
+    def add_command(self, name: str) -> None:
+        if name and name not in self.commands:
+            self.commands.append(name)
+
+    def tools_text(self) -> str:
+        return "\n".join(self.tools) if self.tools else "(no tools registered yet)"
+
+    def extensions_text(self) -> str:
+        if not self.extensions:
+            return "(no extension activity observed yet)"
+        return "\n".join(f"{mod}  —  {st}" for mod, st in sorted(self.extensions.items()))
+
+    def budget_text(self) -> str:
+        return self.budget or "Budget OK (no cost_budget_exceeded seen)."
+
+
+__all__ = ["Catalog", "StatusModel"]

--- a/contrib/gateway-peers/terminal/tests/test_tui_render.py
+++ b/contrib/gateway-peers/terminal/tests/test_tui_render.py
@@ -108,3 +108,46 @@ async def test_esc_interrupts_an_in_flight_turn() -> None:
         await pilot.pause(0.1)
         after = len([b for b in client.sent if b.get("control") == "interrupt"])
         assert after == before  # idle Esc does not send another interrupt
+
+
+async def test_command_palette_lists_local_and_gateway_commands() -> None:
+    from agentm_terminal.frontends.tui.modals import CommandPalette
+
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        client.push(
+            _frame(
+                "session_ready",
+                tool_names=["bash", "read"],
+                command_names=["new", "status"],
+                model="m",
+            )
+        )
+        await pilot.pause(0.1)
+        assert app.catalog.tools == ["bash", "read"]
+        assert "/new" in app.catalog.commands and "/status" in app.catalog.commands
+
+        await pilot.press("ctrl+r")
+        await pilot.pause(0.1)
+        assert isinstance(app.screen, CommandPalette)
+        # built-ins + the gateway commands surfaced from session_ready.
+        assert "/help" in app.screen._all and "/new" in app.screen._all
+
+
+async def test_tools_slash_opens_info_modal() -> None:
+    from agentm_terminal.frontends.tui.modals import InfoModal
+
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        client.push(_frame("session_ready", tool_names=["bash"], model="m"))
+        await pilot.pause(0.1)
+        inp = app.query_one("#prompt-input")
+        inp.text = "/tools"  # type: ignore[attr-defined]
+        inp.action_submit()  # type: ignore[attr-defined]
+        await pilot.pause(0.1)
+        assert isinstance(app.screen, InfoModal)
+        assert "bash" in app.screen._body
+        # A local slash command is NOT forwarded to the gateway.
+        assert all(b.get("content") != "/tools" for b in client.sent)


### PR DESCRIPTION
## What

**Phase 4 (final)** of the terminal-TUI rebuild — the control-surface interactions on top of the live conversation (Phases 1–3).

## How
- **Command palette** (Ctrl+R): filterable picker over TUI-local commands + the gateway/extension commands surfaced from `session_ready` / `api_register`. A local command runs in-app; anything else is echoed + forwarded to the gateway.
- **Slash dispatch**: `/help` `/clear` `/copy-last` `/tools` `/extensions` `/budget` `/quit` handled in the TUI (modals/actions); other slashes forward to the gateway's command router (`//` escapes — a path, not a command).
- **Info modals** (snapshot-on-open): `/tools` `/extensions` `/budget` render a running `Catalog` fed from `session_ready` (tools/commands/model), `api_register` (live registration), `extension_install`/`reload`/`unload` (lifecycle), and `cost_budget_exceeded`.
- **/copy-last**: yanks the last assistant reply via OSC 52 (`App.copy_to_clipboard` — no clipboard dep, works over SSH/tmux).
- **HelpScreen** documents keys + commands; the `Footer` already surfaces the bindings.

`state.py` gains `Catalog`; `modals.py` adds `HelpScreen`/`InfoModal`/`CommandPalette`; `router.py` feeds the catalog + records the last assistant text.

## Tests (ui, opt-in)
The palette lists local + gateway commands after `session_ready`; `/tools` opens an `InfoModal` listing the tools and is **not** forwarded to the gateway. `ruff`/`mypy` clean; 5 ui Pilot tests pass.

## Deferred (noted)
Input history on Up/Down and `/`-at-empty-input auto-open need TextArea key interception — follow-up, not load-bearing.

Builds on #186/#187/#188/#189 — completes the rebuild plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)