### PR TITLE
feat(tui): input history, /-opens-palette, tool arg-summary, Ctrl+E

### DIFF
--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/app.py
@@ -15,7 +15,8 @@ from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
-from textual.widgets import Footer
+from textual.dom import DOMNode
+from textual.widgets import Collapsible, Footer, TextArea
 
 from ...client import TerminalClient
 from .modals import CommandPalette, HelpScreen, InfoModal
@@ -43,6 +44,7 @@ class AgentMTui(App[int]):
         Binding("ctrl+d", "quit_app", "quit", priority=True, show=True),
         Binding("ctrl+l", "clear_log", "clear", show=True),
         Binding("ctrl+r", "command_palette", "commands", show=True),
+        Binding("ctrl+e", "toggle_tool", "expand", show=True),
         Binding("escape", "cancel", "cancel", show=False),
     ]
 
@@ -64,6 +66,7 @@ class AgentMTui(App[int]):
         self._router = Router(self)
         self._consumer: asyncio.Task[None] | None = None
         self._history: list[str] = []
+        self._hist_idx = 0  # cursor into _history (== len means "fresh line")
         self._last_text = ""  # last assistant text, for /copy-last
         self._ctrlc_ts = 0.0
         # True from prompt-submit until the loop's agent_end; gates Esc-interrupt.
@@ -168,6 +171,7 @@ class AgentMTui(App[int]):
         if not text:
             return
         self._history.append(text)
+        self._hist_idx = len(self._history)  # reset history cursor to the fresh line
         # Slash commands (not ``//path``): TUI-local ones are handled here;
         # everything else is forwarded to the gateway's command router.
         if text.startswith("/") and not text.startswith("//"):
@@ -223,6 +227,30 @@ class AgentMTui(App[int]):
         except Exception:  # noqa: BLE001
             self.toast("failed to send to gateway", variant="warn")
 
+    @on(PromptInput.HistoryNav)
+    def _on_history_nav(self, msg: PromptInput.HistoryNav) -> None:
+        if not self._history:
+            return
+        inp = self.query_one("#prompt-input", PromptInput)
+        if msg.delta < 0:  # older
+            if self._hist_idx > 0:
+                self._hist_idx -= 1
+                inp.text = self._history[self._hist_idx]
+        elif self._hist_idx < len(self._history) - 1:  # newer
+            self._hist_idx += 1
+            inp.text = self._history[self._hist_idx]
+        else:  # past the newest -> back to a fresh empty line
+            self._hist_idx = len(self._history)
+            inp.text = ""
+
+    @on(TextArea.Changed, "#prompt-input")
+    def _on_input_changed(self, event: TextArea.Changed) -> None:
+        # Typing `/` on an otherwise-empty line opens the command palette
+        # (Claude-Code style) rather than inserting a literal slash.
+        if event.text_area.text == "/":
+            event.text_area.text = ""
+            self.action_command_palette()
+
     # --- bindings -------------------------------------------------------
 
     def action_interrupt_or_quit(self) -> None:
@@ -237,6 +265,15 @@ class AgentMTui(App[int]):
 
     def action_quit_app(self) -> None:
         self.exit(0)
+
+    def action_toggle_tool(self) -> None:
+        # Expand/collapse the nearest Collapsible (tool block) up from focus.
+        node: DOMNode | None = self.focused
+        while node is not None:
+            if isinstance(node, Collapsible):
+                node.collapsed = not node.collapsed
+                return
+            node = node.parent
 
     async def action_clear_log(self) -> None:
         await self.transcript.remove_children()

--- a/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/widgets.py
+++ b/contrib/gateway-peers/terminal/src/agentm_terminal/frontends/tui/widgets.py
@@ -128,16 +128,16 @@ class ToolBlock(Collapsible):
     """One tool call: title ``name ⟳/✓/✗`` + collapsible args/result body."""
 
     def __init__(self, *, name: str, args: dict[str, Any]) -> None:
-        self._name = name
+        self._label = _tool_label(name, args)  # e.g. "bash(ls -la)" / "read(README.md)"
         self._args_text = _format_args(args)
         self._body = Static(self._args_text, classes="tool-body", markup=False)
         super().__init__(
-            self._body, title=f"{name}  {TOOL_RUNNING}", collapsed=True
+            self._body, title=f"{self._label}  {TOOL_RUNNING}", collapsed=True
         )
 
     def set_result(self, *, ok: bool, content: str) -> None:
         glyph = TOOL_OK if ok else TOOL_ERROR
-        self.title = f"{self._name}  {glyph}"
+        self.title = f"{self._label}  {glyph}"
         body = f"{self._args_text}\n\n{content}" if content else self._args_text
         self._body.update(body)
         if not ok:
@@ -212,6 +212,8 @@ class PromptInput(TextArea):
     BINDINGS = [
         Binding("enter", "submit", "send", show=False, priority=True),
         Binding("ctrl+j", "newline", "newline", show=False, priority=True),
+        Binding("up", "history_prev", show=False),
+        Binding("down", "history_next", show=False),
     ]
 
     class Submitted(Message):
@@ -221,12 +223,59 @@ class PromptInput(TextArea):
             super().__init__()
             self.text = text
 
+    class HistoryNav(Message):
+        """Posted when Up/Down should browse input history (delta -1 older / +1 newer)."""
+
+        def __init__(self, delta: int) -> None:
+            super().__init__()
+            self.delta = delta
+
     def action_submit(self) -> None:
         # Bubble up; the App owns the send (it holds the wire client).
         self.post_message(self.Submitted(self.text))
 
     def action_newline(self) -> None:
         self.insert("\n")
+
+    def action_history_prev(self) -> None:
+        # On the first row, Up browses older history; otherwise move the cursor.
+        if self.cursor_location[0] == 0:
+            self.post_message(self.HistoryNav(-1))
+        else:
+            self.action_cursor_up()
+
+    def action_history_next(self) -> None:
+        # On the last row, Down browses newer history; otherwise move the cursor.
+        if self.cursor_location[0] >= self.text.count("\n"):
+            self.post_message(self.HistoryNav(1))
+        else:
+            self.action_cursor_down()
+
+
+_TOOL_SUMMARY_KEY = {
+    "bash": "command",
+    "read": "file_path",
+    "write": "file_path",
+    "edit": "file_path",
+}
+
+
+def _tool_label(name: str, args: dict[str, Any], limit: int = 48) -> str:
+    """``name(summary)`` — Claude-Code-style one-glance label. Summary is the
+    salient arg (command / file_path) or the first scalar arg value."""
+    key = _TOOL_SUMMARY_KEY.get(name.lower())
+    value: Any = args.get(key) if key else None
+    if value is None:
+        value = next(
+            (v for v in args.values() if isinstance(v, (str, int, float, bool))),
+            None,
+        )
+    if value is None:
+        return name
+    text = str(value).splitlines()[0] if isinstance(value, str) else str(value)
+    if len(text) > limit:
+        text = text[:limit] + "…"
+    return f"{name}({text})"
 
 
 def _format_args(args: dict[str, Any], limit: int = 600) -> str:

--- a/contrib/gateway-peers/terminal/tests/test_tui_render.py
+++ b/contrib/gateway-peers/terminal/tests/test_tui_render.py
@@ -151,3 +151,59 @@ async def test_tools_slash_opens_info_modal() -> None:
         assert "bash" in app.screen._body
         # A local slash command is NOT forwarded to the gateway.
         assert all(b.get("content") != "/tools" for b in client.sent)
+
+
+async def test_input_history_up_down_cycles_prior_inputs() -> None:
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        inp = app.query_one("#prompt-input")
+        for text in ("first", "second"):
+            inp.text = text  # type: ignore[attr-defined]
+            inp.action_submit()  # type: ignore[attr-defined]
+            await pilot.pause(0.05)
+        # Input is empty; Up walks back (newest first), Down walks forward.
+        await pilot.press("up")
+        await pilot.pause(0.05)
+        assert inp.text == "second"  # type: ignore[attr-defined]
+        await pilot.press("up")
+        await pilot.pause(0.05)
+        assert inp.text == "first"  # type: ignore[attr-defined]
+        await pilot.press("down")
+        await pilot.pause(0.05)
+        assert inp.text == "second"  # type: ignore[attr-defined]
+        await pilot.press("down")
+        await pilot.pause(0.05)
+        assert inp.text == ""  # type: ignore[attr-defined]
+
+
+async def test_slash_on_empty_line_opens_palette() -> None:
+    from agentm_terminal.frontends.tui.modals import CommandPalette
+
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        inp = app.query_one("#prompt-input")
+        inp.text = "/"  # type: ignore[attr-defined]  # simulate typing a slash
+        await pilot.pause(0.1)
+        assert isinstance(app.screen, CommandPalette)
+        assert inp.text == ""  # type: ignore[attr-defined]  # the slash was consumed
+
+
+async def test_tool_block_title_shows_arg_summary() -> None:
+    client = _FakeClient()
+    app = AgentMTui(client=client, sender_id="local", chat_id="terminal")
+    async with app.run_test(size=(100, 30)) as pilot:
+        client.push(_frame("turn_start", turn_id=1))
+        client.push(
+            _frame(
+                "tool_call",
+                tool_call_id="t1",
+                name="bash",
+                args={"command": "ls -la"},
+            )
+        )
+        await pilot.pause(0.15)
+        blocks = list(app.query(ToolBlock))
+        assert len(blocks) == 1
+        assert "bash(ls -la)" in str(blocks[0].title)


### PR DESCRIPTION
## What

**Phase 5 (polish)** — the deferred interactions from #190 plus Claude-Code-parity touches. TUI-only.

## How
- **Input history**: Up/Down browse prior inputs when the cursor is on the first/last row (otherwise they move the cursor, so multi-line editing stays intact). A history cursor resets on each submit.
- **`/` opens the palette**: typing `/` on an empty line opens the command palette (Claude-Code style) instead of inserting a literal slash; the slash is consumed.
- **Tool arg-summary**: tool blocks title as `name(summary)` — `bash(ls -la)`, `read(README.md)` — using the salient arg (command / file_path) or the first scalar arg, for one-glance scanning.
- **Ctrl+E** expands/collapses the nearest tool block up from focus.

## Tests (ui)
History cycles newest→oldest→back-to-empty; `/` opens the palette and clears the input; a `tool_call` renders a `name(arg)` title. `ruff`/`mypy` clean; **8** ui Pilot tests pass.

## Deferred (noted)
Auto-scroll "stick to bottom only when pinned" — a correct version needs a scroll-follow refactor; today's always-scroll is acceptable, so I left it rather than ship a fragile heuristic.

Builds on #186–#190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)