### PR TITLE
fix(loader): exempt floor atoms from scenario requires-validator

### DIFF
--- a/src/agentm/extensions/loader.py
+++ b/src/agentm/extensions/loader.py
@@ -381,6 +381,17 @@ def _parse_extensions(
     return sort_extensions_by_requires(extensions, source=source)
 
 
+# Atoms the session factory auto-mounts as floor atoms regardless of whether a
+# scenario lists them (see ``session_factory.ensure_floor_atom``). An atom may
+# ``requires`` one of these without the scenario manifest redundantly listing
+# it — requires-validation runs here on the manifest list, before the factory
+# injects the floor atoms, so a required floor atom would otherwise read as
+# "not loaded". Names match the role fulfillers' ``MANIFEST.name``.
+_FLOOR_ATOM_NAMES: frozenset[str] = frozenset(
+    {"prompt_templates", "compaction_prompts", "slash_commands", "system_prompt"}
+)
+
+
 def sort_extensions_by_requires(
     extensions: list[tuple[str, dict[str, Any]]],
     *,
@@ -413,7 +424,7 @@ def sort_extensions_by_requires(
 
     for name, manifest in manifests.items():
         for dep in manifest.requires:
-            if dep not in entries_by_name:
+            if dep not in entries_by_name and dep not in _FLOOR_ATOM_NAMES:
                 raise ScenarioLoadError(
                     source,
                     ValueError(
@@ -436,7 +447,10 @@ def sort_extensions_by_requires(
             )
         temporary.add(name)
         for dep in manifests[name].requires:
-            visit(dep)
+            # Floor-atom deps (and any dep not in this list) are mounted and
+            # ordered separately by the factory — skip them here.
+            if dep in manifests:
+                visit(dep)
         temporary.remove(name)
         permanent.add(name)
         entry = entries_by_name[name]

--- a/tests/unit/extensions/test_loader_requires.py
+++ b/tests/unit/extensions/test_loader_requires.py
@@ -1,0 +1,64 @@
+"""Fail-stop tests for ``sort_extensions_by_requires`` floor-atom handling.
+
+The scenario requires-validator runs on the manifest's own extension list,
+before the session factory injects floor atoms (compaction_prompts,
+prompt_templates, slash_commands, system_prompt). An atom that ``requires`` a
+floor atom must therefore validate WITHOUT the manifest redundantly listing
+it — otherwise the validator raises, the factory falls back to an empty load,
+and the session comes up with no Operations bundle. Regression guard for the
+gateway-breaking bug where mounting ``llm_compaction`` (which requires the
+``compaction_prompts`` floor atom) blew up scenario load.
+
+A genuinely-missing non-floor dependency must still raise.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from agentm.extensions import ExtensionManifest
+from agentm.extensions.loader import ScenarioLoadError, sort_extensions_by_requires
+
+
+def _register(module_path: str, manifest: ExtensionManifest) -> str:
+    mod = types.ModuleType(module_path)
+    mod.MANIFEST = manifest  # type: ignore[attr-defined]
+
+    def install(api: Any, config: Any) -> None:  # pragma: no cover - never called
+        return None
+
+    mod.install = install  # type: ignore[attr-defined]
+    sys.modules[module_path] = mod
+    return module_path
+
+
+def test_requires_floor_atom_without_manifest_listing_is_ok() -> None:
+    # ``llm_compaction`` requires the ``compaction_prompts`` floor atom plus
+    # ``prompt_templates``. Listing only ``prompt_templates`` must not raise —
+    # the factory auto-mounts ``compaction_prompts``.
+    result = sort_extensions_by_requires(
+        [
+            ("agentm.extensions.builtin.prompt_templates", {}),
+            ("agentm.extensions.builtin.llm_compaction", {}),
+        ]
+    )
+    modules = [m for m, _ in result]
+    assert "agentm.extensions.builtin.llm_compaction" in modules
+
+
+def test_missing_non_floor_requires_still_raises() -> None:
+    _register(
+        "_test_requirer_atom",
+        ExtensionManifest(
+            name="_test_requirer",
+            description="",
+            registers=(),
+            requires=("_test_absent_non_floor_dep",),
+        ),
+    )
+    with pytest.raises(ScenarioLoadError):
+        sort_extensions_by_requires([("_test_requirer_atom", {})])


### PR DESCRIPTION
## Problem
Mounting `llm_compaction` (which `requires=("compaction_prompts", "prompt_templates")`) broke the **chatbot scenario / gateway**:

```
RuntimeError: no atom registered Operations; the active scenario manifest must list an atom that calls api.register_operations(...)
```

Root cause: `sort_extensions_by_requires` runs inside `load_scenario` on the **manifest's** extension list — *before* the session factory injects floor atoms (`compaction_prompts`, `prompt_templates`, `slash_commands`, `system_prompt`). `compaction_prompts` is floor-auto-mounted, not manifest-listed, so the requires-presence check raised `"requires 'compaction_prompts', but … is not loaded"`. `load_scenario` then raised, the factory caught it and fell back to an **empty** `to_load` (`session_factory.py:602`), so `operations_local` never loaded → the Operations error.

`general_purpose` only avoided this via a TEMP workaround line (redundantly listing `compaction_prompts`); this PR removes that workaround and fixes it properly.

## Fix
- Exempt the known floor-atom names from the requires-presence check in `sort_extensions_by_requires`, and skip them in the topological recursion. A genuinely-missing **non-floor** dependency still raises.
- Revert the TEMP workaround in `general_purpose/manifest.yaml` (was uncommitted locally).

## Test plan
- [x] New `test_loader_requires.py`: an atom requiring a floor atom validates without listing it; a missing non-floor dep still raises.
- [x] Repro: both `general_purpose` and `chatbot` sessions now build (were FAIL on chatbot).
- [x] `ruff` + `mypy` clean; full unit suite **260 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)