### PR TITLE
fix(gateway): mount wire_driver into live sessions; diagnostic via emit_sync

### DIFF
--- a/src/agentm/core/runtime/session.py
+++ b/src/agentm/core/runtime/session.py
@@ -429,6 +429,42 @@ class AgentSession:
             raise KeyError(f"service {name!r} is already registered")
         self._services[name] = obj
 
+    def install_atom(self, name: str, config: dict[str, Any] | None = None) -> None:
+        """Mount a builtin atom into this *already-created* session.
+
+        Callable from the embedding host (not just from inside an atom). The
+        single-process gateway's ``SessionManager`` uses it to mount
+        ``wire_driver`` *after* it has injected the ``wire_outbound`` /
+        ``session_key`` / ``turn_context`` / ``approval_manager`` services
+        the atom reads — so the install cannot happen at create time.
+
+        Loads ``agentm.extensions.builtin.<name>`` and runs its
+        ``install(api, config)`` against this session's live extension scope,
+        which shares the session bus and service registry. Only sync-install
+        atoms are supported on this synchronous host path (``wire_driver``
+        is sync); an awaitable install raises rather than being silently
+        dropped.
+        """
+        import inspect
+
+        from agentm.core.runtime.extension import load_extension
+
+        if self._extension_api is None:
+            raise RuntimeError(
+                f"cannot install_atom({name!r}): session has no extension scope"
+            )
+        module_path = f"agentm.extensions.builtin.{name}"
+        result = load_extension(module_path, self._extension_api, config or {})
+        if inspect.isawaitable(result):
+            # Avoid leaking an un-awaited coroutine; the host call site (the
+            # gateway SessionManager) invokes this synchronously.
+            if hasattr(result, "close"):
+                result.close()
+            raise RuntimeError(
+                f"install_atom({name!r}) requires an async install, which the "
+                "synchronous host path does not support"
+            )
+
     @property
     def tool_renderers(self) -> dict[str, Any]:
         return {

--- a/src/agentm/extensions/builtin/wire_driver.py
+++ b/src/agentm/extensions/builtin/wire_driver.py
@@ -357,7 +357,6 @@ _ASYNC_PROJECTORS: tuple[tuple[str, Projector], ...] = (
     (TurnEndEvent.CHANNEL, _p_turn_end),
     (ChildSessionStartEvent.CHANNEL, _p_child_start),
     (ChildSessionEndEvent.CHANNEL, _p_child_end),
-    (DiagnosticEvent.CHANNEL, _p_diagnostic),
     (AgentEndEvent.CHANNEL, _p_agent_end),
 )
 
@@ -366,6 +365,10 @@ _ASYNC_PROJECTORS: tuple[tuple[str, Projector], ...] = (
 # async handler is silently skipped by ``emit_sync`` — so these schedule the
 # async sink on the running loop.
 _SYNC_PROJECTORS: tuple[tuple[str, Projector], ...] = (
+    # ``diagnostic`` can be dispatched via emit_sync (e.g. recovery-floor
+    # diagnostics), where an async handler is silently skipped — so it lives
+    # here. A sync handler is valid under both emit and emit_sync.
+    (DiagnosticEvent.CHANNEL, _p_diagnostic),
     (ExtensionInstallEvent.CHANNEL, _p_extension_install),
     (ExtensionReloadEvent.CHANNEL, _p_extension_reload),
     (ExtensionUnloadEvent.CHANNEL, _p_extension_unload),

--- a/tests/unit/gateway/test_wire_driver_atom.py
+++ b/tests/unit/gateway/test_wire_driver_atom.py
@@ -196,9 +196,12 @@ async def test_diagnostic_error_emits_outbound() -> None:
             "turn_context": {"channel": "terminal", "chat_id": "t1", "thread_id": None},
         }
     )
-    await api.handlers[DiagnosticEvent.CHANNEL][0](
-        DiagnosticEvent(level="error", source="loop", message="boom")
-    )
+    # diagnostic is a SYNC handler (it can be emit_sync-dispatched, where an
+    # async handler is silently skipped); it schedules the sink on the loop.
+    handler = api.handlers[DiagnosticEvent.CHANNEL][0]
+    assert not asyncio.iscoroutinefunction(handler)
+    handler(DiagnosticEvent(level="error", source="loop", message="boom"))
+    await asyncio.sleep(0)
     assert out[0]["metadata"]["kind"] == "diagnostic_error"
     assert out[0]["content"] == "boom"
 


### PR DESCRIPTION
Two fixes that make the single-process gateway actually work end-to-end **live** — it never did before: the `wire_driver` mount path was latent-broken and only runs *after* a session is successfully created, which earlier failures (scenario/operations) always masked.

## 1. `AgentSession.install_atom` (the real blocker)
The gateway's `SessionManager` calls `sess.install_atom("wire_driver")` **after** injecting the `wire_outbound` / `session_key` / `turn_context` / `approval_manager` services the atom reads (so it can't be installed at create time) — but `AgentSession` only had `set_service`, **no `install_atom`** (the only `install_atom` was `ExtensionAPI`'s write-to-disk self-modify path — wrong shape). This surfaced as `AttributeError: 'AgentSession' object has no attribute 'install_atom'` the first time a session was ever created successfully.

Added a host-side `install_atom(name, config=None)` that loads `agentm.extensions.builtin.<name>` via `load_extension` against the session's **live extension scope**, which shares the session bus and the `runtime.services` registry `set_service` writes to — so wire_driver's `api.get_service(...)` finds the gateway-set services and `api.on(...)` subscribes the session bus. Sync-install only (wire_driver is sync); an awaitable install raises rather than leaking an un-awaited coroutine.

## 2. `wire_driver`: `diagnostic` via `emit_sync`
Moved the `diagnostic` projector from the async to the sync handler table. `diagnostic` can be `bus.emit_sync`-dispatched (recovery-floor diagnostics), where an async handler is silently skipped — the `Async handler on channel 'diagnostic' skipped during emit_sync` warning seen in a live run. A sync handler is valid under both paths. Existing diagnostic test updated to the sync schedule-then-drain shape.

## Notes
- Verified live over `unix://` (a real prompt now streams). No dedicated `install_atom` test added (per request — manual verification); the **right** fail-stop test is a stub-provider gateway-live run that mounts wire_driver and asserts a `stream_text` frame reaches the peer (worth adding later — it's exactly what would've caught this).
- Core runtime change → handing off for review, not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)