### PR TITLE
feat(replay-fork): unify agent/harness model on config.toml + wire trigger registry

### DIFF
--- a/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
+++ b/contrib/scenarios/rca/src/agentm_rca/eval/agent.py
@@ -203,6 +203,7 @@ class AgentMAgent(BaseAgent):
         scenario: str = "rca",
         model: str | None = None,
         provider: str | None = None,
+        provider_tuple: tuple[str, dict[str, Any]] | None = None,
         exp_id: str | None = None,
         max_turns: Any = None,
         chained_fork: Any = None,
@@ -220,6 +221,9 @@ class AgentMAgent(BaseAgent):
             or os.environ.get("AGENTM_PROVIDER")
             or "anthropic"
         )
+        self._provider_tuple = provider_tuple
+        if provider_tuple is not None:
+            self._model = provider_tuple[1].get("model", self._model)
         self._exp_id = exp_id
         self._max_turns = _coerce_max_turns(max_turns, _DEFAULT_MAX_TURNS)
         self._chained_fork = _coerce_bool(chained_fork, default=False)
@@ -457,16 +461,17 @@ class AgentMAgent(BaseAgent):
         bus.on("tool_result", _on_tool_result)
         bus.on("before_send_to_llm", _on_before_llm)
 
-        # Mirror ``agentm.cli._build_provider`` so the eval adapter honors
-        # the same ``AGENTM_PROVIDER`` / ``OPENAI_*`` / ``ANTHROPIC_*``
-        # convention as ``uv run agentm``. Previously we always pinned
-        # the anthropic provider, which silently routed Doubao-Seed
-        # requests through whatever ``ANTHROPIC_BASE_URL`` happened to
-        # point at (e.g. the Kimi anthropic-compat gateway) instead of
-        # the intended ``OPENAI_BASE_URL`` LiteLLM endpoint.
-        provider_module, provider_config = _build_provider(
-            self._provider, self._model
-        )
+        # When a pre-resolved config.toml profile is available, use it
+        # directly so the agent's endpoint/key are explicit and no
+        # ambient OPENAI_*/ANTHROPIC_* env vars can bleed in.  Fall back
+        # to the legacy env-based builder for callers that still pass
+        # raw model/provider strings (e.g. rcabench-platform eval YAML).
+        if self._provider_tuple is not None:
+            provider_module, provider_config = self._provider_tuple
+        else:
+            provider_module, provider_config = _build_provider(
+                self._provider, self._model
+            )
 
         # Auto-write a distill meta sidecar so ``llmharness-distill export``
         # can pair this rollout's replay sidecar to ground truth without a
@@ -513,7 +518,7 @@ class AgentMAgent(BaseAgent):
             extra_extensions=extra_extensions,
             initial_messages=list(initial_messages or []),
             bus=bus,
-            loop_config=LoopConfig(max_turns=max_turns),
+            loop_config=LoopConfig(max_turns=max_turns, max_tool_calls_per_turn=20),
         )
 
         session = await create_agent_session(AgentSession, config)

--- a/contrib/scenarios/rca/src/agentm_rca/eval/replay_fork/cli.py
+++ b/contrib/scenarios/rca/src/agentm_rca/eval/replay_fork/cli.py
@@ -2,20 +2,18 @@
 
 Example::
 
-    # harness=glm5.1 on Ark, agent=Doubao via .env / OPENAI_* env
-    set -a; . ./.env; set +a
     uv run python -m agentm_rca.eval.replay_fork.cli run \\
         --source-exp agentm-ab100-baseline-0525-0847 \\
         --harness-model ark-glm51 \\
-        --agent-model Doubao-Seed-2.0-pro \\
+        --agent-model litellm \\
         --scenario rca:baseline \\
         --max-depth 3 \\
         --out runs/glm51-replay/results.jsonl
 
-The harness model is a ``~/.agentm/config.toml`` profile (its endpoint /
-key travel in the profile). The agent model is an id resolved against the
-ambient ``OPENAI_*`` env the way the rca eval driver builds its provider,
-so the continuation hits the same endpoint the recorded baseline did.
+Both ``--harness-model`` and ``--agent-model`` are
+``~/.agentm/config.toml`` profile names. The profile carries the
+endpoint, api_key, and model id, so no ambient ``OPENAI_*`` env vars
+are needed (or consulted).
 """
 
 from __future__ import annotations
@@ -66,11 +64,8 @@ def run(
         str, typer.Option("--harness-model", help="config.toml profile for extractor+auditor")
     ] = "ark-glm51",
     agent_model: Annotated[
-        str, typer.Option("--agent-model", help="model id for the continuation agent")
-    ] = "Doubao-Seed-2.0-pro",
-    agent_provider: Annotated[
-        str, typer.Option("--agent-provider", help="provider id for the continuation agent")
-    ] = "openai",
+        str, typer.Option("--agent-model", help="config.toml profile for the continuation agent")
+    ] = "litellm",
     scenario: Annotated[
         str, typer.Option("--scenario", help="scenario for the continuation agent")
     ] = "rca:baseline",
@@ -170,6 +165,18 @@ def run(
         typer.echo(f"# resume: skipping {len(skip_ids)} cases already in {out}")
 
     harness_provider = build_profile_provider(harness_model)
+    agent_provider = build_profile_provider(agent_model)
+
+    # -- Build trigger registry: cadence + on-submission --
+    from llmharness.audit.triggers import TriggerRegistry
+    from llmharness.extensions.trigger_cadence import _CadenceTrigger
+    from llmharness.extensions.trigger_on_submission import _OnSubmissionTrigger
+
+    trigger_registry = TriggerRegistry()
+    trigger_registry.register_trigger(_CadenceTrigger(interval=5))
+    trigger_registry.register_trigger(
+        _OnSubmissionTrigger(tool_names=frozenset({"submit_investigation", "submit_final_report"}))
+    )
 
     # -- Build the fork strategy from CLI flags --
     strategy: ForkStrategy
@@ -185,6 +192,7 @@ def run(
             max_depth=max_depth,
             sidecar_dir=sidecar_dir,
             skip_extractor=skip_extractor,
+            trigger_registry=trigger_registry,
         )
         typer.echo(
             f"# strategy: {strategy.label}\n"
@@ -192,12 +200,14 @@ def run(
             f"base_url={harness_provider[1].get('base_url')}"
         )
 
-    typer.echo(f"# agent:   provider={agent_provider} model={agent_model} scenario={scenario}")
+    typer.echo(
+        f"# agent:   {agent_provider[0]} model={agent_provider[1].get('model')} "
+        f"base_url={agent_provider[1].get('base_url')} scenario={scenario}"
+    )
 
     agent = AgentMAgent(
         scenario=scenario,
-        model=agent_model,
-        provider=agent_provider,
+        provider_tuple=agent_provider,
         max_turns=max_turns,
     )
     source: EvalDbCaseSource | SessionFileCaseSource

--- a/contrib/scenarios/rca/src/agentm_rca/eval/replay_fork/strategy.py
+++ b/contrib/scenarios/rca/src/agentm_rca/eval/replay_fork/strategy.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from agentm.core.abi.messages import AgentMessage
+from llmharness.audit.triggers import TriggerRegistry
 
 from .case_source import ReplayCase
 
@@ -169,6 +170,7 @@ class HarnessStrategy(ForkStrategy):
         cwd: str | None = None,
         sidecar_dir: str | os.PathLike[str] | None = None,
         skip_extractor: bool = False,
+        trigger_registry: TriggerRegistry | None = None,
     ) -> None:
         self._harness_provider = harness_provider
         self._max_depth = max_depth
@@ -177,6 +179,7 @@ class HarnessStrategy(ForkStrategy):
         self._cwd = cwd or os.getcwd()
         self._sidecar_dir = Path(sidecar_dir) if sidecar_dir is not None else None
         self._skip_extractor = skip_extractor
+        self._trigger_registry = trigger_registry
 
     @property
     def label(self) -> str:
@@ -237,6 +240,7 @@ class HarnessStrategy(ForkStrategy):
             max_surfaces_per_node=1,
             out_path=out_path,
             skip_extractor=self._skip_extractor,
+            trigger_registry=self._trigger_registry,
             trace_id=control_id,
         )
 


### PR DESCRIPTION
## What

Cherry-picks the one commit from `eval/rca-replay-fork` that hadn't yet
landed on `main`. The other 7 commits on that branch (pluggable trigger
system, `max_tool_calls_per_turn`, `SessionFileCaseSource`,
parent_session_id/trace_id threading) already reached `main` via separate
PRs — this closes out the branch.

Scope is the RCA replay-fork eval tooling only (3 files, +45/-26):

- `eval/agent.py`: add `provider_tuple` support so the continuation agent
  resolves its model from a `~/.agentm/config.toml` profile instead of
  ambient `OPENAI_*` env vars.
- `replay_fork/cli.py`: `--agent-model` is now a config.toml profile name
  (default `litellm`), `--agent-provider` dropped; build a `TriggerRegistry`
  (cadence + on_submission) and pass it through.
- `replay_fork/strategy.py`: thread `trigger_registry` into
  `HarnessStrategy` / `run_fork_tree_experiment`.

## Conflict resolution

`strategy.py` had a textual conflict at the `run_fork_tree_experiment(...)`
call — `main` had added `trace_id=control_id`, this commit adds
`trigger_registry=self._trigger_registry`. Both kwargs exist on the current
signature, so the resolution keeps both.

## Verification

- `ruff check` clean on the 3 files
- `mypy` clean on the 3 files
- modules import cleanly

After merge, `eval/rca-replay-fork` and its worktree can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)