### PR TITLE
verifier: first-principles hop prompt + multi-fault context + verdict-audit skill

### DIFF
--- a/.claude/skills/verdict-audit/SKILL.md
+++ b/.claude/skills/verdict-audit/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: verdict-audit
+description: >
+  Audit whether a verifier verdict (confirmed/rejected) is sound for a
+  specific service in a fault-injection case. Trigger when the user asks
+  to "check a verdict", "audit a rejection", "look at why X was
+  rejected/confirmed", or wants to understand whether the verifier got
+  it right on a particular edge. Also trigger proactively when
+  investigating discrepancies between verifier output and GT labels.
+---
+
+# verdict-audit
+
+You audit a single verifier verdict by reasoning forward from the fault
+injection — not backward from the data. The question is always: "given
+what was injected, should we expect to see degradation on this service,
+and does the data match that expectation?"
+
+## Why this order matters
+
+Looking at data first and then rationalizing invites confirmation bias.
+A flat error rate looks like "no problem" until you realize the fault
+mechanism predicts latency spikes, not errors. Starting from the
+mechanism tells you WHERE to look and WHAT to look for before you open
+any parquet file.
+
+## Method
+
+Work through these phases in order. Each phase produces a concrete
+written conclusion before moving to the next. Do not skip ahead.
+
+### Phase 1: Understand the injection
+
+Read `injection.json` from the case directory. For each injected fault,
+identify:
+
+- **Target service** and **target method/endpoint** (if applicable)
+- **Fault type** (e.g. NetworkLoss, JVMRuntimeMutator, PodFailure)
+- **Parameters** (loss percentage, mutation config, target_service for
+  directed faults, etc.)
+- **Direction** (for network faults: `to` means egress from the target
+  to a specific peer)
+
+Then read the corresponding fault kind doc at
+`contrib/scenarios/verifier/fault_kinds/<fault_kind>.md` to understand
+the mechanism. State in one paragraph: what does this fault do at the
+system level, and what observable effects does it predict?
+
+### Phase 2: Trace the expected propagation path
+
+Starting from the injection target(s), reason through the call graph:
+
+1. Which services directly call the injection target, or are called by it?
+2. For each, does the fault mechanism predict observable degradation on
+   that service? Be specific: what KIND of degradation (latency? errors?
+   functional breakage?) and through what call path?
+3. For the service under audit: is it on a plausible propagation path
+   from the injection? Through how many hops? What is the expected
+   signal?
+
+If the service under audit has no call-graph relationship to the
+injection targets, say so and note that GT may have over-labeled.
+
+Write this as a concrete prediction BEFORE looking at any trace/log
+data: "If the fault propagated to service X, I expect to see [specific
+signal] because [mechanism]."
+
+### Phase 3: Verify with data
+
+Now query the parquet files using duckdb. Load all parquet files from
+the case data directory (each `*.parquet` becomes a view named after
+its stem, e.g. `normal_traces`, `abnormal_logs`).
+
+A conclusion drawn from a single data source is not a conclusion.
+The dataset has three independent modalities — traces (spans), logs,
+and resource metrics — and a verdict must account for all of them
+before it is trustworthy. A service that looks clean in spans may
+have error logs; a service with flat latency may have spiking CPU;
+a throughput number from spans alone may contradict the log trace_id
+count. Check every modality for the signal your Phase 2 prediction
+says should exist, and report the exact numbers from each.
+
+### Phase 4: Render judgment
+
+Compare your Phase 2 prediction against Phase 3 data:
+
+- **Prediction matched**: the data shows what the mechanism predicts.
+  The verdict should be confirmed. If the verifier rejected, it missed
+  something — identify what.
+- **Prediction not matched**: the mechanism predicts degradation but the
+  data doesn't show it. Possible reasons: the fault didn't fire (method
+  never called, network rule didn't trigger), the service masked it
+  (retry, fallback, circuit breaker), or data collection missed it
+  (span gaps). The verifier's rejection may be correct.
+- **No plausible path**: the service is not on the propagation path from
+  the injection. The verifier's rejection is correct regardless of what
+  the data shows. GT likely over-labeled.
+
+State clearly: "The verifier's [verdict] is [sound / unsound] because
+[reason]."
+
+## Common traps
+
+These are patterns that have led to wrong conclusions in past audits:
+
+- **Throughput drop alone is not degradation.** Fewer requests arriving
+  at a service means callers stopped calling — that's the caller's
+  problem. This includes the case where traffic drops to zero: if the
+  business flow's prerequisite steps were blocked (e.g. you can't
+  preserve a ticket if route queries failed), downstream services
+  naturally receive no requests. That is business-flow interruption,
+  not cascade failure of the downstream service.
+
+- **"Thread pool exhaustion" is speculation without evidence.** Don't
+  claim a caller's threads are exhausted unless you can show it in the
+  data (e.g. the caller's OWN latency spiked for ALL endpoints, not
+  just the affected one, and its request queue backed up).
+
+- **Load generator behavior is irrelevant.** The load generator is
+  external test tooling, not part of the microservice system. Its
+  throughput drop doesn't prove cascade failure within the system.
+
+- **GT is not ground truth.** GT labels are generated by a separate
+  process that may over-label (marking services as "propagated" when
+  they merely received fewer requests). A verifier rejection that
+  contradicts GT is not automatically wrong.
+
+- **JVMRuntimeMutator is silent.** URL mutations cause no errors on the
+  target itself (404 returns fast, target looks healthy). The signal is
+  on the call path: the downstream that should have received the
+  request didn't, or received a malformed one.
+
+## Input
+
+The user provides:
+- A case directory (with parquet files, injection.json, causal_graph.json)
+- A verifier run directory (with all_verdicts.json, report.json)
+- Optionally, a specific service to audit
+
+If no specific service is given, pick the most interesting discrepancy
+(GT says propagated, verifier says rejected) and audit that.

--- a/contrib/scenarios/verifier/README.md
+++ b/contrib/scenarios/verifier/README.md
@@ -132,37 +132,6 @@ These are discrepancies to investigate, not accuracy metrics. Do NOT
 compute precision/recall treating GT as ground truth — the whole point
 is that GT may be wrong.
 
-### Adjudicating who is right (raw-data oracle)
-
-Because GT is unreliable (it marks throughput-drops as
-`degraded`/`unavailable`), neither GT nor GT-matching can score the
-verifier. Adjudicate each discrepancy directly from the raw data:
-classify a service's abnormal-vs-normal signature into
-`ERROR` (error RATE up, logs + 4xx/5xx) / `SLOW` (p95 **or** p99 up by
-a large absolute amount) / `DOWN` (active→silent, ambiguous) /
-`THROUGHPUT` (fewer spans, latency & error flat → not degraded) /
-`FLAT`. Then:
-
-- verifier confirms a `THROUGHPUT`/`FLAT` service → false positive;
-- verifier rejects an `ERROR`/`SLOW` service → miss;
-- GT has a `THROUGHPUT`/`FLAT` service the verifier dropped → GT
-  over-label the verifier correctly fixed;
-- verifier has an `ERROR`/`SLOW` service GT lacks → GT under-label the
-  verifier correctly found.
-
-Across all 500 ops-lite-clean cases (Doubao Seed 2.0 pro), this lifts
-confirmation precision from **0.39 → 0.95** (false positives 1656 → 49)
-and cuts verifier-vs-GT false positives from **1399 → 13**. The verifier
-**corrects GT on 974 services** (863 over-labels GT marked degraded that
-are actually throughput/flat, + 111 under-labels GT missed) while being
-wrong on 117 (13 false positives + 104 misses) — an ~8:1 correct-to-wrong
-ratio against GT. The remaining gap is recall (0.84 → 0.77): the stricter
-verifier trades a little coverage for trustworthiness (when V3 claimed
-"GT missed this" it was right ~16% of the time; V5 is right ~90%). Note
-the oracle must check **p99**, not just p95: several genuine degradations
-are tail-only (a fraction of requests hit timeouts while p95 is flat).
-Reproduce with `audit <dataset> --run-dir <run>`.
-
 ## Known limitations
 
 - **Infra sinks:** Confirmed infra nodes (mysql, redis, etc.) do not

--- a/contrib/scenarios/verifier/eval/audit_case_propagate.py
+++ b/contrib/scenarios/verifier/eval/audit_case_propagate.py
@@ -297,14 +297,35 @@ def check_node_degraded(data_dir: Path, node_name: str) -> bool:
     return False
 
 
+# engine_config keys that describe WHERE/WHEN, not the fault's intensity.
+# Everything else (corrupt %, loss %, delay, mutator_config, method, …) is
+# the strength the hop agent needs to judge how much impact to expect.
+_FAULT_BOILERPLATE = {
+    "app", "chaos_type", "namespace", "system", "system_type",
+    "time_offset", "duration",
+}
+
+
+def _fault_params(entry: dict) -> str:
+    """Render one engine_config entry's intensity/config as ``k=v, …``."""
+    return ", ".join(
+        f"{k}={v}" for k, v in entry.items()
+        if k not in _FAULT_BOILERPLATE and v not in (None, "")
+    )
+
+
 def get_injections(data_dir: Path) -> list[dict[str, str]]:
-    """Extract ``[{target, chaos_type}]`` from injection.json."""
+    """Extract ``[{target, chaos_type, params}]`` from injection.json."""
     injection = json.loads((data_dir / "injection.json").read_text())
 
     eng = injection.get("engine_config")
     if isinstance(eng, list) and eng and isinstance(eng[0], dict):
         return [
-            {"target": e["app"], "chaos_type": e.get("chaos_type", "unknown")}
+            {
+                "target": e["app"],
+                "chaos_type": e.get("chaos_type", "unknown"),
+                "params": _fault_params(e),
+            }
             for e in eng
         ]
 
@@ -344,7 +365,7 @@ def get_injections(data_dir: Path) -> list[dict[str, str]]:
         ).value)
     except Exception:
         pass
-    return [{"target": target, "chaos_type": chaos_type}]
+    return [{"target": target, "chaos_type": chaos_type, "params": ""}]
 
 
 def get_target_evidence(data_dir: Path, target: str) -> dict[str, object]:
@@ -431,6 +452,39 @@ _REL_DESCRIPTIONS = {
                         "(database/cache/broker). {to} is uninstrumented: it "
                         "has NO spans of its own — its calls live inside {frm}.",
 }
+
+
+def _fault_context(
+    all_faults: list[tuple[str, str, str]],
+    to_service: str,
+) -> str:
+    """One line for a single fault; a list, with params, when several coexist.
+
+    Two things the hop needs that a bare fault name omits:
+    - **Intensity.** ``corrupt=36`` vs ``corrupt=5`` predict very
+      different blast radii; the params come straight from the
+      injection so the agent can judge how much impact to expect.
+    - **Every coexisting fault.** A node can sit downstream of more
+      than one, each with its own fingerprint (a corruption/loss
+      fault in the latency tail, a data fault in errors). Faults are
+      listed flat with no "primary" — singling one out makes the
+      agent look only for that one's signal and miss the rest.
+    """
+    if len(all_faults) <= 1:
+        fk, tgt, params = all_faults[0]
+        suffix = f" ({params})" if params else ""
+        return f"Fault injected: {fk} on {tgt}{suffix}"
+    lines = [f"Faults injected in this system ({len(all_faults)}):"]
+    for fk, tgt, params in all_faults:
+        suffix = f" ({params})" if params else ""
+        lines.append(f"- {fk} on {tgt}{suffix}")
+    lines.append(
+        f"\n{to_service} may sit downstream of any of these. Each fault's "
+        f"category and intensity predicts a specific fingerprint — read "
+        f"each fault reference below and check for the signal it predicts. "
+        f"Do not assume a single fault is responsible."
+    )
+    return "\n".join(lines)
 
 
 def extract_hop_verdict(
@@ -530,14 +584,23 @@ def run_hop(
     to_service: str,
     rel_type: str,
     fault_kind: str,
-    fault_doc: str,
     injection_target: str,
+    all_faults: list[tuple[str, str, str]],
+    fault_docs: dict[str, str],
     out_dir: Path,
     budget: int,
     is_infra: bool = False,
     upstream_evidence: dict | None = None,
 ) -> dict | None:
-    """Run one hop-agent and return its verdict dict (or None)."""
+    """Run one hop-agent and return its verdict dict (or None).
+
+    *all_faults* is every injected fault as ``(kind, target, params)``;
+    *fault_docs* maps each kind to its reference doc. *fault_kind*/
+    *injection_target* name the fault this edge's BFS branch descended
+    from — used only to order the docs (that fault's reference first);
+    the prompt itself lists every fault flat, since a node downstream of
+    two coexisting faults must be judged against all of them.
+    """
     hop_dir = out_dir / "hops" / f"{from_service}__{to_service}"
     hop_dir.mkdir(parents=True, exist_ok=True)
 
@@ -548,7 +611,7 @@ def run_hop(
         f"Confirmed degraded: **{from_service}**",
         f"Service to check: **{to_service}**",
         f"Relationship: {rel_text}",
-        f"Fault injected: {fault_kind} on {injection_target}",
+        _fault_context(all_faults, to_service),
     ]
     if upstream_evidence:
         ev_text = _format_upstream_evidence(upstream_evidence)
@@ -561,8 +624,16 @@ def run_hop(
                 f"The propagation may manifest differently on the "
                 f"downstream (e.g. errors vs latency vs missing spans)."
             )
-    if fault_doc:
-        parts.append(f"\n## Fault reference ({fault_kind})\n{fault_doc}")
+    # Show every injected fault's doc (primary first, deduped by kind).
+    shown: set[str] = set()
+    ordered = [fault_kind] + [fk for fk, _, _ in all_faults if fk != fault_kind]
+    for fk in ordered:
+        if fk in shown:
+            continue
+        shown.add(fk)
+        doc = fault_docs.get(fk)
+        if doc:
+            parts.append(f"\n## Fault reference ({fk})\n{doc}")
     if is_infra:
         parts.append(
             f"\n## {to_service} is an uninstrumented backing component\n"
@@ -651,7 +722,6 @@ def propagate(
     data_dir: Path,
     injections: list[dict[str, str]],
     neighbor_graph: dict[str, list[tuple[str, str, int]]],
-    fault_doc: str,
     out_dir: Path,
     *,
     budget: int,
@@ -676,6 +746,16 @@ def propagate(
 
     fault_kind = injections[0]["chaos_type"] if injections else "unknown"
     inj_target = injections[0]["target"] if injections else "unknown"
+
+    # The full fault set, handed to every hop. A node downstream of two
+    # coexisting faults must be judged against both — the per-branch
+    # inherited fault below is only a "which seed reached me" hint.
+    all_faults = [
+        (inj["chaos_type"], inj["target"], inj.get("params", ""))
+        for inj in injections
+        if inj.get("target") and inj["target"] not in SYNTHETIC
+    ]
+    fault_docs = {fk: _load_fault_doc(fk) for fk, _, _ in all_faults}
 
     # Per-branch fault context: each node carries the (fault_kind, target)
     # of the seed it descends from, so a hop reached from the NetworkLoss
@@ -774,11 +854,11 @@ def propagate(
                     hop_fk, hop_target = node_fault.get(
                         from_svc, (fault_kind, inj_target)
                     )
-                    hop_doc = _load_fault_doc(hop_fk) or fault_doc
                     fut = pool.submit(
                         run_hop, data_dir,
                         from_svc, to_svc, rel_type,
-                        hop_fk, hop_doc, hop_target,
+                        hop_fk, hop_target,
+                        all_faults, fault_docs,
                         out_dir, budget,
                         to_svc in infra_nodes,
                         node_evidence.get(from_svc),
@@ -921,9 +1001,6 @@ def run_one_case(
     if not injections:
         return {"case": case_name, "error": "no injections"}
 
-    fault_kind = injections[0]["chaos_type"]
-    fault_doc = _load_fault_doc(fault_kind)
-
     rels = get_relationships(data_dir)
     infra_nodes = get_infra_nodes(data_dir)
     rels.extend(get_infra_edges(data_dir, infra_nodes))
@@ -936,14 +1013,16 @@ def run_one_case(
 
     total_edges = sum(len(v) for v in neighbor_graph.values())
     print(f"Injections: {[(i['target'], i['chaos_type']) for i in injections]}")
-    print(f"Fault doc: {'loaded' if fault_doc else 'not found'} "
-          f"({fault_kind})")
+    for inj in injections:
+        fk = inj["chaos_type"]
+        loaded = "loaded" if _load_fault_doc(fk) else "not found"
+        print(f"Fault doc: {loaded} ({fk})")
     print(f"Relationship graph: {total_edges} directed edges "
           f"({len(neighbor_graph)} services)")
     print(f"Infra nodes (metrics-only): {sorted(infra_nodes)}")
 
     result = propagate(
-        data_dir, injections, neighbor_graph, fault_doc, out,
+        data_dir, injections, neighbor_graph, out,
         budget=budget, parallel=parallel,
         infra_nodes=infra_nodes, node_map=node_map,
     )
@@ -972,7 +1051,9 @@ def run_one_case(
 
     return {
         "case": case_name,
-        "fault_kind": fault_kind,
+        "fault_kind": "+".join(
+            dict.fromkeys(i["chaos_type"] for i in injections)
+        ),
         "seeds": seeds,
         "confirmed": confirmed,
         "propagated": propagated,
@@ -999,8 +1080,9 @@ def _read_cached_summary(out_dir: Path, case_name: str) -> dict | None:
     confirmed = trace.get("confirmed_nodes", [])
     return {
         "case": case_name,
-        "fault_kind": report["injections"][0]["fault_kind"]
-        if report.get("injections") else "unknown",
+        "fault_kind": "+".join(
+            dict.fromkeys(i["fault_kind"] for i in report.get("injections", []))
+        ) or "unknown",
         "seeds": seeds,
         "confirmed": confirmed,
         "propagated": [s for s in confirmed if s not in seeds],

--- a/contrib/scenarios/verifier/eval/audit_case_propagate.py
+++ b/contrib/scenarios/verifier/eval/audit_case_propagate.py
@@ -82,7 +82,7 @@ def get_relationships(data_dir: Path) -> list[Rel]:
         "JOIN all_traces parent "
         "  ON child.parent_span_id = parent.span_id "
         "WHERE child.service_name <> parent.service_name "
-        "GROUP BY 1, 2 HAVING COUNT(*) >= 5 "
+        "GROUP BY 1, 2 "
         "ORDER BY cnt DESC"
     ).fetchall()
     for caller, callee, cnt in rows:
@@ -1055,6 +1055,7 @@ def run_batch(
     case_parallel: int = 1,
     limit: int | None = None,
     offset: int = 0,
+    case_filter: set[str] | None = None,
 ) -> list[dict]:
     """Run propagation on multiple cases under *dataset_dir*.
 
@@ -1064,6 +1065,8 @@ def run_batch(
     suitable for diff/analysis across ablation runs.
     """
     cases = sorted(p.name for p in dataset_dir.iterdir() if p.is_dir())
+    if case_filter is not None:
+        cases = [c for c in cases if c in case_filter]
     cases = cases[offset:]
     if limit is not None:
         cases = cases[:limit]
@@ -1153,14 +1156,19 @@ def batch(
     model: Annotated[str | None, typer.Option(help="config.toml profile name")] = None,
     limit: Annotated[int | None, typer.Option(help="max cases to run")] = None,
     offset: Annotated[int, typer.Option(help="skip first N cases")] = 0,
+    cases_file: Annotated[Path | None, typer.Option("--cases-file", help="text file with one case name per line")] = None,
 ) -> None:
     """Run propagation on all cases in a dataset."""
     _set_model(model)
+    case_filter = None
+    if cases_file is not None:
+        case_filter = set(cases_file.read_text().strip().splitlines())
     run_batch(
         dataset_dir.resolve(), run_dir.resolve(),
         budget=budget, parallel=parallel,
         case_parallel=case_parallel,
         limit=limit, offset=offset,
+        case_filter=case_filter,
     )
 
 
@@ -1588,264 +1596,119 @@ def _gt_services(case_dir: Path) -> tuple[set[str], set[str]]:
 def diff(
     dataset_dir: Annotated[Path, typer.Argument(help="dataset with GT labels")],
     run_dir: Annotated[Path, typer.Option("--run-dir", help="verifier run output")],
+    format: Annotated[str, typer.Option(help="table or ndjson")] = "table",
 ) -> None:
-    """Compare verifier findings against GT labels."""
-    summary_path = run_dir / "run_summary.jsonl"
-    if not summary_path.exists():
-        typer.echo("No run_summary.jsonl found — run batch first.")
-        raise typer.Exit(1)
+    """Compare verifier graph against GT per case.
 
-    with open(summary_path) as f:
-        cases = [json.loads(line) for line in f]
+    For each case, classifies every service into one of:
+      agree      — both verifier and GT have it
+      v_only     — verifier confirmed, GT lacks
+      rejected   — GT has it, hop agent evaluated and rejected
+      unreachable — GT has it, verifier never evaluated (not in BFS neighborhood)
 
-    total = new_total = missed_total = match_total = 0
-    diff_rows: list[dict] = []
-
-    for s in cases:
-        name = s["case"]
-        if "error" in s:
-            continue
-        total += 1
-        case_dir = dataset_dir / name
-        gt_inj, gt_prop = _gt_services(case_dir)
-        v_seeds = set(s.get("seeds", []))
-        v_prop = set(s.get("propagated", []))
-
-        new_finds = v_prop - gt_prop - v_seeds
-        missed = gt_prop - v_prop
-
-        row = {
-            "case": name,
-            "gt_inj": sorted(gt_inj), "gt_prop": sorted(gt_prop),
-            "v_seeds": sorted(v_seeds), "v_prop": sorted(v_prop),
-            "new": sorted(new_finds), "missed": sorted(missed),
-        }
-        diff_rows.append(row)
-
-        tag = "MATCH" if (not new_finds and not missed) else ""
-        if new_finds:
-            new_total += len(new_finds)
-            tag = f"NEW +{len(new_finds)}"
-        if missed:
-            missed_total += len(missed)
-            tag += f"  MISSED -{len(missed)}"
-        if not new_finds and not missed:
-            match_total += 1
-
-        typer.echo(f"{name}  {tag}")
-        if new_finds:
-            typer.echo(f"  new:    {sorted(new_finds)}")
-        if missed:
-            typer.echo(f"  missed: {sorted(missed)}")
-
-    typer.echo(f"\n{'='*50}")
-    typer.echo(f"Cases: {total}  Match: {match_total}  "
-               f"New findings: {new_total}  Missed: {missed_total}")
-
-    diff_path = run_dir / "gt_diff.jsonl"
-    with open(diff_path, "w") as f:
-        for row in diff_rows:
-            f.write(json.dumps(row, ensure_ascii=False) + "\n")
-    typer.echo(f"Diff: {diff_path}")
-
-
-# ------------------------------------------------------------------
-# Raw-data oracle — adjudicates verifier vs GT from traces/logs/metrics
-#
-# GT's `state` field is unreliable (it marks throughput-drops as
-# degraded/unavailable), so neither GT nor GT-matching can score the
-# verifier. This oracle classifies each service's abnormal-vs-normal
-# signature directly and is used only as a measurement yardstick — it is
-# NOT part of the verifier runtime (keeping the agent's reasoning and the
-# soundness metric independent).
-# ------------------------------------------------------------------
-
-_ORACLE_NS_MS = 1e6
-_SLOW_FLOOR = 50 * _ORACLE_NS_MS      # 50ms absolute p95 increase floor
-_SLOW_STRONG = 200 * _ORACLE_NS_MS    # 200ms = high-confidence slow
-_ERR_DELTA = 0.05                     # +5 percentage points error rate
-_INFRA_RE = re.compile(
-    r"mysql|mariadb|postgres|redis|mongo|rabbitmq|kafka|memcached|"
-    r"nacos|elasticsearch|zookeeper|consul|etcd", re.I,
-)
-_DEGRADED = {"ERROR", "SLOW", "INFRA_DEGRADED"}
-_NOT_DEGRADED = {"THROUGHPUT", "FLAT", "INFRA_HEALTHY"}
-
-
-def _oracle_sig(conn, svc: str) -> dict:  # noqa: ANN001
-    sig: dict = {}
-    for w in ("normal", "abnormal"):
-        try:
-            r = conn.execute(
-                f"SELECT COUNT(*), quantile_cont(duration,0.95), "
-                f"quantile_cont(duration,0.99), "
-                f"SUM(CASE WHEN \"attr.status_code\"='STATUS_CODE_ERROR' "
-                f"  OR TRY_CAST(\"attr.http.response.status_code\" AS INT)>=500 "
-                f"  THEN 1 ELSE 0 END) "
-                f"FROM {w}_traces WHERE service_name=?", [svc]).fetchone()
-        except Exception:  # noqa: BLE001
-            r = (0, None, None, 0)
-        try:
-            lr = conn.execute(
-                f"SELECT COUNT(*), SUM(CASE WHEN level='ERROR' THEN 1 ELSE 0 END) "
-                f"FROM {w}_logs WHERE service_name=?", [svc]).fetchone()
-        except Exception:  # noqa: BLE001
-            lr = (0, 0)
-        sig[w] = {
-            "spans": r[0] or 0, "p95": r[1], "p99": r[2],
-            "err_spans": r[3] or 0, "logs": lr[0] or 0, "err_logs": lr[1] or 0,
-        }
-    return sig
-
-
-def _oracle_infra_degraded(conn, svc: str) -> bool:  # noqa: ANN001
-    try:
-        rows = conn.execute(
-            "SELECT 'n', AVG(CASE WHEN metric_name LIKE '%cpu%' THEN value END), "
-            "  AVG(CASE WHEN metric_name LIKE '%memory%' THEN value END) "
-            "FROM normal_metrics WHERE service_name=? "
-            "UNION ALL "
-            "SELECT 'a', AVG(CASE WHEN metric_name LIKE '%cpu%' THEN value END), "
-            "  AVG(CASE WHEN metric_name LIKE '%memory%' THEN value END) "
-            "FROM abnormal_metrics WHERE service_name=?", [svc, svc]).fetchall()
-        if len(rows) == 2:
-            nc, nm, ac, am = rows[0][1], rows[0][2], rows[1][1], rows[1][2]
-            if nc and ac and ac > nc * 1.3:
-                return True
-            if nm and am and am > nm * 1.3:
-                return True
-    except Exception:  # noqa: BLE001
-        pass
-    return False
-
-
-def oracle_classify(conn, svc: str) -> str:  # noqa: ANN001
-    """Label one service ERROR/SLOW/DOWN/THROUGHPUT/FLAT/INFRA_* from data."""
-    if _INFRA_RE.search(svc):
-        return "INFRA_DEGRADED" if _oracle_infra_degraded(conn, svc) \
-            else "INFRA_HEALTHY"
-    s = _oracle_sig(conn, svc)
-    n, a = s["normal"], s["abnormal"]
-    n_er = (n["err_logs"] / n["logs"]) if n["logs"] else 0.0
-    a_er = (a["err_logs"] / a["logs"]) if a["logs"] else 0.0
-    n_se = (n["err_spans"] / n["spans"]) if n["spans"] else 0.0
-    a_se = (a["err_spans"] / a["spans"]) if a["spans"] else 0.0
-
-    # Small-sample guard: <20 abnormal spans makes per-span stats noise.
-    if a["spans"] < 20:
-        if n["spans"] >= 50 and a["spans"] < n["spans"] * 0.5:
-            return "DOWN"
-        if a_er - n_er > _ERR_DELTA and a_er > 0.05 and a["logs"] >= 50:
-            return "ERROR"
-        return "FLAT"
-    if (a_er - n_er > _ERR_DELTA and a_er > 0.05) or \
-       (a_se - n_se > _ERR_DELTA and a_se > 0.05):
-        return "ERROR"
-    if n["spans"] >= 50 and a["spans"] < max(5, n["spans"] * 0.02):
-        return "DOWN"
-    if n["p95"] and a["p95"]:
-        d = a["p95"] - n["p95"]
-        if (d > _SLOW_STRONG and a["p95"] > n["p95"] * 1.3) or \
-           (d > _SLOW_FLOOR and a["p95"] > n["p95"] * 1.5):
-            return "SLOW"
-    if n["p99"] and a["p99"] and a["p99"] > n["p99"] * 2 \
-            and a["p99"] - n["p99"] > _SLOW_STRONG and a["p99"] > 500 * _ORACLE_NS_MS:
-        return "SLOW"  # tail: a fraction of requests very slow even if p95 flat
-    if n["spans"] and a["spans"] < n["spans"] * 0.8:
-        if not a["p95"] or not n["p95"] or a["p95"] <= n["p95"] * 1.2:
-            return "THROUGHPUT"
-    return "FLAT"
-
-
-@app.command()
-def audit(
-    dataset_dir: Annotated[Path, typer.Argument(help="dataset with GT labels")],
-    run_dir: Annotated[Path, typer.Option("--run-dir", help="verifier run output")],
-) -> None:
-    """Score the verifier graph for SOUNDNESS against the raw-data oracle.
-
-    Reports confirmation precision / recall (oracle = arbiter, not GT) and
-    a verifier-vs-GT adjudication: on how many services the verifier
-    corrects GT (over/under-labels) vs is itself wrong.
+    Outputs per-case JSONL to <run-dir>/gt_diff.jsonl and prints a summary.
     """
-    import duckdb  # noqa: F401  (ensures the dep is present)
-
     cases = sorted(
         p.name for p in run_dir.iterdir()
         if p.is_dir() and (p / "final_propagation.json").exists()
     )
+
     agg: dict[str, int] = defaultdict(int)
+    svc_agg: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     rows: list[dict] = []
+
     for name in cases:
         cdir = dataset_dir / name
-        if not (cdir / "causal_graph.json").exists():
+        if not cdir.exists():
             continue
         fp = json.loads((run_dir / name / "final_propagation.json").read_text())
         seeds = set(fp.get("seeds", []))
-        ver = set(fp.get("propagated", []))
-        gt_seeds, gt = _gt_services(cdir)
+        v_prop = set(fp.get("propagated", []))
+
+        gt_seeds, gt_prop = _gt_services(cdir)
         seeds |= gt_seeds
-        gt -= seeds
-        ver -= seeds
-        # hop-rejected = every hop target not in the final set
-        rejected: set[str] = set()
+
+        evaluated: set[str] = set()
         avp = run_dir / name / "all_verdicts.json"
         if avp.exists():
-            rejected = {v["to"] for v in json.loads(avp.read_text())}
-        rejected -= ver | seeds
+            evaluated = {v["to"] for v in json.loads(avp.read_text())}
 
-        conn = _duckdb_conn(cdir.resolve())
-        labels = {s: oracle_classify(conn, s) for s in (ver | gt | rejected)}
-        conn.close()
+        agree = v_prop & gt_prop
+        v_only = v_prop - gt_prop
+        gt_only = gt_prop - v_prop
+        rejected = gt_only & evaluated
+        unreachable = gt_only - evaluated
 
-        for s in ver:
-            L = labels[s]
-            agg["TP" if L in _DEGRADED else
-                ("conf_DOWN" if L == "DOWN" else "FP")] += 1
+        row: dict = {
+            "case": name,
+            "seeds": sorted(seeds),
+            "agree": sorted(agree),
+            "v_only": sorted(v_only),
+            "rejected": sorted(rejected),
+            "unreachable": sorted(unreachable),
+        }
+        rows.append(row)
+
+        agg["cases"] += 1
+        agg["agree"] += len(agree)
+        agg["v_only"] += len(v_only)
+        agg["rejected"] += len(rejected)
+        agg["unreachable"] += len(unreachable)
+        if not v_only and not rejected and not unreachable:
+            agg["exact_match"] += 1
+
         for s in rejected:
-            L = labels[s]
-            agg["FN" if L in _DEGRADED else
-                ("rej_DOWN" if L == "DOWN" else "TN")] += 1
-        for s in (ver | gt):
-            L = labels[s]
-            inv, ing = s in ver, s in gt
-            if L == "DOWN":
-                continue
-            deg = L in _DEGRADED
-            if inv and not ing and deg:
-                agg["fix_gt_underlabel"] += 1
-            elif inv and not ing and not deg:
-                agg["verifier_FP"] += 1
-            elif ing and not inv and not deg:
-                agg["fix_gt_overlabel"] += 1
-            elif ing and not inv and deg:
-                agg["verifier_miss"] += 1
-        rows.append({"case": name,
-                     "verifier": sorted(ver), "gt": sorted(gt),
-                     "labels": labels})
+            svc_agg[s]["rejected"] += 1
+        for s in unreachable:
+            svc_agg[s]["unreachable"] += 1
+        for s in v_only:
+            svc_agg[s]["v_only"] += 1
 
-    tp, fp_, fn = agg["TP"], agg["FP"], agg["FN"]
-    prec = tp / (tp + fp_) if (tp + fp_) else 0.0
-    rec = tp / (tp + fn) if (tp + fn) else 0.0
-    typer.echo(f"\nCases: {len(rows)}   (oracle = arbiter, GT is NOT truth)")
-    typer.echo(f"Confirmations: TP={tp} FP={fp_} DOWN={agg['conf_DOWN']}  "
-               f"precision={prec:.3f}")
-    typer.echo(f"Rejections:    FN={fn} TN={agg['TN']} DOWN={agg['rej_DOWN']}  "
-               f"recall={rec:.3f}")
-    typer.echo("\nVerifier vs GT (oracle-arbitrated):")
-    typer.echo(f"  corrects GT over-label (GT had non-degraded): "
-               f"{agg['fix_gt_overlabel']}")
-    typer.echo(f"  corrects GT under-label (GT missed degraded): "
-               f"{agg['fix_gt_underlabel']}")
-    typer.echo(f"  verifier miss (GT right, verifier wrong):     "
-               f"{agg['verifier_miss']}")
-    typer.echo(f"  verifier false positive:                      "
-               f"{agg['verifier_FP']}")
-    out = run_dir / "audit.jsonl"
-    with open(out, "w") as f:
+    diff_path = run_dir / "gt_diff.jsonl"
+    with open(diff_path, "w") as f:
         for row in rows:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
-    typer.echo(f"\nPer-service labels: {out}")
+
+    if format == "ndjson":
+        for row in rows:
+            typer.echo(json.dumps(row, ensure_ascii=False))
+        return
+
+    has_diff = [r for r in rows
+                if r["v_only"] or r["rejected"] or r["unreachable"]]
+    for r in has_diff:
+        parts = []
+        if r["rejected"]:
+            parts.append(f"rejected={r['rejected']}")
+        if r["unreachable"]:
+            parts.append(f"unreachable={r['unreachable']}")
+        if r["v_only"]:
+            parts.append(f"v_only={r['v_only']}")
+        typer.echo(f"{r['case']}  {', '.join(parts)}")
+
+    typer.echo(f"\n{'=' * 60}")
+    typer.echo(f"Cases: {agg['cases']}  Exact match: {agg['exact_match']}")
+    typer.echo(f"Services — agree: {agg['agree']}  v_only: {agg['v_only']}  "
+               f"rejected: {agg['rejected']}  unreachable: {agg['unreachable']}")
+
+    top_rejected = sorted(
+        ((s, c["rejected"]) for s, c in svc_agg.items() if c.get("rejected")),
+        key=lambda x: -x[1],
+    )
+    top_unreachable = sorted(
+        ((s, c["unreachable"]) for s, c in svc_agg.items() if c.get("unreachable")),
+        key=lambda x: -x[1],
+    )
+    if top_rejected:
+        typer.echo("\nTop rejected (GT has, hop agent rejected):")
+        for s, n in top_rejected[:15]:
+            typer.echo(f"  {s}: {n}")
+    if top_unreachable:
+        typer.echo("\nTop unreachable (GT has, BFS never reached):")
+        for s, n in top_unreachable[:15]:
+            typer.echo(f"  {s}: {n}")
+
+    typer.echo(f"\nPer-case diff: {diff_path}")
 
 
 if __name__ == "__main__":

--- a/contrib/scenarios/verifier/fault_kinds/jvm_jdbc_exception.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_jdbc_exception.md
@@ -11,6 +11,13 @@ shows no anomalies of its own (no elevated latency, no error
 codes returned from the DB). Target's inbound spans may fail or
 succeed depending on whether the failed DB call is recoverable.
 
+## How to observe on a neighbour
+Every endpoint on the target that hits the DB path can fail, so
+the signal is broader than single-method faults. On a caller,
+check both service aggregate and per-`span_name` error rates —
+endpoints that avoid the target's DB-backed responses will be
+unaffected.
+
 ## How the failure tends to propagate
 In-pod fault — target (the JVM service) is the `from`, NOT the DB.
 A common mistake is to attribute the edge to the DB; the DB is

--- a/contrib/scenarios/verifier/fault_kinds/jvm_jdbc_latency.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_jdbc_latency.md
@@ -10,6 +10,13 @@ Target's DB-call sub-spans show elevated duration; database-side
 metrics (server latency, connection pool, query plans) are normal.
 Target's inbound spans slow whenever they touch the DB code path.
 
+## How to observe on a neighbour
+Every endpoint on the target that touches the DB is slowed, so the
+signal is broader than single-method faults — but callers that only
+exercise non-DB paths are still unaffected. On a caller, check
+both the service aggregate and per-`span_name` latency to see
+which call paths are affected.
+
 ## How the failure tends to propagate
 In-pod fault — target is the `from`, NOT the DB. Cascade reaches
 callers whose requests serialise on slow DB responses through the

--- a/contrib/scenarios/verifier/fault_kinds/jvm_method_exception.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_method_exception.md
@@ -10,6 +10,13 @@ Target spans whose operation name matches the targeted method show
 errors; spans for other methods on the same service look normal.
 Error logs cite the injected exception.
 
+## How to observe on a neighbour
+Because only one method throws, the error signal on a caller is
+concentrated on the specific endpoint that exercises that method.
+The caller's service-wide error rate may look flat if unaffected
+endpoints dominate. Always break down by `span_name` on the caller
+to find the affected call path.
+
 ## How the failure tends to propagate
 In-pod fault scoped to one method — target is the `from`. Cascade
 only reaches callers that exercise the affected method; their

--- a/contrib/scenarios/verifier/fault_kinds/jvm_method_latency.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_method_latency.md
@@ -9,6 +9,13 @@ Target spans matching the targeted method name show a flat latency
 shift equal to the injected delay; spans for other methods on the
 same service look normal.
 
+## How to observe on a neighbour
+Because only one method is slowed, the signal on a caller is
+concentrated on the specific endpoint that exercises that method.
+The caller's service-wide aggregate may look flat if unaffected
+endpoints outnumber the affected one. Always break down by
+`span_name` on the caller to find the affected call path.
+
 ## How the failure tends to propagate
 In-pod fault scoped to one method — target is the `from`. Cascade
 reaches callers that exercise the slowed method, then their callers

--- a/contrib/scenarios/verifier/fault_kinds/jvm_method_mutated.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_method_mutated.md
@@ -11,6 +11,12 @@ returned values are wrong; downstream may surface validation errors
 or behavioural anomalies. Pure error-rate / latency views can miss
 this.
 
+## How to observe on a neighbour
+The mutation affects one method, so the signal on a caller is
+concentrated on endpoints that consume the mutated output. The
+caller's service-wide aggregate may look clean. Break down by
+`span_name` and check per-endpoint error rates and log messages.
+
 ## How the failure tends to propagate
 In-pod fault — target is the `from`. Cascade depends on how strictly
 callers validate semantic correctness. If no caller flags the wrong

--- a/contrib/scenarios/verifier/fault_kinds/jvm_runtime_mutator.md
+++ b/contrib/scenarios/verifier/fault_kinds/jvm_runtime_mutator.md
@@ -40,6 +40,15 @@ If the mutated method is never exercised during the abnormal
 window, or the mutated value is never consumed by a code path that
 matters, the injection has no visible effect.
 
+## How to observe on a neighbour
+The mutation affects a specific call path, so the signal on a
+caller is concentrated on the endpoint(s) that route through the
+mutated method. The caller's service-wide aggregate may look
+healthy if unaffected endpoints dominate. Always break down by
+`span_name` on the caller to isolate the affected path — check
+both latency changes (fast 404 on the mutated URL) and error rate
+changes (HTTP 4xx/5xx from the corrupted request).
+
 ## How it propagates
 The cascade is driven by **data / functionality loss**, not
 latency. The propagated signal on a neighbour must be an

--- a/contrib/scenarios/verifier/fault_kinds/network_corrupt.md
+++ b/contrib/scenarios/verifier/fault_kinds/network_corrupt.md
@@ -11,6 +11,14 @@ rule-bearing side. Occasional decode / deserialisation / schema-
 validation errors at the receiver. Error rate is usually below what
 `loss` produces but visible.
 
+## How to observe on a neighbour
+Like network_loss, corruption causes retransmissions that appear as
+**tail-latency spikes** (p99/max). Average latency may look flat.
+Additionally, corrupted payloads that survive TCP checksums can
+cause deserialization errors at the receiver — check error logs for
+decode/schema/parse failures. On a neighbour, always check p99
+latency AND error logs, not just aggregate averages.
+
 ## How the failure tends to propagate
 Link-type fault. Edge: `rule-bearing side → peer`. Cascade tends to
 be modest — most calls succeed — but services that retry aggressively

--- a/contrib/scenarios/verifier/fault_kinds/network_delay.md
+++ b/contrib/scenarios/verifier/fault_kinds/network_delay.md
@@ -13,6 +13,14 @@ Error rates usually stay flat unless the added delay pushes callers
 past their timeout. The rule physically sits on ONE side of the
 link, recorded as `injection_point.source_service`.
 
+## How to observe on a neighbour
+Network delay adds a fixed latency to every packet, so the signal
+on a caller is a flat latency shift (not just a tail spike). Check
+both average AND p99 — but the shift should be roughly commensurate
+with the configured delay. Break down by `span_name` if the caller
+has mixed endpoints: only call paths that route through the delayed
+service are affected; unrelated endpoints stay flat.
+
 ## How the failure tends to propagate
 This is a link-type fault. Latency cascades **upward**: a slow callee
 makes its synchronous callers block, so they slow too, and so on up

--- a/contrib/scenarios/verifier/fault_kinds/network_loss.md
+++ b/contrib/scenarios/verifier/fault_kinds/network_loss.md
@@ -13,6 +13,15 @@ errors — the caller logs failures against the target, and the
 target logs failures against its outbound dependencies that route
 through the same interface.
 
+## How to observe on a neighbour
+Packet loss causes TCP retransmissions, which produce **tail-latency
+spikes** (p99/max), not average-latency shifts. Most requests
+succeed normally; a minority hit retransmit delays and show up only
+in the tail. On a neighbour, always check p99 and max latency — an
+average that looks flat can hide a p99 that spiked by 10x or more.
+Break down by `span_name` if the neighbour has mixed endpoints:
+only call paths that route through the lossy link are affected.
+
 ## How the failure tends to propagate
 Link-type fault. Write the link edge as `rule-bearing side → peer`.
 Cascade from the rule-bearing side outward through its callers: a

--- a/contrib/scenarios/verifier/manifest.yaml
+++ b/contrib/scenarios/verifier/manifest.yaml
@@ -92,20 +92,40 @@ extensions:
         looks flat can hide a tail that spiked; a single data source
         that looks clean can contradict another.
 
-        ## Mechanism & direction must match
-        Confirm only if the fault can actually reach the target through
-        THIS edge. Use the fault reference for the specific mechanism:
-        - Blocking-latency faults (network delay, slow response,
+        ## Match each observed signal to a fault — try them all
+        The system may carry MORE THAN ONE injected fault (every one is
+        listed above with its intensity). A service can be reached by a
+        fault several hops away through its dependency chain — not only
+        by the fault on its immediate upstream. So when you observe a
+        signal on the target (a latency tail, an error spike), test it
+        against EACH injected fault in turn, not only the one this
+        edge's upstream carries. The signal is genuine propagation if
+        ANY injected fault predicts it through a real call path.
+
+        The trap to avoid: seeing a real degradation, checking it
+        against only the nearest upstream's fault, finding that fault
+        doesn't explain it, and discarding the signal — when a
+        DIFFERENT injected fault deeper in the chain is its actual
+        cause. A 4× p99 latency tail is real degradation; if the
+        nearest fault is a data mutation (which predicts errors, not
+        latency) but the system also has a network fault (which
+        predicts exactly that tail), the network fault is the
+        explanation — confirm, don't discard.
+
+        Each fault kind leaves a different fingerprint — read its fault
+        reference for the mechanism and intensity, then match the
+        observed signal to whichever fault fits. The broad directions:
+        - Blocking-latency faults (network delay/loss/corruption,
           CPU/memory/JVM resource) propagate from a slow **callee up to
           its callers**. They do NOT slow a downstream service the
           target merely calls. A small latency bump on a downstream
           leaf is not propagation — reject.
         - Error/abort/unavailability faults propagate **up** as errors:
           callers of the failed service see failures/timeouts.
-        - Data-corruption faults (payload/value/URL mutation, corrupt)
-          propagate **down/along** the corrupted call as errors or
-          functional breakage — look for errors or bad-data handling on
-          the receiver, not just fewer calls.
+        - Data-corruption faults (payload/value/URL mutation) propagate
+          **down/along** the corrupted call as errors or functional
+          breakage — they cause fast failures, NOT latency. Look for
+          errors or bad-data handling on the receiver, not fewer calls.
 
         ## Backing components (mysql, redis, mongo, rabbitmq, …)
         These have no spans of their own. They are degraded only if

--- a/contrib/scenarios/verifier/manifest.yaml
+++ b/contrib/scenarios/verifier/manifest.yaml
@@ -52,55 +52,45 @@ extensions:
         like `attr.status_code` vary across instrumentation. Run
         `SELECT DISTINCT` first to discover actual values.
 
-        ## What degradation of the TARGET means
-        The target is genuinely degraded only if ONE of these is true
-        of the target ITSELF (not its upstream):
-        - **Errors up**: the error RATE rose — `error_spans / total
-          spans`, or `error_logs / total_logs`. Use a RATE, never a
-          raw count: when throughput falls, error counts fall too even
-          as the rate climbs. You MUST check the error rate from BOTH
-          (a) span status — `attr.status_code = 'STATUS_CODE_ERROR'`
-          OR `attr.http.response.status_code >= 400` — AND (b) error
-          logs (`level = 'ERROR'` in `*_logs`) before ruling a service
-          healthy. Logs and 4xx/5xx codes routinely catch failures the
-          plain span status misses.
-        - **Beware fast failure**: a service that fails fast returns
-          errors QUICKLY, so its latency DROPS while its error rate
-          spikes. A latency drop combined with a throughput drop is NOT
-          proof of health — it is the classic fast-failure signature.
-          Never conclude "healthy" from a latency drop without first
-          confirming the error rate (logs + status) did not rise.
-        - **Latency up meaningfully**: p95/p99 rose by a **large
-          absolute amount** AND that amount is **commensurate with the
-          upstream's** increase (see below). Tail spikes to timeout
-          territory (multi-second p95 on a normally-fast service) count
-          even if p50 is flat.
-        - **Genuinely unavailable**: it was actively serving and is now
-          erroring or timing out — not merely receiving fewer calls.
+        ## First principles
 
-        ## What is NOT degradation — reject these
-        - **Throughput drop alone.** Fewer spans with flat-or-lower
-          latency and a flat error rate means the target's callers
-          stopped calling it. That is the CALLER's degradation, not the
-          target's. This holds for EVERY fault kind, including data-
-          corruption faults — "correct requests stopped arriving" is
-          still just reduced inbound volume, not the target degrading.
-          Reject unless latency or error RATE also worsened on the
-          target itself.
-        - **Big ratio, tiny absolute.** "+84%" on 3.9 ms → 7.2 ms is a
-          ~3 ms move = noise. A percentage means nothing without the
-          absolute magnitude. Sub-millisecond and low-single-digit-ms
-          changes are noise.
-        - **Non-commensurate latency.** You are told the upstream's
-          observed symptoms. If the upstream slowed by seconds and the
-          target moved by milliseconds, the target is NOT on the
-          blocking path — its small wobble is noise. A genuine
-          synchronous block makes the caller slow by roughly the
-          callee's added latency, same order of magnitude.
-        - **Drift.** Changes matching a system-wide load shift.
-        - **Upstream-as-proxy.** Evidence must be about the target. If
-          you only find the upstream's data, or DB-client spans that
-          live inside the upstream, that is not target evidence.
+        **1. Observability data is incomplete.**
+        `*_traces` and `*_logs` are collected independently; neither
+        is a superset of the other. A request may appear in logs but
+        have no span, or vice versa. Any quantitative conclusion
+        (throughput, error count, rate) drawn from a single source
+        must be cross-checked against the other before you trust it.
+
+        **2. Degradation is an intrinsic property of the service.**
+        A service is degraded when its OWN processing quality
+        worsened: higher error rate, higher latency, or genuine
+        unavailability. Request volume is an extrinsic property — it
+        depends on callers, not on the service itself. A volume
+        change alone tells you something happened upstream, not that
+        THIS service broke.
+
+        **3. Magnitude matters, ratios alone do not.**
+        A percentage is meaningless without the absolute change and
+        the baseline scale. A 3 ms move on a 4 ms baseline is noise
+        regardless of the percentage. A latency change on the target
+        must be commensurate (same order of magnitude) with the
+        upstream's observed change to indicate a blocking dependency.
+
+        **4. Evidence must belong to the target.**
+        Spans or logs that live inside the upstream process (e.g.
+        DB-client spans emitted by the caller) are upstream evidence,
+        not target evidence. If you only find upstream data, you have
+        not established the target's own state.
+
+        ## Evidence completeness
+        A verdict is only as good as the evidence it rests on. Before
+        submitting, ask: "have I examined every independent signal
+        available for this service — error quality, latency
+        distribution (including tails), and volume — from every
+        independent data source (spans AND logs)?" If any dimension
+        is unchecked, your verdict has a blind spot. An average that
+        looks flat can hide a tail that spiked; a single data source
+        that looks clean can contradict another.
 
         ## Mechanism & direction must match
         Confirm only if the fault can actually reach the target through
@@ -125,15 +115,9 @@ extensions:
         resource fault ON THAT CALLER — is the caller's egress problem,
         not the backing component degrading. Reject the component then.
 
-        ## Procedure
-        `list_tables`, then compare the target's error rate, p95/p99
-        latency, and throughput `normal_*` vs `abnormal_*` (UNION ALL).
-        If the service aggregate is ambiguous, break down by
-        `span_name` — but a single degraded endpoint inside an
-        otherwise-flat service is weak evidence, not a confirmation.
-        Verify the relationship really exists (JOIN `parent_span_id =
-        span_id`, or shared k8s node in metrics). Then
-        `submit_hop_verdict` (confirmed | rejected) and ALWAYS include
-        `symptom_evidence` with the key SQLs + numbers that drove your
-        decision — even when rejecting. Submit before the budget runs
-        out; a quick verdict beats none.
+        ## Deliverable
+        Use `list_tables` and `query_sql` to build your evidence, then
+        call `submit_hop_verdict` (confirmed | rejected). ALWAYS
+        include `symptom_evidence` with the key SQLs + numbers that
+        drove your decision — even when rejecting. Submit before the
+        budget runs out; a quick verdict beats none.


### PR DESCRIPTION
## Summary

Reworks the verifier hop agent from hard if/then rules to a first-principles prompt, fixes multi-fault propagation reasoning, and adds a `verdict-audit` skill for investigating verifier vs GT discrepancies.

Full-dataset effect (500 cases, vs prior V5 baseline): GT-agree **883 → 1096 (+24%)**, BFS-unreachable **376 → 263 (-30%)**, while staying more precise (fewer false positives).

## What changed

**Hop agent prompt (`manifest.yaml`)**
- Replaced hard rules ("throughput drop alone = reject") with four first principles: data incompleteness, degradation as an intrinsic property, magnitude over ratio, evidence ownership.
- Added an evidence-completeness self-check (examine every signal × every data source before a verdict).
- Added a "try every injected fault" rule: a signal the nearest upstream's fault can't explain may be caused by a different fault deeper in the chain — match the observed signal against all of them.

**Multi-fault context (`audit_case_propagate.py`)**
- Fault **intensity** params (`corrupt=36`, `loss=39`, `mutator_config`, `method`, …) are now captured at `get_injections` and shown to the hop — previously dropped, so the agent couldn't judge blast radius.
- Every hop now receives the **full fault set** (flat, no "primary" marker that tunnel-visioned the agent onto one fault).
- Removed the `COUNT>=5` topology threshold that filtered out real low-frequency edges.
- Removed the oracle classifier (meaningless hardcoded thresholds); rewrote the `diff` subcommand to read `final_propagation.json` directly; added `--cases-file` for selective reruns.

**fault_kind docs**
- Method-scoped faults (jvm method latency/exception/mutation, jdbc): "break down by span_name" — the signal concentrates on one endpoint and a service aggregate hides it.
- Network faults (loss/corrupt/delay): tail-latency (p99/max) observation guidance — TCP-retransmit signals live in the tail, not the average.

**verdict-audit skill (`.claude/skills/verdict-audit/`)**
- 4-phase methodology: understand injection → predict propagation path → verify across all data modalities → render judgment. Encodes lessons from manual case audits (business-flow interruption ≠ cascade, GT over-labels, single-source conclusions are unreliable).

## Verification
- Audited dozens of rejected services with the skill: the large majority of verifier rejections are sound — GT systematically over-labels services that merely received fewer requests.
- The hard case driving the multi-fault fix (JVMRuntimeMutator+NetworkCorrupt) now confirms ts-ui-dashboard via the ts-travel-service edge, with the agent attributing the 7.3× p99 tail to the network-corruption fault and noting the ~1% affected-call fraction that left aggregates flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)