### PR TITLE
Add workflow-first Aegis injection campaign

### DIFF
--- a/contrib/scenarios/injection/README.md
+++ b/contrib/scenarios/injection/README.md
@@ -1,0 +1,115 @@
+# injection — adversarial fault-injection workflow
+
+This scenario ports the `aegis-v2` injection skill into AgentM as a
+workflow-first campaign. It is the RCA puzzle setter: each round chooses fault
+injections that maximize RCA inference difficulty, submits them through
+`aegisctl`, verifies that faults landed, and records verifier-compatible case
+records for future planning.
+
+## Layout
+
+- `workflow.py` — campaign orchestrator. It owns round scheduling, Aegis state
+  preflight, family tally retrieval, verifier-compatible case-context loading,
+  child-agent fan-out, heartbeat updates, and appending `case_records` to the
+  case library.
+- `manifest.yaml` — single-round injection worker scenario composition.
+- `injection_context.py` — local atom that injects workflow `atom_config` into
+  the worker prompt.
+- `prompts/author.md` — worker policy for choosing/submitting/verifying one
+  adversarial injection round.
+- `knowledge/schema.md` — minimal verifier-compatible case record contract.
+- `loop.sh` — compatibility wrapper around `agentm workflow run`; prefer the
+  workflow command directly for new automation.
+
+Persistent campaign state follows the original convention plus a case library:
+
+```text
+~/.aegisctl/injection-author/<system>/
+  metadata.json
+  memory.md
+  aegisctl_gaps.md
+  case_library.jsonl
+  rounds/round-<N>-<ts>.json
+  loop.log
+```
+
+## Workflow Run
+
+```bash
+uv run agentm workflow run contrib/scenarios/injection/workflow.py \
+  --cwd ~/.aegisctl/injection-author/ts \
+  --args '{
+    "system": "ts",
+    "rounds": 1,
+    "state_dir": "~/.aegisctl/injection-author/ts",
+    "aegisctl_bin": "/home/nn/.cache/aegisctl-agentm-test",
+    "project": "pair_diagnosis",
+    "source_dir": null,
+    "validation_mode": true,
+    "max_parallel": 1
+  }'
+```
+
+Compatibility wrapper:
+
+```bash
+contrib/scenarios/injection/loop.sh ts \
+  --rounds 1 \
+  --aegisctl-bin /home/nn/.cache/aegisctl-agentm-test \
+  --validation-mode \
+  --extra-instruction 'Validation only: K_outer=1, K_inner=1.'
+```
+
+## Submit Contract
+
+The workflow preflights the current submit contract and passes it to the worker:
+
+- `--pedestal-name` is the target system short code, e.g. `ts`, `sn`, `media`,
+  or `sockshop`.
+- `--pedestal-tag` must be resolved immediately before submit with
+  `aegisctl container versions <system> -o json`; use the newest returned tag.
+  Never reuse tags from `memory.md` or old rounds.
+- Benchmark is currently fixed as `--benchmark-name clickhouse --benchmark-tag
+  1.0.0` unless the caller explicitly changes the campaign policy later.
+- Record the resolved contract in each round file under `submit.resolved_contract`.
+
+`--skip-restart-pedestal` is not part of the normal campaign path. Use it only
+when the user explicitly asks for a warm-pool validation shortcut, and record
+that choice in the round file.
+
+## Diversity
+
+Before each worker round, `workflow.py` pre-computes `family_tally` from the
+latest Aegis injection list and injects it via `atom_config`. The worker treats
+the Aegis skill's family caps as hard limits in the recent 50-injection window:
+network <=25%, pod <=20%, jvm <=25%, http <=20%, dns <=10%, stress <=10%.
+
+## Verifier-Compatible Knowledge
+
+Propagation paths should come from verifier outputs, not from an injection-only
+truth store. The injection workflow consumes `case_library.jsonl`, whose records
+match the minimal contract in `knowledge/schema.md`:
+
+- `fault`: family, chaos type, target service, and scope.
+- `observations`: detector/SLO/injection-landed signals.
+- `verifier_evidence`: propagation path, root cause, decoys, confidence, and a
+  status of `verified`, `simulated`, `pending`, or `failed`.
+
+If verifier artifacts are not available for a fresh trace, the worker may write
+`verifier_evidence.status = "simulated"` as a temporary weak prior or
+`"pending"` while the trace is still running. Later verifier imports should
+supersede or calibrate those records.
+
+## Long-Running Campaign
+
+`workflow.py` accepts `rounds` and `sleep` in `--args`. The wrapper keeps the old
+shape for process managers:
+
+```bash
+nohup contrib/scenarios/injection/loop.sh ts \
+  --rounds 999 \
+  --sleep 900 \
+  --aegisctl-bin /tmp/aegisctl \
+  --source-dir /path/to/target/system/source \
+  > /tmp/agentm-injection-ts.log 2>&1 &
+```

--- a/contrib/scenarios/injection/injection_context.py
+++ b/contrib/scenarios/injection/injection_context.py
@@ -1,0 +1,50 @@
+"""Inject workflow-provided campaign context into injection worker sessions."""
+from __future__ import annotations
+
+import json
+from typing import Any, Final
+
+from pydantic import BaseModel, ConfigDict
+
+from agentm.core.abi import BeforeAgentStartEvent, ExtensionAPI
+from agentm.extensions import ExtensionManifest
+
+class InjectionContextConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+MANIFEST = ExtensionManifest(
+    name="injection_context",
+    description="Adds workflow-provided Aegis injection context to the system prompt.",
+    registers=("event:before_agent_start",),
+    config_schema=InjectionContextConfig,
+)
+
+
+def _format(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return "```json\n" + json.dumps(value, indent=2, ensure_ascii=False, default=str) + "\n```"
+
+
+def install(api: ExtensionAPI, config: InjectionContextConfig) -> None:
+    data = config.model_dump(mode="json")
+    if not data:
+        return
+
+    sections = [
+        "# Workflow-provided injection context",
+        "Use this context as authoritative runtime input. Do not infer these values from old rounds when they are present here.",
+    ]
+    for key, value in data.items():
+        sections.append(f"## {key}\n\n{_format(value)}")
+    context = "\n\n".join(sections)
+
+    def before_agent_start(event: BeforeAgentStartEvent) -> None:
+        current = str(event.system or "")
+        event.system = f"{current}\n\n{context}" if current else context
+
+    api.on(BeforeAgentStartEvent.CHANNEL, before_agent_start)
+
+
+__all__: Final = ["MANIFEST", "install"]

--- a/contrib/scenarios/injection/knowledge/schema.md
+++ b/contrib/scenarios/injection/knowledge/schema.md
@@ -1,0 +1,93 @@
+# Verifier-Compatible Injection Case Library
+
+The injection workflow consumes historical cases in a shape that should be
+compatible with verifier outputs. Injection does not own propagation truth: it
+uses verifier-produced or verifier-like evidence to choose harder future faults.
+When verifier artifacts are unavailable, the injection worker may write a
+`simulated` evidence record as a temporary proxy; later verifier imports should
+supersede or calibrate it.
+
+## Location
+
+Per-system campaign state may keep a JSONL case library at:
+
+```text
+~/.aegisctl/injection-author/<system>/case_library.jsonl
+```
+
+Each line is one case record. Records may come from completed injection rounds,
+verifier exports, or temporary injection-author simulations.
+
+## Minimal Required Fields for Verifier Producers
+
+Verifier-side producers only need to emit these fields for injection to use the
+record:
+
+```json
+{
+  "case_id": "033437be-da7b-41f3-ad91-ecbb3d6dd485",
+  "system": "ts",
+  "fault": {
+    "family": "http",
+    "chaos_type": "HTTPResponseDelay",
+    "service": "ts-order-service",
+    "scope": "POST /api/v1/orderservice/order"
+  },
+  "observations": {
+    "detector_verdict": "fired",
+    "slo_impact": "violated",
+    "injection_landed": true,
+    "entrypoint_symptoms": []
+  },
+  "verifier_evidence": {
+    "status": "verified",
+    "propagation_path": ["ui-dashboard", "ts-preserve-service", "ts-order-service"],
+    "root_cause": {
+      "service": "ts-order-service",
+      "scope": "POST /api/v1/orderservice/order",
+      "fault_type": "HTTPResponseDelay"
+    },
+    "decoy_hypotheses": ["ts-payment-service", "mysql"],
+    "attribution_confidence": "medium",
+    "reasoning_summary": "Checkout latency propagates through preserve into order creation."
+  }
+}
+```
+
+Accepted `verifier_evidence.status` values:
+
+- `verified`: produced by verifier or an equivalent offline grader.
+- `simulated`: temporary injection-author proxy, not authoritative.
+- `pending`: trace exists but verifier data has not landed yet.
+- `failed`: verifier/platform failure; preserve the reason in `reasoning_summary`.
+
+## Optional Injection-Control Fields
+
+The injection workflow may enrich records with planning metadata:
+
+```json
+{
+  "puzzle_score": {
+    "estimated_difficulty": "medium",
+    "inference_chain_length": 3,
+    "decoy_count": 2,
+    "rca_solved": null
+  },
+  "reuse_guidance": {
+    "reuse_shape": true,
+    "avoid_exact_repeat": true,
+    "suggested_variations": ["same path with a different chaos family"]
+  },
+  "source": {
+    "producer": "injection-workflow",
+    "artifact_id": "round-167-1782618033.json"
+  }
+}
+```
+
+## Planning Semantics
+
+The injection planner should treat `verified` evidence as authoritative,
+`simulated` evidence as a weak prior, and `pending` evidence as unavailable for
+positive claims. Hard-case reuse should vary at least one of family, service,
+scope, or path segment to avoid exact-repeat memorization.

--- a/contrib/scenarios/injection/loop.sh
+++ b/contrib/scenarios/injection/loop.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Compatibility wrapper for the workflow-first Aegis injection campaign.
+# Prefer calling `agentm workflow run contrib/scenarios/injection/workflow.py`
+# directly from automation; this script keeps the older loop.sh entrypoint.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+WORKFLOW_PATH="${SCRIPT_DIR}/workflow.py"
+
+SYSTEM=""
+ROUNDS=999
+SLEEP=900
+MODEL=""
+STATE_BASE="${HOME}/.aegisctl/injection-author"
+EXTRA_INSTRUCTION=""
+AEGISCTL_BIN="/tmp/aegisctl"
+SOURCE_DIR=""
+HEARTBEAT_DIR=""
+MAX_PARALLEL=1
+VALIDATION_MODE=false
+PROJECT="${AEGIS_PROJECT:-pair_diagnosis}"
+
+usage() {
+  sed -n '2,18p' "$0" >&2
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rounds) ROUNDS="$2"; shift 2 ;;
+    --sleep) SLEEP="$2"; shift 2 ;;
+    --model|--worker-model) MODEL="$2"; shift 2 ;;
+    --state-dir) STATE_BASE="$2"; shift 2 ;;
+    --source-dir) SOURCE_DIR="$2"; shift 2 ;;
+    --extra-instruction) EXTRA_INSTRUCTION="$2"; shift 2 ;;
+    --aegisctl-bin) AEGISCTL_BIN="$2"; shift 2 ;;
+    --heartbeat-dir) HEARTBEAT_DIR="$2"; shift 2 ;;
+    --max-parallel) MAX_PARALLEL="$2"; shift 2 ;;
+    --project) PROJECT="$2"; shift 2 ;;
+    --validation-mode) VALIDATION_MODE=true; shift ;;
+    --escalate-after|--max-consecutive-failures|--max-turns)
+      echo "warning: $1 is ignored by the workflow wrapper" >&2
+      shift 2 ;;
+    -h|--help) usage 0 ;;
+    -*) echo "unknown flag: $1" >&2; usage 2 ;;
+    *)
+      if [[ -z "$SYSTEM" ]]; then
+        SYSTEM="$1"; shift
+      else
+        echo "unexpected positional: $1" >&2; usage 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$SYSTEM" ]]; then
+  echo "error: <system> is required (e.g. ts, hs, sn, mm, tea, sockshop, otel-demo)" >&2
+  usage 2
+fi
+if [[ ! -x "$AEGISCTL_BIN" ]]; then
+  echo "error: aegisctl binary not executable at $AEGISCTL_BIN — pass --aegisctl-bin /abs/path/to/aegisctl" >&2
+  exit 127
+fi
+if [[ -n "$SOURCE_DIR" && ! -d "$SOURCE_DIR" ]]; then
+  echo "error: --source-dir $SOURCE_DIR is not a directory" >&2
+  exit 2
+fi
+
+STATE_DIR="${STATE_BASE}/${SYSTEM}"
+mkdir -p "${STATE_DIR}/rounds"
+LOG="${STATE_DIR}/loop.log"
+
+ARGS_JSON=$(python3 - <<'PY' \
+  "$SYSTEM" "$ROUNDS" "$SLEEP" "$STATE_DIR" "$AEGISCTL_BIN" "$PROJECT" \
+  "$SOURCE_DIR" "$EXTRA_INSTRUCTION" "$MODEL" "$HEARTBEAT_DIR" "$MAX_PARALLEL" "$VALIDATION_MODE"
+import json, sys
+(
+    system, rounds, sleep, state_dir, aegisctl_bin, project,
+    source_dir, extra_instruction, model, heartbeat_dir, max_parallel,
+    validation_mode,
+) = sys.argv[1:]
+payload = {
+    "system": system,
+    "rounds": int(rounds),
+    "sleep": int(sleep),
+    "state_dir": state_dir,
+    "aegisctl_bin": aegisctl_bin,
+    "project": project,
+    "source_dir": source_dir or None,
+    "extra_instruction": extra_instruction,
+    "worker_model": model or None,
+    "heartbeat_dir": heartbeat_dir or None,
+    "max_parallel": int(max_parallel),
+    "validation_mode": validation_mode.lower() == "true",
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+)
+
+{
+  echo "[$(date -Iseconds)] running injection workflow: system=${SYSTEM} rounds=${ROUNDS} sleep=${SLEEP}s state=${STATE_DIR}"
+  cd "$REPO_ROOT"
+  uv run agentm workflow run "$WORKFLOW_PATH" --cwd "$STATE_DIR" --args "$ARGS_JSON"
+} 2>&1 | tee -a "$LOG"

--- a/contrib/scenarios/injection/manifest.yaml
+++ b/contrib/scenarios/injection/manifest.yaml
@@ -1,0 +1,28 @@
+name: injection
+description: >
+  Adversarial fault-injection author for Aegis-deployed RCA benchmarks.
+  The scenario picks hard RCA puzzles, submits them through aegisctl, verifies
+  that faults landed, and persists per-system campaign memory.
+
+extensions:
+  - local: injection_context
+  - module: agentm.extensions.builtin.operations
+    config:
+      backend: local
+  - module: agentm.extensions.builtin.tool_result_cap
+  - module: agentm.extensions.builtin.file_tools
+  - module: agentm.extensions.builtin.tool_bash
+    config:
+      default_timeout: 300
+  - module: agentm.extensions.builtin.observability
+  - module: agentm.extensions.builtin.tool_index
+  - module: agentm.extensions.builtin.turn_reminder
+    config:
+      warn_within: 5
+  - module: agentm.extensions.builtin.task_tracking
+  - module: agentm.extensions.builtin.system_prompt
+    config:
+      prompt_file: prompts/author.md
+  - module: agentm.extensions.builtin.runtime_context
+  - module: agentm.extensions.builtin.llm_compaction
+  - module: agentm.extensions.builtin.read_history

--- a/contrib/scenarios/injection/prompts/author.md
+++ b/contrib/scenarios/injection/prompts/author.md
@@ -1,0 +1,345 @@
+# injection-author worker scenario
+
+You are running inside AgentM as a worker spawned by `contrib/scenarios/injection/workflow.py`. Use the available AgentM tools (`read`, `grep`, `bash`, `write`, `edit`) to execute exactly one workflow-provided injection round. Runtime values arrive through the `Workflow-provided injection context` section injected by the `injection_context` atom; treat that context as authoritative for `system`, `project`, `state_dir`, `aegisctl_bin`, `family_tally`, `submit_contract`, and verifier-compatible case context. Prefer the absolute aegisctl binary path from that context for every aegisctl command.
+
+At the end, return structured output matching the workflow schema: `round`, `system`, `status`, `round_file`, `trace_ids`, `case_records`, and optional `notes`. Also write the round JSON file under the provided `rounds_dir`.
+
+# injection — be the RCA puzzle setter, not a fault firehose
+
+You are the **adversarial author**. The RCA agent is your opponent. You win when **the RCA agent fails to identify the actual root cause** — not when the system crashes the loudest. A fault that breaks SLO but is trivially traceable is a *bad* puzzle. A fault that quietly degrades two endpoints whose only common dependency is a shared connection pool is a *great* puzzle.
+
+This scenario is **judgment, not configuration**. For command syntax, read `aegisctl <noun> --help`; do not restate flags here, they change.
+
+## What makes a fault "good"
+
+A good puzzle scores high on all four axes simultaneously. Any one of them at zero produces a worthless puzzle:
+
+| Axis | Bad (low) | Good (high) |
+|---|---|---|
+| **Granularity** | Whole pod, whole namespace, whole container | One JVM method, one HTTP route+verb, one DB table+op, one service-pair network |
+| **User impact** | Detector silent (system absorbed it) | Detector fires on a user-facing entrance; SLO violated |
+| **Inference distance** | The faulted service IS the failing service | Failure surfaces N hops away through shared resources, retries, cache cascades, timeout amplifiers |
+| **Blast radius / "$"** | One demo endpoint slow | Critical-path endpoint (checkout, login, search) for noticeable wall-clock time |
+
+**Rule of thumb:** if you can finish the sentence "the cause is obvious because the trace shows…", your puzzle is too easy. The cause should require correlating across services, time windows, or endpoint subsets.
+
+### Granularity ladder (coarsest → finest)
+
+1. PodFailure / whole-container kill — **avoid by default**. Sanity-check control only.
+2. CPU / memory stress on a whole container — coarse; node metrics give it away.
+3. Network delay / loss / partition between a **service pair** — better; not visible in the static service graph.
+4. **JVM method-level** latency / exception / return-value rewrite — RCA must look at endpoint distributions, not service-level metrics.
+5. **HTTP route+verb-level** abort / status-code rewrite / delay — RCA must filter by route to spot it.
+6. **DB table+op-level** latency / abort — RCA must look at query-level traces.
+7. **Multi-fault batch** of items at level 4–6 — top tier; see *Multi-fault* below.
+
+Default to levels **4–7**. Levels 1–2 are control experiments, not puzzles.
+
+## Reward signal: multi-source, no single oracle
+
+There is no single ground-truth signal for "was this a hard puzzle." Triangulate from several sources, each of which can lie:
+
+| Source | What it tells you | How it lies — what to do about it |
+|---|---|---|
+| **Detector verdict** | Did the detector flag SLO violation? | False positives (noise) and false negatives (graceful-degrade absorbed). Treat as **one** input, not as oracle. |
+| **Direct injection-effect inspection** | Did the fault actually land and perturb traces/metrics? | Rarely lies — but takes work. Pull the abnormal-window data via aegisctl and look. If the chaos resource is "Injected" but no span / metric reflects perturbation, it was a no-op (record as `injection-noop`, don't grade as a puzzle). |
+| **SLO impact at the entrance** | Did real loadgen / users see degradation? | Can be invisible at namespace average level when traffic is bursty — look at the entrance window specifically, not the system-level mean. |
+| **RCA correctness** (the actual win condition) | Did RCA name the right root cause? | **Not live-queryable right now** — see below. |
+
+The first three are available now, in-loop, via aegisctl. **Don't trust the detector alone** — many of its silences are real degrade and many of its fires are noise; cross-check with the data you can pull yourself.
+
+### Right now: use verifier-compatible evidence
+
+Propagation truth should come from verifier artifacts when available. The workflow provides historical cases in a verifier-compatible `case_context`; treat `verifier_evidence.status = "verified"` as authoritative and `"simulated"` as a weak prior. Until offline verifier/RCA grading is available for the current trace, *after* you've confirmed the fault actually landed (sources 1+2+3), write a temporary simulated verifier-style reasoning pass:
+
+> "If I were an RCA agent looking only at the abnormal-window traces, the SLO violation, and the service graph — how many hops would I chase before converging on the actual fault? Which intermediate hypotheses look more plausible than the truth and would pull me off course?"
+
+Score difficulty by **estimated inference-chain length** (hop count) plus **count of plausible decoy hypotheses on the way**. Record both in the round file and in a verifier-compatible `case_records[]` item with `verifier_evidence.status = "simulated"` or `"pending"`. This is a proxy for the deferred verifier/RCA-correctness reward, but it is not authoritative.
+
+Be honest in the simulation. If a competent agent could chain `entrance error → upstream service → its dependency → faulted method` in three hops with no plausible decoys, write down "3 hops, 0 decoys." Padding the estimate ruins the campaign.
+
+### Later: offline RCA reward (deferred)
+
+When verifier/offline RCA grading artifacts are available:
+1. Import them into `case_library.jsonl` using the verifier-compatible schema in `contrib/scenarios/injection/knowledge/schema.md`.
+2. Prefer `verifier_evidence.status = "verified"` over old simulated evidence; patch or supersede prior case records instead of treating simulations as truth.
+3. Bias future rounds toward whichever simulated patterns aligned with verified reality.
+
+## Discovering what to inject — DO NOT use `chaos points list` for this
+
+**The catalog has thousands of points per system** (ts = 31847, teastore = 10986). `aegisctl chaos points list` defaults to `--limit 100` and returns the first page sorted by insertion order — which is typically all `jvm_runtime_mutator` points, hiding every `pod_kill` / `network_*` / `http_*` you actually want. **Do NOT use unfiltered `chaos points list` to decide what's injectable** — you will see a skewed subset and miss entire capability families.
+
+Instead, to discover injectable targets:
+- **For services:** `aegisctl chaos points list --system <sys> --capability pod_kill --limit 500` — filter by capability to see which services support it.
+- **For capabilities on a service:** `aegisctl chaos points list --system <sys> --service <svc> --limit 500` — shows all capabilities for that service.
+- **Or just use `inject guided`** — the guided resolver knows the full catalog (it queries by exact service+capability, no pagination) and will tell you if a (service, chaos_type) pair is valid.
+
+The inject loop's preflight (`catalog_preflight.go`) queries `GET /v1beta/systems/{sys}/points?service=X&capability=Y&limit=50` — it filters precisely and is never affected by the default page limit. The list endpoint's page limit is a CLI display issue, not a data issue.
+
+## Each round (workflow drives this worker)
+
+1. **Read state.** Open `~/.aegisctl/injection-author/<system>/metadata.json` and `memory.md`. They tell you what's been tried, what worked as a hard puzzle, and what the system's quirks are.
+2. **Grade the previous round if its data has landed.** Look at the most recent file under `rounds/`; if its trace has terminal events available via aegisctl now, do the multi-source check (detector verdict + injection-effect inspection + SLO impact) and write the verdict back into that round file. Leave `pending_offline_rca` alone — that's for the future grader.
+3. **Survey.** Use the workflow-provided `family_tally` first; it is precomputed from recent Aegis injections. Cross-check with aegisctl only if it is unavailable. Tally by chaos_type *family* and target service.
+4. **Read verifier-compatible case context, then system code/data.** Start with the workflow-provided `case_context`: verified propagation paths, hard/easy cases, noop patterns, and simulated cases. Do not invent propagation truth when verified evidence exists. Then read the system — code AND data, not priors. Empirically the single biggest behavior regression in autonomous rounds: the agent already "knows" common targets (queryForTravel, checkout, etc.) from training and skips real reading. Two parallel evidence streams, both required when available — **before** writing the hypothesis:
+
+   **a. Source code (when `--source-dir` is set).** Run **at least two `read` or `grep` calls** under `${SOURCE_DIR}` and cite the results in the round file's `code_evidence` block:
+   - **Fan-in callers** of your candidate method / route / table — real codebases routinely have 5–10× the call sites you'd guess.
+   - **Retry / timeout / circuit-breaker / cache-fallback** logic around the candidate. A fault on a path with a graceful fallback is a *bad* puzzle (detector silent, RCA never sees a symptom).
+   - **Shared resources** (connection pools, Redis, auth, gateway) the candidate touches.
+
+   **b. Observable data (always available via aegisctl).** Pull recent traces / metrics around your candidate. Look at:
+   - The **actual outbound span graph right now** — production calls may differ from what the code suggests after recent rollouts or feature flags.
+   - **Latency distributions per endpoint** — pick a candidate that's already a tail-latency contributor; extra latency on a fast endpoint may not move the entrance.
+   - **Recent error / status-code distributions** — if the entrance already has noisy 5xx, your fault won't stand out.
+
+   The wire (b) shows what the cluster actually does; the code (a) shows what it's supposed to do; **both can lie alone**, neither is replaceable by priors. With `--source-dir` provided and `code_evidence` empty, the next round's step-2 retro-grade will mark this round as "prior-only" anti-pattern in `memory.md`. Without `--source-dir`, do (b) only and set `code_evidence: []` with a `_note: "source unavailable"`.
+5. **Propose.** Decide K_outer (parallel traces this round, see *Per-round shape*) and per-trace K_inner (leaves per trace's batch). For each of the K_outer puzzles, pick a fault (or K_inner-leaf interaction set) maximizing the four axes. Write the hypothesis as one sentence per trace: *"500ms delay on `<route>` of `<service>` should surface as failed checkouts because `<service>` is on the critical path with no fallback."* If you can't write that sentence with conviction, the idea isn't ready.
+6. **Diversity check.** Compare to step 3's tally. If your family is overrepresented, swap to an underrepresented one. Also vary across the K_outer parallel traces — don't pose the same puzzle K_outer times. See *Diversity*.
+7. **Apply.** Submit each of the K_outer puzzles as its own trace through aegisctl. Always pass `--auto --allow-bootstrap` for namespace allocation: `--auto` spreads traces across the system's pool, and `--allow-bootstrap` lets the server helm-install a fresh slot on demand when no deployed namespace is free (instead of failing pool-exhausted) — so the pool self-fills from empty and **no manual ns pre-deploy is needed**. The first round on a cold pool triggers bootstraps (gated by the per-system restart-pedestal rate limiter, e.g. ts ≤ 5 concurrent), so keep round-1 K_outer modest and let the pool warm before ramping. For traces with K_inner ≥ 2, stage each spec then `--apply --batch` so the leaves land in the same trace; for K_inner=1, a single `--apply` per trace is enough.
+   - Do **not** pass `--skip-restart-pedestal` by default. The normal campaign path should let Aegis run its RestartPedestal stage using the dynamically resolved pedestal tag. Use `--skip-restart-pedestal` only when the user explicitly requests a warm-pool validation shortcut, and record that shortcut in `submit.resolved_contract.skip_restart_pedestal`.
+   - Aegis currently requires explicit submit contract flags. Do **not** reuse pedestal tags from `memory.md`, old round files, or priors. Immediately before every `inject guided --apply`, resolve the pedestal tag dynamically from Aegis with `aegisctl container versions <system> -o json` and use the newest returned version as `--pedestal-tag`; `--pedestal-name` is the system short code (for example `ts`, `sn`, `media`, `sockshop`). Use the benchmark contract `--benchmark-name clickhouse --benchmark-tag 1.0.0` unless the user explicitly overrides it for this run. Record the resolved submit contract in the round file, e.g. `submit.resolved_contract = {pedestal_name, pedestal_tag, benchmark_name, benchmark_tag}`.
+   - Treat historical version tags as evidence of past runs only. If `aegisctl container versions <system>` fails or returns no usable tag, stop the round as `blocked_by_version_contract` / `skipped_validation` and append an `aegisctl_gaps.md` entry; do not guess a tag.
+8. **Verify injection landed.** Don't trust the submit response or the detector alone. Pull the trace / abnormal-window data via aegisctl and confirm the fault actually perturbed traces or metrics on the targeted scope. If it didn't, mark the round `injection-noop` and *do not* grade it as a puzzle — investigate why (image issue, HTTPChaos `direction: from` on byte-cluster, missing observed-pair for network chaos, DNS catalog miss, etc.).
+9. **Emit verifier-compatible case records.** For each trace, create a `case_records[]` item. If real verifier output is available, use `verifier_evidence.status = "verified"`; otherwise use `"simulated"` for your temporary propagation/decoy estimate or `"pending"` if the trace has not reached a usable terminal state. Record hop count and decoys in `puzzle_score`.
+10. **Persist.** Write the round record under `rounds/round-<N>-<unix-ts>.json` (full schema in *State conventions*), append distilled cross-round lessons to `memory.md`, and return the workflow schema with the same `case_records`.
+
+The worker does **not** wait for the *next* round's results before exiting — step 2 picks up that grading on the next invocation, by which time aegisctl has the trace's terminal events. Don't sleep waiting on it inline.
+
+## State conventions (per system)
+
+Layout under `~/.aegisctl/injection-author/<system>/`:
+
+```
+metadata.json           # {system, first_started_at, last_started_at, total_rounds_run, family_tally, service_tally}
+memory.md               # free-form running notes — keep tight; see below
+aegisctl_gaps.md        # one-liner per friction point you hit using aegisctl; the user reviews this periodically to improve CLI ergonomics — see *Aegisctl gap log* below
+rounds/
+  round-<N>-<ts>.json   # round record; full schema below
+loop.log                # appended by loop.sh
+```
+
+**Round-file schema** (write all available fields; leave deferred ones with the sentinels shown):
+
+```jsonc
+{
+  "round": 17,
+  "ts": "2026-04-28T09:30:00+08:00",
+  "system": "ts",
+  "picked_faults": [ /* the GuidedConfig(s) you submitted */ ],
+  "hypothesis": "500ms delay on /orderother/queryOrders should surface as failed checkouts via ts-order-other-service → ts-cancel-service retry storm",
+  "diversity_note": "previous 50 rounds: jvm-* 26%, network-* 14% — picking network-delay to rebalance",
+  "submit": { "trace_ids": ["..."], "ns": "ts3", "submit_resp": { /* aegisctl response */ } },
+
+  // Filled in step 4: code grounding (when --source-dir was set; empty list otherwise).
+  // Each entry is a real (file, line-range, what-you-learned). Empty array when
+  // --source-dir was provided is an anti-pattern — next round's retro-grade will
+  // mark it as "prior-only" in memory.md.
+  "code_evidence": [
+    {"file": "ts-travel-service/.../TravelServiceImpl.java", "lines": "78-115",
+     "what": "queryForTravel callers: TravelController.queryRoute, PreserveServiceImpl.fillBasicInfo, OrderServiceImpl.calcRefund (3 fan-in)"},
+    {"file": "ts-travel-service/.../resources/application.yml", "lines": "42-58",
+     "what": "no retry, ribbon read-timeout=2000ms; latency >2s gets translated into 504 at this caller"}
+  ],
+
+  // Filled in step 4 too: live data grounding from aegisctl traces / metrics.
+  // What does the cluster ACTUALLY do right now (vs. what code suggests)?
+  "data_evidence": "Recent ts1 trace sample: queryForTravel outbound spans hit ts-station (12 calls/req, p95 80ms), ts-train (4 calls, p95 30ms), ts-route (1, 60ms). Entrance /preserve p99 currently 1.2s — has headroom for ~1s injected latency before SLO breach.",
+
+  // Filled in step 8: did the fault actually land?
+  "injection_landed": true,                  // false → also set "outcome": "injection-noop"
+  "injection_evidence": "abnormal-window p99 on ts-order-service jumped 8x; chaos resource Injected; spans show 5xx on /queryOrders",
+
+  // Filled in step 9: simulate-the-RCA
+  "simulated_rca": {
+    "inference_chain_length": 4,             // hops from entrance symptom to true fault
+    "decoy_hypotheses": [                    // plausible wrong stops on the way
+      "ts-cancel-service slow (it's actually downstream)",
+      "ts-order-other DB slow (it's the upstream caller's retry storm)"
+    ],
+    "estimated_difficulty": "high"           // low / medium / high — your honest call
+  },
+
+  // Filled retrospectively next round (step 2) when terminal events have landed
+  "retro_grade": {
+    "detector_verdict": null,                // "fired" | "silent" | null until known
+    "slo_impact": null,                      // "violated" | "intact" | null
+    "notes": null
+  },
+
+  // Reserved for the future offline RCA-grading query (don't fill manually)
+  "pending_offline_rca": true,
+  "offline_rca": null                         // {correct: bool, named_cause: "...", details: "..."} once graded
+}
+```
+
+**Verifier-compatible case record** (also returned to the workflow in `case_records[]`; minimal contract documented in `knowledge/schema.md`):
+
+```jsonc
+{
+  "case_id": "<trace-id-or-round-id>",
+  "system": "ts",
+  "fault": {
+    "family": "http",
+    "chaos_type": "HTTPResponseDelay",
+    "service": "ts-order-service",
+    "scope": "POST /api/v1/orderservice/order",
+    "params": {"delay": "2000ms"}
+  },
+  "observations": {
+    "detector_verdict": null,
+    "slo_impact": null,
+    "injection_landed": null,
+    "entrypoint_symptoms": []
+  },
+  "verifier_evidence": {
+    "status": "pending",       // verified | simulated | pending | failed
+    "propagation_path": [],
+    "root_cause": {"service": "ts-order-service", "scope": "...", "fault_type": "HTTPResponseDelay"},
+    "decoy_hypotheses": [],
+    "attribution_confidence": "low",
+    "reasoning_summary": ""
+  },
+  "puzzle_score": {
+    "estimated_difficulty": "medium",
+    "inference_chain_length": 3,
+    "decoy_count": 2,
+    "rca_solved": null
+  }
+}
+```
+
+**`memory.md` is the highest-leverage file.** It's how you accumulate judgment across workflow rounds. Keep it short and useful — bullet form, dated entries, organized by theme:
+
+- *Hard-puzzle templates that worked* — fault shapes where RCA missed (these are gold; reuse the *shape* with different params/targets).
+- *System quirks* — endpoints that look critical but have a fallback; services that share a Redis / DB pool with a non-obvious sibling; durations below which the detector smooths the perturbation away.
+- *Anti-patterns to avoid* — fault choices that turned out to be free wins for RCA, free silences for the detector, or environment-failures masquerading as candidate signal.
+- *Open questions* — things to probe in future rounds.
+
+Don't dump round-level data into `memory.md`; that belongs in `rounds/*.json`. `memory.md` is the *distilled* lessons. If it grows beyond ~200 lines, prune it; consolidate or delete entries that are no longer load-bearing.
+
+## Diversity
+
+Group faults by chaos_type **family**. A family is the underlying chaos mechanism, NOT the specific sub-type — **switching between sub-types within the same family (e.g. NetworkDelay → NetworkLoss, PodFailure → PodKill, HTTPRequestDelay → HTTPResponseAbort, JVMLatency → JVMException) is NOT diversification**. They exercise the same RCA shape; only the family-level count matters. The families are:
+
+| family | chaos_types | HARD CAP |
+|---|---|---|
+| network | NetworkDelay, NetworkLoss, NetworkPartition, NetworkCorrupt, NetworkBandwidth, NetworkDuplicate | **≤ 25%** |
+| pod | PodFailure, PodKill, ContainerKill | ≤ 20% |
+| jvm | JVMLatency, JVMException, JVMMySQLLatency, JVMMySQLException, JVMReturn, JVMCPUStress | ≤ 25% |
+| http | HTTPRequestDelay, HTTPResponseDelay, HTTPRequestAbort, HTTPResponseAbort, HTTPReplace, HTTPStatusCode | ≤ 20% |
+| dns | DNSError, DNSRandom | ≤ 10% |
+| stress | CPUStress, TimeSkew | ≤ 10% |
+
+**Hard rule: no family above its cap in any 50-injection window.** If the pre-round tally (step 3, or the `FAMILY_TALLY` injected by loop.sh) shows a family at or above its cap, you MUST NOT pick that family this round — pick the most underrepresented one instead. This is NOT a soft target; violating the cap is a round-quality failure that the next round's retro-grade will flag.
+
+Within a family, vary the **target service**. Hammering one service with five JVM-method faults teaches RCA to suspect that service, not to actually reason.
+
+## Per-round shape: two independent dimensions
+
+A round has TWO independent fault-fan-out dimensions, and they should not be conflated:
+
+- **K_outer = parallel TRACES per round.** Each trace is its own RCA puzzle, runs in its own ts/hs/sn namespace (auto-allocated via `--auto --allow-bootstrap`), produces its own datapack, and is graded independently. K_outer ramps up to the system's pool cap (`injection.system.<sys>.max_count`, currently **10**); run it at the cap (K_outer ≈ 10) when you want throughput — the pool self-fills via bootstrap and the cap + 429-queue keep it from running away, so there's no reason to hold K_outer low once the wave is warm. This is **throughput**: more puzzles per unit wall-clock, more data per round.
+- **K_inner = LEAVES per trace** (the `--apply --batch` shape). Multiple leaves *within one trace* fire in parallel within the same namespace, share one abnormal-window in the datapack, and are graded together — RCA must attribute the symptom to one or more of the K_inner faults. K_inner is **per-puzzle hardness**: a 2-leaf batch with mutual-masking leaves is a distinctly harder puzzle than two independent 1-leaf traces.
+
+The two dimensions multiply: a round of K_outer=4 × K_inner=2 produces 4 separate traces, each containing 2 interacting leaves — i.e. 8 chaos resources, 4 datapacks, 4 RCA puzzles.
+
+Don't merge the two dimensions in your head. "Multi-fault" alone is ambiguous; always say "K_outer parallel" or "K_inner-leaf batch" so it's unambiguous what shape you're submitting.
+
+### K_outer guidance
+
+Default to **K_outer ≥ 2** when the namespace pool has slack — independent puzzles per round are pure throughput win. Cap K_outer below the deployed pool size for the system (so namespace allocation has retry headroom) and below any backend rate-limit ceiling (BuildDatapackRateLimiter default 8; #289-style ClickHouse freshness-probe contention shows up around K_outer≥4 if the probe isn't partition-pruned). When in doubt, ramp K_outer upward across rounds and watch the BuildDatapack failure rate.
+
+K_outer=1 is **not** a default — it's a deliberate choice when the round only has one good puzzle to pose this iteration (e.g. a deeply-considered K_inner=3 with a tight interaction hypothesis where parallel siblings would just add noise to the analysis).
+
+### K_inner — the multi-fault batch (`--apply --batch`)
+
+`aegisctl inject guided --stage` / `--apply --batch` submits multiple finalized configs as one experiment that fires **in parallel within a single namespace and one trace**. Use K_inner ≥ 2 when there's a real reason for the leaves to *interact within the same trace's data*:
+
+- **Mutual masking** — A's symptom looks like B's effect and vice versa; RCA must disentangle.
+- **Co-trigger / amplification** — cache-tier latency + DB-pool exhaustion produce a much bigger blowup than either alone, and RCA must resist blaming whichever shows up first in the trace.
+- **Multi-root-cause grading** — many RCA frameworks return a single root cause; K_inner ≥ 2 tests whether they can return a set.
+
+Suggested K_inner mix (drift gradually based on what's working):
+
+- K_inner=1 — ~50–60% of traces
+- K_inner=2 — ~25–35%
+- K_inner=3+ — ~10–15% (only with a clear interaction hypothesis)
+
+Don't K_inner for its own sake — two unrelated leaves crammed into one trace aren't harder than two separate traces, they're a single puzzle with random noise. The interesting K_inner batches share a service, a dependency, or a time window so symptoms entangle.
+
+**K_inner ≠ K_outer.** Two unrelated faults on *different* namespaces are not a K_inner=2 batch — they're K_outer=2 single-leaf traces, which is exactly what you want for throughput. Don't merge them into one trace just to have a "bigger" batch.
+
+Backend constraints (K_inner only): every spec in one `--apply --batch` must share `system`, `system_type`, and `namespace` (or all leave namespace empty for the auto-allocate path). Duration is `max` across the batch.
+
+## Unit and platform traps
+
+Recurring footguns; if you forget these, half the rounds become wasted environment noise:
+
+- **Time windows are pinned in the backend; do not pass them.** `--duration`, `--interval`, `--pre-duration` are gone from `aegisctl inject guided`. The backend enforces a fixed schedule (restart 25 min → warmup 2 min → normal 5 min → abnormal 5 min); any per-spec `duration` you ship is silently overridden. Don't try to "stagger duration" to bypass dedup — pick a different chaos type / target instead.
+- **Stress numerical fields are integers, no units.** `memory_size: 512` (MiB), `cpu_load: 80` (percent), `time_offset: 60` (seconds). String forms get rejected.
+- **cpu_stress: check the target pod's resources first, then tune for latency.** Before a `cpu_stress` inject, look up the target pod's CPU limit + live usage (`kubectl get deploy <svc> -o jsonpath='{.spec.template.spec.containers[0].resources}'` + `kubectl top pod`; or the post-#563 chart values — Go/C++ services ≈ cpu 500m, JVM cpu 3-5 / teastore 300m). Set `cpu_worker × cpu_load` so the stress demand *plus the service's own CPU* clears the CPU **limit** → CFS throttling → entrance latency climbs. VERIFIED 2026-06-11: cpu_stress bites all 6 benchmarks (CPU pinned at the cap, entrance p95 up **1.7–44×** — media 8.2×, sn 11–44×, hs 4×, otel-demo 4.5×, sockshop 3.4×, teastore 1.7×). For ts's 5-core limits you need more workers / a heavier on-path service.
+  - **memory_stress AND jvm_memory_stress are DISABLED — do NOT inject them.** Verified 2026-06-11 across every runtime: neither produces a detector-visible signal. StressChaos `memory_stress` is inert below the cgroup limit (C++/Go absorb the allocation, latency flat; on a JVM the native-RSS stressor never touches the heap) and only OOM-KILLS above it — a *crash* signal, not latency (equivalent to a one-shot PodKill, which the campaign already avoids for empty-window / datapack-build-fail risk). (Tested 2026-06-11: the OOM-kill restarts the pod exactly once — no CrashLoop, the stressor does not re-inject — and the chaos CR recovers cleanly afterward, so this is about signal quality, NOT CR safety.) JVMChaos `jvm_memory_stress` throws a real `OutOfMemoryError` but only on the Byteman stressor thread → JVM logs only, no latency/error on the request path. There is no good memory→latency lever under the generous #563 limits; use cpu_stress (+ network / pod / dns / http) and skip memory stress entirely.
+- **Backend dedupes byte-identical fingerprints.** Re-submitting the same `(system, ns, app, chaos_type, params)` tuple within the dedup window returns 200 with `data.items: []` and a `batches_exist_in_database` warning — looks "successful", no trace created. Time-window fields no longer participate in the fingerprint (they're fixed), so you must vary `(app, target_service, chaos_type, ...)` to get a fresh trace.
+- **Network chaos pairs must already be observed in cluster traffic.** Freshly installed namespaces have no pairs. Either warm with traffic before submit, or pick chaos types that don't need pair pre-check (Pod*, JVM*, CPU/Memory, DNS-FQDN).
+- **DNSError needs an FQDN cataloged in the resolver.** Short service names and arbitrary external hosts both fail; use `<svc>.<ns>.svc.cluster.local`.
+- **JVMChaos requires `/bin/sh` in the target image.** Distroless / minimal-busybox images fail with chaos-daemon `exit 101`. Stick to systems whose containers have a real shell.
+- **HTTPChaos on byte-cluster: inbound only.** byte-cluster CNI is Cello (`eni_shared`) on a Cilium IPVLAN datapath. Upstream chaos-mesh tproxy bridges pod eth0 — kernel rejects this on IPVLAN children, and historical advice was "skip HTTP* entirely." That's no longer true: as of `chaos-daemon:20260515-bridgeless` (deployed via `tproxyBridgeless: true` in `aegislab/manifests/byte-cluster/chaos-mesh.values.yaml`) tproxy installs TPROXY rules directly in the pod netns. **Inbound** chaos (HTTPDelay/Abort/Replace/StatusCode with default `target: Request` or `target: Response` on a service that *receives* HTTP) works end-to-end. **`direction: from` (egress / outbound chaos initiated by the pod) does not work** on this CNI — Cilium's tc-bpf egress program short-circuits before netfilter, so no iptables rule (REDIRECT, mangle, fwmark, anything) sees the packet. To express outbound semantics, target the callee's inbound instead. If a campaign genuinely needs caller-only egress chaos, skip it on byte-cluster (no current workaround). On other clusters where bridge mode works, both directions are still available.
+- **HTTPChaos only affects services that SERVE http** (it proxies the selected pod's INBOUND http). A gRPC/Thrift server (DSB internals are Thrift; some otel-demo backends e.g. checkout are gRPC, serving rpc only) silently ignores HTTPChaos — dispatch succeeds, nothing perturbs, detector → no_anomaly. The point catalog gates this (HTTP points are emitted only for apps that serve http, not for apps that merely make http *client* calls), so the survey shouldn't offer an inert one; but if you hand-write a spec, keep HTTP* off gRPC/Thrift targets — use pod / network / stress / dns there.
+- **DB table-level faults (`jvm_mysql_exception`, JVM/DB latency·abort) only fire if that exact `(table, sql_type)` is actually queried during the window.** A point on a cold table is a silent noop — it attaches (`AllInjected=True`) but never throws because no matching SQL runs, so the round comes back `injection_landed=false`. Target HOT tables: rank by live query frequency *before* picking the point — `SELECT OBJECT_NAME, COUNT_READ FROM performance_schema.table_io_waits_summary_by_table WHERE COUNT_READ>0 ORDER BY COUNT_READ DESC` on the system's DB (e.g. ts: `auth_user` ~34M reads, `route_stations`/`route_distances` ~7M, `orders` ~1.5M are hot; most other tables are cold and will noop). `mysql_connector` must match the app's JDBC driver major (defaults to 9 for MySQL 9.7). jvm_mysql fires end-to-end as of `chaos-daemon:20260612-mysql-fix-v4`.
+- **PodKill restarts in seconds; PodFailure holds the pod down.** For sustained perturbation use PodFailure.
+- **`system_type` may not equal the short code.** Check the cluster's seed (`data.yaml`) before writing the first spec — wrong type produces "mismatched system type" 500s.
+
+## System-specific signal levels (empirical, prune as you learn)
+
+Detector responsiveness varies wildly across benchmarks. Update `memory.md` per-system as you learn:
+
+- **TrainTicket (ts)** — high signal; ~50–80% +1 on PodFailure / JVMException targeting on-path methods. Stable winners reproduce. Loop produces useful per-method posterior in 5–10 rounds.
+- **otel-demo** — was noise-floor (~2% fire) from a detector ENTRANCE misconfig: it scored a sparse Envoy ingress (~1 sample/min) instead of the load-generator user-journey SLI, so leaf-service faults read as no_anomaly. Root-caused + FIXED in detector 1.0.4 (2026-06-08) → now ~37% fire, leaf-service faults observable. **Grade normally; do NOT pause it.** (If a fresh benchmark shows persistent noise-floor, suspect the same entrance/SLI mapping before blaming candidate quality.)
+- **sockshop** — ~zero detector signal across many rounds. Detector keys off something other than chaos magnitude. Pause similarly.
+- **DSB stack (hs / sn / mm)** — historically required Go-SDK OTel endpoint fix (no scheme prefix); confirm spans land before grading rounds. tea-store has a jmeter firehose risk on chart < 0.1.4.
+
+When a system shows persistent ~5–15% +1 over 5+ rounds with no parameter pattern, it's a detector-implementation issue, not a candidate-quality issue. Stop iterating, write `~/.aegisctl/injection-author/<system>/PAUSED.md` summarizing what was tried, and tell the user.
+
+## Adapt difficulty
+
+Without a live RCA reward, use your own step-9 **simulated inference-chain length + decoy count** as the in-loop control signal, then re-calibrate once offline RCA grading lands:
+
+- Several rounds of "≤2 hops, 0 decoys" → puzzles are too easy. Move down the granularity ladder, multi-fault more, target shared-resource paths.
+- Several rounds of "≥4 hops with multiple plausible decoys" plus `injection_landed=true` → sweet spot; hold and vary along family/service axes to avoid memorization rather than escalating further.
+- Frequent `injection-noop` → not a difficulty problem, an environment problem. Stop tuning faults and revisit *Unit and platform traps* / cluster health.
+- Detector silent on a fault that the data shows did perturb the system → real graceful-degrade signal — record but don't grade as a puzzle win.
+- When offline RCA grading lands and consistently contradicts your past simulations (e.g. RCA solves rounds you tagged `estimated_difficulty: high`), calibrate down: your decoy-counting was too generous. Update `memory.md` with the corrected pattern and reuse it.
+
+## Stop conditions
+
+Stop or pause when:
+
+- The user says stop or asks for a summary.
+- You've cycled the ladder × family matrix and have no underrepresented cell to fill without repeating.
+- The platform is showing damage — namespace pool exhausted, detector image not pulling, dedupe firing on every submission. That's a platform issue; flag it and pause until resolved.
+
+## Aegisctl gap log
+
+Every time aegisctl forced you to work around it — output format awkward to parse, a flag missing, a verb you expected absent, a query that needed raw mysql/kubectl/curl to answer, error messages that hid the cause — append **one line** to `aegisctl_gaps.md`:
+
+```
+2026-04-28T10:15+08 | wanted: count traces by detector verdict per system | issue: trace list -o ndjson has no detector field, had to join with task list by trace_id | workaround: jq join script | severity: medium
+```
+
+Format: `<iso-ts> | wanted: <X> | issue: <what aegisctl can't / makes hard> | workaround: <what you did> | severity: low|medium|high`. Keep each entry to one line. The user reviews this file periodically and ports recurring patterns into aegisctl improvements — that's how the CLI gets less hostile over time.
+
+This is different from `memory.md`: that file captures judgments about the *target system*; `aegisctl_gaps.md` captures issues with the *tool itself*. Keep them separate so the user can grep one without wading through the other.
+
+## Don't
+
+- **Don't** open `mysql` / `kubectl` / `redis-cli` for things aegisctl can do. Flag the gap in `aegisctl_gaps.md` (so it surfaces to the user for fixing) and use the workaround for this round only.
+- **Don't** kill the entrance pod as your "hard puzzle." Free win for RCA.
+- **Don't** confuse "detector silent" with "puzzle hard."
+- **Don't** dump round-level submit responses into `memory.md`. That goes in `rounds/*.json`. `memory.md` is the *distilled* judgment.
+- **Don't** spam the same fault family or same target service. That's fake diversity.
+- **Don't** treat a +1 from the detector as the win condition. RCA being wrong is the win condition.
+
+## Workflow orchestration
+
+Use `agentm workflow run contrib/scenarios/injection/workflow.py --args '{...}'` for campaign orchestration. `loop.sh` is only a compatibility wrapper around that workflow. The workflow owns round scheduling, family-tally precomputation, verifier-compatible case-context retrieval, heartbeat updates, and appending returned `case_records` to `case_library.jsonl`. This worker scenario owns one round of judgment and Aegis tool use.

--- a/contrib/scenarios/injection/workflow.py
+++ b/contrib/scenarios/injection/workflow.py
@@ -1,0 +1,397 @@
+"""Workflow-first Aegis injection campaign orchestrator.
+
+The workflow owns round orchestration and deterministic state plumbing. Child
+agents own judgment and Aegis tool use. Historical knowledge is represented as
+verifier-compatible case records so injection can consume verifier outputs when
+those become available.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from agentm.extensions.builtin.workflow import WorkflowContext
+
+FAMILY: dict[str, str] = {
+    "NetworkDelay": "network",
+    "NetworkLoss": "network",
+    "NetworkPartition": "network",
+    "NetworkCorrupt": "network",
+    "NetworkBandwidth": "network",
+    "NetworkDuplicate": "network",
+    "PodFailure": "pod",
+    "PodKill": "pod",
+    "ContainerKill": "pod",
+    "JVMLatency": "jvm",
+    "JVMException": "jvm",
+    "JVMMySQLLatency": "jvm",
+    "JVMMYSQLLatency": "jvm",
+    "JVMMySQLException": "jvm",
+    "JVMMYSQLException": "jvm",
+    "JVMReturn": "jvm",
+    "JVMCPUStress": "jvm",
+    "HTTPRequestDelay": "http",
+    "HTTPResponseDelay": "http",
+    "HTTPRequestAbort": "http",
+    "HTTPResponseAbort": "http",
+    "HTTPReplace": "http",
+    "HTTPStatusCode": "http",
+    "DNSError": "dns",
+    "DNSRandom": "dns",
+    "CPUStress": "stress",
+    "TimeSkew": "stress",
+    "MemoryStress": "stress",
+}
+
+FAMILY_CAPS: dict[str, int] = {
+    "network": 25,
+    "pod": 20,
+    "jvm": 25,
+    "http": 20,
+    "dns": 10,
+    "stress": 10,
+}
+
+ROUND_RESULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+    "required": ["round", "system", "status", "round_file", "trace_ids", "case_records"],
+    "properties": {
+        "round": {"type": "integer"},
+        "system": {"type": "string"},
+        "status": {"type": "string"},
+        "round_file": {"type": "string"},
+        "trace_ids": {"type": "array", "items": {"type": "string"}},
+        "case_records": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
+        "notes": {"type": "string"},
+    },
+}
+
+
+def _expand(path: str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def _run_jsonl(cmd: list[str], env: dict[str, str]) -> list[dict[str, Any]]:
+    proc = subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    out: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _load_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.is_file():
+        return dict(default)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return dict(default)
+    return data if isinstance(data, dict) else dict(default)
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def _load_jsonl(path: Path, limit: int = 200) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows[-limit:]
+
+
+def _append_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+
+
+def _recent_rounds(rounds_dir: Path, limit: int = 10) -> list[dict[str, Any]]:
+    files = sorted(rounds_dir.glob("round-*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    rounds: list[dict[str, Any]] = []
+    for path in files[:limit]:
+        item = _load_json(path, {})
+        if item:
+            item["_path"] = str(path)
+            rounds.append(item)
+    return rounds
+
+
+def _aegis_env(project: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault("AEGIS_INSECURE_SKIP_VERIFY", "true")
+    env.setdefault("AEGIS_NON_INTERACTIVE", "true")
+    env.setdefault("AEGIS_PROJECT", project)
+    env.setdefault("AEGIS_TIMEOUT", "120")
+    return env
+
+
+def _family_tally(aegisctl_bin: str, project: str, system: str) -> dict[str, Any]:
+    env = _aegis_env(project)
+    base = [aegisctl_bin, "inject", "list", "--project", project, "--size", "100", "--page", "1", "-o", "ndjson"]
+    scope = f"system={system}"
+    try:
+        rows = _run_jsonl([*base, "--system", system], env)
+        meta = next((r.get("_meta") for r in rows if isinstance(r.get("_meta"), dict)), {})
+        if int(meta.get("total") or 0) == 0:
+            scope = f"project={project} (system-filter fallback)"
+            rows = _run_jsonl(base, env)
+    except Exception as exc:  # noqa: BLE001 - workflow should continue with degraded context
+        return {"available": False, "error": str(exc), "scope": scope, "counts": {}, "percent": {}}
+
+    counts: Counter[str] = Counter()
+    for row in rows:
+        if "_meta" in row:
+            continue
+        chaos_type = str(row.get("fault_type") or row.get("chaos_type") or "")
+        counts[FAMILY.get(chaos_type, chaos_type or "unknown")] += 1
+    total = sum(counts.values())
+    percent = {k: (100 * v // total if total else 0) for k, v in counts.items()}
+    blocked = [fam for fam, cap in FAMILY_CAPS.items() if percent.get(fam, 0) >= cap]
+    return {
+        "available": True,
+        "scope": scope,
+        "total": total,
+        "counts": dict(counts),
+        "percent": percent,
+        "caps": FAMILY_CAPS,
+        "blocked_families": blocked,
+    }
+
+
+def _latest_pedestal_contract(aegisctl_bin: str, project: str, system: str) -> dict[str, Any]:
+    env = _aegis_env(project)
+    cmd = [aegisctl_bin, "container", "versions", system, "-o", "json"]
+    try:
+        proc = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        data = json.loads(proc.stdout)
+    except Exception as exc:  # noqa: BLE001
+        return {"available": False, "error": str(exc), "pedestal_name": system}
+    items = data.get("items") if isinstance(data, dict) else None
+    tag = None
+    if isinstance(items, list) and items:
+        first = items[0]
+        if isinstance(first, dict):
+            tag = first.get("name") or first.get("tag") or first.get("version")
+        elif isinstance(first, str):
+            tag = first
+    return {
+        "available": bool(tag),
+        "pedestal_name": system,
+        "pedestal_tag": tag,
+        "benchmark_name": "clickhouse",
+        "benchmark_tag": "1.0.0",
+        "policy": "resolve immediately before every submit; do not reuse old round tags",
+    }
+
+
+def _case_context(case_records: list[dict[str, Any]]) -> dict[str, Any]:
+    hard: list[dict[str, Any]] = []
+    easy: list[dict[str, Any]] = []
+    noop: list[dict[str, Any]] = []
+    verified_paths: list[dict[str, Any]] = []
+    for rec in case_records[-100:]:
+        evidence = rec.get("verifier_evidence") if isinstance(rec.get("verifier_evidence"), dict) else {}
+        observations = rec.get("observations") if isinstance(rec.get("observations"), dict) else {}
+        score = rec.get("puzzle_score") if isinstance(rec.get("puzzle_score"), dict) else {}
+        if evidence.get("status") == "verified" and evidence.get("propagation_path"):
+            verified_paths.append({
+                "case_id": rec.get("case_id"),
+                "fault": rec.get("fault"),
+                "propagation_path": evidence.get("propagation_path"),
+                "decoys": evidence.get("decoy_hypotheses", []),
+            })
+        if observations.get("injection_landed") is False:
+            noop.append(rec)
+        elif score.get("estimated_difficulty") == "high":
+            hard.append(rec)
+        elif score.get("estimated_difficulty") == "low":
+            easy.append(rec)
+    return {
+        "hard_cases": hard[-10:],
+        "easy_cases": easy[-10:],
+        "noop_patterns": noop[-10:],
+        "verified_paths": verified_paths[-20:],
+        "note": "Propagation evidence is verifier-compatible. Treat simulated evidence as a weak prior only.",
+    }
+
+
+def _round_number(meta: dict[str, Any], recent: list[dict[str, Any]]) -> int:
+    nums = [int(r.get("round") or 0) for r in recent if isinstance(r.get("round"), int)]
+    return max([int(meta.get("total_rounds_run") or 0), *nums], default=0) + 1
+
+
+def _build_campaign_state(raw_args: dict[str, Any]) -> dict[str, Any]:
+    system = str(raw_args.get("system") or "ts")
+    project = str(raw_args.get("project") or os.environ.get("AEGIS_PROJECT") or "pair_diagnosis")
+    state_dir = _expand(str(raw_args.get("state_dir") or f"~/.aegisctl/injection-author/{system}"))
+    aegisctl_bin = str(raw_args.get("aegisctl_bin") or "/tmp/aegisctl")
+    rounds_dir = state_dir / "rounds"
+    rounds_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = state_dir / "metadata.json"
+    meta = _load_json(meta_path, {
+        "system": system,
+        "first_started_at": _now_iso(),
+        "total_rounds_run": 0,
+    })
+    meta["system"] = system
+    meta["last_started_at"] = _now_iso()
+    _write_json(meta_path, meta)
+
+    recent = _recent_rounds(rounds_dir)
+    case_library = _load_jsonl(state_dir / "case_library.jsonl")
+    return {
+        "system": system,
+        "project": project,
+        "state_dir": str(state_dir),
+        "rounds_dir": str(rounds_dir),
+        "aegisctl_bin": aegisctl_bin,
+        "source_dir": raw_args.get("source_dir"),
+        "extra_instruction": raw_args.get("extra_instruction", ""),
+        "validation_mode": bool(raw_args.get("validation_mode", False)),
+        "max_parallel": int(raw_args.get("max_parallel") or 1),
+        "metadata": meta,
+        "recent_rounds": recent,
+        "case_library": case_library,
+        "next_round": _round_number(meta, recent),
+        "family_tally": _family_tally(aegisctl_bin, project, system),
+        "submit_contract": _latest_pedestal_contract(aegisctl_bin, project, system),
+        "case_context": _case_context(case_library),
+    }
+
+
+def _archive_cases(state: dict[str, Any], result: dict[str, Any]) -> None:
+    rows = result.get("case_records")
+    if not isinstance(rows, list):
+        return
+    clean = [row for row in rows if isinstance(row, dict)]
+    _append_jsonl(Path(state["state_dir"]) / "case_library.jsonl", clean)
+
+
+def _update_metadata_after_round(state: dict[str, Any], result: dict[str, Any]) -> None:
+    meta_path = Path(state["state_dir"]) / "metadata.json"
+    meta = _load_json(meta_path, {})
+    meta["last_completed_at"] = _now_iso()
+    meta["total_rounds_run"] = max(int(meta.get("total_rounds_run") or 0), int(result.get("round") or 0))
+    meta["last_workflow_status"] = result.get("status")
+    meta["family_tally"] = state.get("family_tally")
+    _write_json(meta_path, meta)
+
+
+async def _run_one_round(ctx: WorkflowContext, state: dict[str, Any], scenario: str, model: str | None) -> dict[str, Any]:
+    round_no = int(state["next_round"])
+    context = {
+        "mode": "single_round_worker",
+        "round": round_no,
+        "system": state["system"],
+        "project": state["project"],
+        "state_dir": state["state_dir"],
+        "rounds_dir": state["rounds_dir"],
+        "aegisctl_bin": state["aegisctl_bin"],
+        "source_dir": state.get("source_dir"),
+        "validation_mode": state.get("validation_mode"),
+        "recent_rounds": state.get("recent_rounds", []),
+        "family_tally": state.get("family_tally"),
+        "submit_contract": state.get("submit_contract"),
+        "case_context": state.get("case_context"),
+        "extra_instruction": state.get("extra_instruction", ""),
+        "verifier_case_contract": {
+            "minimum_fields": ["case_id", "system", "fault", "observations", "verifier_evidence"],
+            "evidence_status": ["verified", "simulated", "pending", "failed"],
+            "schema_doc": "contrib/scenarios/injection/knowledge/schema.md",
+        },
+    }
+    result = await ctx.agent(
+        "Run one Aegis adversarial injection round using the workflow-provided context.",
+        scenario=scenario,
+        model=model,
+        atom_config={"injection_context": context},
+        schema=ROUND_RESULT_SCHEMA,
+        timeout=3600,
+        trace_label=f"injection-round-{round_no}",
+    )
+    if not isinstance(result, dict):
+        return {
+            "round": round_no,
+            "system": state["system"],
+            "status": "agent_result_not_dict",
+            "round_file": "",
+            "trace_ids": [],
+            "case_records": [],
+            "notes": str(result),
+        }
+    return result
+
+
+async def run(ctx: WorkflowContext) -> dict[str, Any]:
+    raw_args = dict(ctx.args)
+    rounds = int(raw_args["rounds"]) if "rounds" in raw_args else 1
+    sleep_seconds = int(raw_args.get("sleep") or raw_args.get("sleep_seconds") or 0)
+    scenario = str(raw_args.get("scenario") or Path(__file__).parent)
+    model = raw_args.get("worker_model") or raw_args.get("model")
+    model_name = str(model) if model else None
+    heartbeat_dir_arg = raw_args.get("heartbeat_dir")
+
+    results: list[dict[str, Any]] = []
+    for idx in range(rounds):
+        ctx.phase(f"round-{idx + 1}")
+        state = _build_campaign_state(raw_args)
+        ctx.log(
+            f"system={state['system']} next_round={state['next_round']} "
+            f"family_tally={state['family_tally'].get('percent', {})}"
+        )
+        result = await _run_one_round(ctx, state, scenario, model_name)
+        results.append(result)
+        _archive_cases(state, result)
+        _update_metadata_after_round(state, result)
+        heartbeat_dir = _expand(str(heartbeat_dir_arg)) if heartbeat_dir_arg else Path(state["state_dir"])
+        heartbeat_dir.mkdir(parents=True, exist_ok=True)
+        (heartbeat_dir / "heartbeat").write_text(_now_iso() + "\n")
+        if idx + 1 < rounds and sleep_seconds > 0:
+            ctx.log(f"sleeping {sleep_seconds}s before next round")
+            await asyncio.sleep(sleep_seconds)
+
+    return {
+        "kind": "injection_campaign",
+        "system": raw_args.get("system") or "ts",
+        "rounds_requested": rounds,
+        "rounds_completed": len(results),
+        "results": results,
+        "case_library_contract": "contrib/scenarios/injection/knowledge/schema.md",
+    }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -403,6 +403,32 @@ requirements:
     depends_on:
       - REQ-087-builtin-atoms-extension-api
 
+  - id: REQ-106-injection-author-scenario
+    title: AgentM-native adversarial fault-injection author scenario
+    description: >
+      The Aegis fault-injection author loop must be runnable as an AgentM
+      workflow rather than an external Claude/Codex skill session. The workflow
+      orchestrates campaign rounds, injects structured context into a single-round
+      worker scenario, preserves per-system campaign state, records verifier-
+      compatible case-library entries, and keeps a compatibility loop wrapper for
+      process-manager deployments.
+    priority: P2
+    status: implemented
+    confidence: provisional
+    code:
+      - path: contrib/scenarios/injection/workflow.py
+      - path: contrib/scenarios/injection/manifest.yaml
+      - path: contrib/scenarios/injection/injection_context.py
+      - path: contrib/scenarios/injection/loop.sh
+      - path: contrib/scenarios/injection/prompts/author.md
+      - path: contrib/scenarios/injection/knowledge/schema.md
+    tests: []
+    docs:
+      - path: contrib/scenarios/injection/README.md
+    depends_on:
+      - REQ-102-rca-scenario-cleanup
+
+
   - id: REQ-089-file-tool-io-seams
     title: File tool atoms use documented read and write seams
     description: >

--- a/src/agentm/core/runtime/session_manager.py
+++ b/src/agentm/core/runtime/session_manager.py
@@ -74,6 +74,23 @@ def _header_to_record(header: SessionHeader) -> dict[str, Any]:
     return asdict(header)
 
 
+_SENSITIVE_CONFIG_KEYS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "auth_token",
+    "bearer_token",
+    "key",
+    "secret",
+    "token",
+}
+
+
+def _is_sensitive_config_key(key: Any) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return normalized in _SENSITIVE_CONFIG_KEYS or normalized.endswith("_api_key")
+
+
 def _json_safe(value: Any, _depth: int = 0) -> Any:
     """Reduce *value* to JSON-serializable primitives, replacing live
     objects with their repr.
@@ -89,7 +106,10 @@ def _json_safe(value: Any, _depth: int = 0) -> Any:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, dict):
-        return {str(k): _json_safe(v, _depth + 1) for k, v in value.items()}
+        return {
+            str(k): "<redacted>" if _is_sensitive_config_key(k) else _json_safe(v, _depth + 1)
+            for k, v in value.items()
+        }
     if isinstance(value, (list, tuple, set)):
         return [_json_safe(v, _depth + 1) for v in value]
     return repr(value)[:200]


### PR DESCRIPTION
## Summary
- Add a workflow-first Aegis adversarial injection campaign under `contrib/scenarios/injection/`.
- Add a single-round injection worker scenario plus `injection_context` local atom so the workflow passes structured `atom_config` instead of building ad-hoc prompts.
- Convert `loop.sh` into a compatibility wrapper around `agentm workflow run`.
- Add a verifier-compatible `case_library.jsonl` contract in `knowledge/schema.md` so injection can consume upstream verifier propagation evidence as historical fault context.
- Redact sensitive provider config keys from persisted session headers to avoid leaking API keys in observability logs.

## Workflow Design
The new boundary is:

- `workflow.py`: owns campaign orchestration, round scheduling, deterministic Aegis preflight, family tally retrieval, case-context loading, heartbeat updates, and appending returned `case_records` to the case library.
- `manifest.yaml` + `prompts/author.md`: one worker round of judgment and Aegis tool use.
- `injection_context.py`: local atom that injects workflow-provided structured context into the worker system prompt.
- `loop.sh`: process-manager compatibility wrapper only; new automation should call `agentm workflow run contrib/scenarios/injection/workflow.py` directly.

The workflow phases are intentionally compatible with future verifier imports:

1. load campaign state (`metadata.json`, recent `rounds/*.json`, `case_library.jsonl`)
2. preflight Aegis (`inject list` family tally, `container versions <system>` submit contract)
3. retrieve verifier-compatible historical case context
4. spawn the single-round injection worker through `ctx.agent(..., atom_config={"injection_context": ...})`
5. persist returned round result and append `case_records` to `case_library.jsonl`

## Verifier-Compatible Minimum Contract
Injection does not own propagation-path truth. It consumes verifier outputs or verifier-like temporary proxies. Upstream verifier artifacts should provide at least:

```json
{
  "case_id": "<trace-or-case-id>",
  "system": "ts",
  "fault": {
    "family": "http",
    "chaos_type": "HTTPResponseDelay",
    "service": "ts-order-service",
    "scope": "POST /api/v1/orderservice/order"
  },
  "observations": {
    "detector_verdict": "fired",
    "slo_impact": "violated",
    "injection_landed": true,
    "entrypoint_symptoms": []
  },
  "verifier_evidence": {
    "status": "verified",
    "propagation_path": ["ui-dashboard", "ts-preserve-service", "ts-order-service"],
    "root_cause": {
      "service": "ts-order-service",
      "scope": "POST /api/v1/orderservice/order",
      "fault_type": "HTTPResponseDelay"
    },
    "decoy_hypotheses": ["ts-payment-service", "mysql"],
    "attribution_confidence": "medium",
    "reasoning_summary": "Checkout latency propagates through preserve into order creation."
  }
}
```

Accepted `verifier_evidence.status` values:

- `verified`: produced by verifier/offline grader and treated as authoritative.
- `simulated`: temporary injection-author proxy, weak prior only.
- `pending`: trace exists but verifier evidence has not landed.
- `failed`: verifier/platform failure; reason should be in `reasoning_summary`.

Full schema guidance lives in `contrib/scenarios/injection/knowledge/schema.md`.

## Submit Contract
- `--pedestal-name` remains the system short code (`ts`, `sn`, `media`, etc.).
- `--pedestal-tag` is dynamically resolved with `aegisctl container versions <system> -o json` before submit; historical tags are not reused.
- benchmark defaults to `clickhouse:1.0.0`.
- `--skip-restart-pedestal` is not default; only use it when explicitly requested as a warm-pool shortcut.

## Validation
- `uv run agentm workflow validate contrib/scenarios/injection/workflow.py`
- `python3 -m py_compile contrib/scenarios/injection/workflow.py contrib/scenarios/injection/injection_context.py`
- `bash -n contrib/scenarios/injection/loop.sh`
- zero-round workflow smoke via `agentm workflow run ... --args '{"rounds":0,...}'`
- scenario load smoke with `uv run agentm --scenario contrib/scenarios/injection/manifest.yaml --max-turns 1 ...`
- secret scan for the provided API key across repo paths
- `uv run ruff check src/agentm/core/runtime/session_manager.py contrib/scenarios/injection/workflow.py contrib/scenarios/injection/injection_context.py`
- `uv run mypy src/agentm/core/runtime/session_manager.py`
- prior real Aegis validation trace `033437be-da7b-41f3-ad91-ecbb3d6dd485` completed all stages: RestartPedestal, FaultInjection, BuildDatapack, RunAlgorithm, CollectResult
